### PR TITLE
Add GitHub Actions CI pipeline for Pull Requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel any in-progress run for the same branch when a new commit is pushed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  host-tests:
+    name: Host Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Submodules use SSH URLs in .gitmodules; actions/checkout rewrites
+          # them to HTTPS automatically using the default GITHUB_TOKEN.
+          submodules: recursive
+
+      - name: Print build tool versions
+        run: |
+          gcc --version
+          make --version
+
+      - name: Run host tests
+        run: make test


### PR DESCRIPTION
## Summary

Implements the CI pipeline described in #82.

- Triggers on every PR targeting `main` and on every push to `main`
- Cancels in-progress runs when new commits are pushed to the same PR branch
- Checks out with `submodules: recursive` (handles SSH→HTTPS rewrite for Unity submodule)
- Runs `make test` on `ubuntu-latest` (host tests only, no ARM toolchain needed)
- Job is named `host-tests` — ready to be set as a required status check in branch protection

## Architecture note

The job structure is designed to accommodate a future `hil-tests` job (self-hosted Raspberry Pi runner) as a second job with `needs: host-tests`. When that's added, it will only need a second required check registered in branch protection.

## After merging

Branch protection must be configured manually:
- Settings → Branches → Add ruleset for `main`
- Enable **Require status checks to pass**
- Add `host-tests` as the required check (appears after this workflow runs once)

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)