### PR TITLE
Add CLAUDE.md and project wiki (docs/wiki/)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# STM32 Bare Metal — Claude Instructions
+
+## Development Workflow
+
+Every feature or fix follows this exact sequence:
+
+1. **Check for an existing Issue** — search open issues before creating a new one
+2. **Open a GitHub Issue** if none exists, describing the work clearly
+3. **Create a branch:** `git checkout -b <issue-number>-<short-description>`
+4. **Implement locally** — commit often with meaningful messages
+5. **Run `make test`** — all host tests must pass before pushing
+6. **Push branch and open PR** — only after local tests pass
+7. **Verify CI passes** — check the `host-tests` GitHub Actions job
+8. **Do NOT merge** — the user reviews and merges all PRs manually
+
+## Build & Test Commands
+
+```sh
+make test                    # Run host unit tests (Unity) — required before any PR
+make                         # Build default firmware example (cli_simple)
+make EXAMPLE=<name>          # Build a specific example
+make all                     # Build all firmware examples
+make clean                   # Remove all build artifacts
+make flash EXAMPLE=<name>    # Flash to NUCLEO board via OpenOCD
+make debug EXAMPLE=<name>    # Flash and attach GDB
+make serial                  # Connect to board serial port (115200 baud)
+```
+
+## Project Wiki
+
+The wiki is the persistent knowledge base for this project. Read it at the start of any
+session involving architecture, drivers, or roadmap decisions.
+
+- @docs/wiki/index.md         — master index of all wiki pages, start here
+- @docs/wiki/architecture.md  — module map, build system, design principles
+- @docs/wiki/roadmap.md       — open issues, priorities, future directions
+
+## Wiki Maintenance
+
+Update the wiki when work has lasting architectural or knowledge value:
+
+- **New or changed driver/module** → update or create its page in `docs/wiki/drivers/`
+- **Architectural decision made** → add an ADR to `docs/wiki/decisions/`
+- **Open issues change** → update `docs/wiki/roadmap.md`
+- **New wiki page added** → add its entry to `docs/wiki/index.md`
+- **Any significant change** → append an entry to `docs/wiki/log.md`
+
+Do NOT update the wiki for small bug fixes or refactors that don't change how future
+work should be done.

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -1,0 +1,101 @@
+# Architecture
+
+## Target Hardware
+
+- **Board:** STM32 NUCLEO-F411RE
+- **MCU:** STM32F411RE — Cortex-M4F, 100 MHz (via PLL), 512 KB flash, 128 KB SRAM
+- **FPU:** Hardware FPU enabled (fpv4-sp-d16, hard-float ABI)
+
+## Design Philosophy
+
+- **No HAL, no vendor libraries.** All peripheral access is via direct memory-mapped register writes using CMSIS/STM32F4xx headers for register definitions only.
+- **No dynamic allocation.** All state is statically allocated.
+- **Layered drivers.** Low-level drivers (GPIO, DMA) are reused by higher-level drivers (UART, SPI). Applications use drivers only, never registers directly.
+- **ISR-safe architecture.** Interrupt handlers are kept minimal; work is deferred to the main loop where possible (e.g. CLI character input vs command execution).
+
+## Directory Layout
+
+```
+stm32-bare-metal/
+├── chip_headers/          CMSIS + STM32F4xx device register definitions (read-only reference)
+├── linker/                Custom linker script (stm32_ls.ld) with stack/heap overflow detection
+├── startup/               Vector table and startup code (stm32f411_startup.c)
+├── drivers/               Peripheral drivers (see Drivers section below)
+│   ├── inc/               Public headers
+│   └── src/               Implementations
+├── utils/                 Reusable utility libraries
+│   ├── inc/               Public headers
+│   └── src/               cli.c, printf_dma.c, string_utils.c
+├── 3rd_party/             External libraries (git submodules)
+│   ├── printf/            Lightweight printf (mpaland/printf fork)
+│   └── log_c/             Minimal logging library (contains Unity as nested submodule)
+├── examples/              Application firmware examples
+│   ├── basic/             Standalone peripheral demos
+│   └── cli_app/           Interactive CLI application (default build target)
+├── tests/                 Host unit tests (compiled with native gcc, not ARM toolchain)
+│   ├── cli/               Tests for utils/src/cli.c
+│   └── string_utils/      Tests for utils/src/string_utils.c
+├── docs/wiki/             Project knowledge base (this wiki)
+├── .github/workflows/     CI pipeline
+├── Makefile               Root build orchestrator
+└── Makefile.common        Shared toolchain config, flags, common rules
+```
+
+## Build System
+
+- **Toolchain:** `arm-none-eabi-gcc`, Cortex-M4 + hard FPU (`-mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard`)
+- **C standard:** `gnu11`
+- **Optimisation:** `-O2 -flto -ffunction-sections -fdata-sections` (dead-code elimination via `--gc-sections`)
+- **Hierarchical Makefiles:** Each subdirectory compiles to a static library (`.a`); the top-level Makefile links them.
+- **Host tests:** Compiled with native `gcc` (no ARM toolchain needed). Unity framework from `3rd_party/log_c/3rd-party/unity/`.
+- **Log level:** Controlled at compile time via `LOG_LEVEL=LOG_LEVEL_DEBUG` (default: `LOG_LEVEL_INFO`).
+
+## Module Map
+
+```
+Application (examples/)
+    │
+    ├── CLI Engine (utils/cli.c)
+    │       └── string_utils (utils/string_utils.c)
+    │
+    ├── printf_dma (utils/printf_dma.c)
+    │       └── UART driver (drivers/uart.c)
+    │               └── DMA driver (drivers/dma.c)
+    │
+    ├── SPI driver (drivers/spi.c)
+    │       ├── GPIO driver (drivers/gpio_handler.c)
+    │       └── DMA driver (drivers/dma.c)
+    │
+    ├── Timer driver (drivers/timer.c)
+    ├── SysTick driver (drivers/systick.c)
+    ├── EXTI driver (drivers/exti_handler.c)
+    │       └── GPIO driver
+    │
+    └── Logging (log_platform.c → log_c → UART driver)
+```
+
+## Key Third-Party Dependencies
+
+| Library | Location | Purpose |
+|---|---|---|
+| CMSIS | `chip_headers/CMSIS/` | Cortex-M4 core definitions |
+| STM32F4xx headers | `chip_headers/CMSIS/Device/ST/STM32F4xx/` | Register definitions |
+| printf (mpaland) | `3rd_party/printf/` | Lightweight printf, no stdlib dependency |
+| log_c | `3rd_party/log_c/` | Minimal levelled logging (~1.8 KB) |
+| Unity | `3rd_party/log_c/3rd-party/unity/` | C unit test framework (for host tests) |
+
+> **Note:** Unity is a nested submodule inside log_c. Issue #84 tracks making it a direct root-level submodule.
+
+## RCC / Clock
+
+- System clock: 100 MHz via PLL (HSI → PLL → SYSCLK)
+- APB1: 50 MHz (TIM2–TIM5, SPI2, SPI3, USART2)
+- APB2: 100 MHz (SPI1, SPI4, SPI5)
+- Configured by `drivers/src/rcc.c` at startup
+
+## Memory Layout (linker script)
+
+- Flash: 0x08000000, 512 KB
+- SRAM: 0x20000000, 128 KB
+- Stack: top of SRAM, grows downward; overflow detection via stack canary section
+- Heap: between BSS end and stack limit (currently unused — no dynamic allocation)

--- a/docs/wiki/ci.md
+++ b/docs/wiki/ci.md
@@ -1,0 +1,56 @@
+# CI Pipeline
+
+## Overview
+
+GitHub Actions workflow at `.github/workflows/ci.yml`.
+
+**Triggers:**
+- Every PR targeting `main` (open, reopen, push to PR branch)
+- Every push to `main` (post-merge validation)
+
+**Concurrency:** In-progress runs are cancelled when a new commit is pushed to the same branch.
+
+## Jobs
+
+### `host-tests` (active)
+
+| Property | Value |
+|---|---|
+| Runner | `ubuntu-latest` (GitHub-hosted, free) |
+| Required check | Yes — blocks PR merge |
+
+**Steps:**
+1. Checkout with `submodules: recursive` (handles SSH→HTTPS URL rewrite for Unity submodule)
+2. Print `gcc` and `make` versions
+3. `make test`
+
+### `hil-tests` (planned — Issue #86)
+
+| Property | Value |
+|---|---|
+| Runner | `[self-hosted, pi-hil]` (Raspberry Pi on local server) |
+| Required check | Yes — will be added to branch protection when implemented |
+| Dependency | `needs: host-tests` |
+
+## Branch Protection
+
+`main` branch requires `host-tests` to pass before merge. Configured in:
+**GitHub → Settings → Branches → Branch protection rules → main**
+
+When `hil-tests` is added: register it as a second required status check in the same rule.
+
+## Planned Improvements
+
+| Issue | Change |
+|---|---|
+| #89 | Upgrade `actions/checkout` to Node.js 24-compatible version (deadline: 2026-06-02) |
+| #85 | Add JUnit XML test reporting — GitHub PR Test Summary tab |
+| #87 | Add `firmware-build` job — installs `arm-none-eabi-gcc`, runs `make all` |
+| #88 | Add code coverage step — gcov/lcov HTML report uploaded as artifact |
+| #86 | Add `hil-tests` job — self-hosted Pi runner, OpenOCD flash, serial assertion |
+
+## Adding a New Required Check
+
+1. Add the new job to `ci.yml`
+2. Push and open a PR so the check runs once (registers the check name with GitHub)
+3. Go to Settings → Branches → edit the `main` rule → add the new check name

--- a/docs/wiki/decisions/001-ci-pipeline.md
+++ b/docs/wiki/decisions/001-ci-pipeline.md
@@ -1,0 +1,49 @@
+# ADR 001: GitHub Actions CI Pipeline
+
+**Date:** 2026-04-11
+**Status:** Accepted
+**PR:** #83
+
+## Context
+
+The project had no automated CI. Every PR was manually tested locally before merging. This was sufficient for a solo developer but left the door open for regressions if local testing was skipped.
+
+## Decision
+
+Add a GitHub Actions CI pipeline that runs `make test` on every PR targeting `main` and blocks merge if it fails.
+
+## Key choices
+
+### GitHub-hosted runners (not self-hosted) for host tests
+
+**Chosen:** `ubuntu-latest` (free, ephemeral, GitHub-managed).
+
+**Why:** The host tests use only native `gcc` and `make`, both pre-installed on the hosted runner. No setup cost. Free for public repos. Self-hosted runners add maintenance burden (runner software updates, machine uptime) that is not justified until hardware tests are needed.
+
+**Future:** When HIL tests are added (Issue #86), a self-hosted Raspberry Pi runner with label `pi-hil` will be registered. Host tests will stay on the hosted runner.
+
+### Job architecture: host-tests + future hil-tests
+
+The workflow was designed from the start with a second `hil-tests` job in mind:
+- `hil-tests` will use `needs: host-tests` — hardware tests only run if host tests pass
+- `hil-tests` will use `runs-on: [self-hosted, pi-hil]`
+- Both jobs will be required checks in branch protection
+
+### Concurrency cancellation
+
+New commits to a PR cancel the in-progress run for the same branch. This keeps feedback fast and avoids wasting runner minutes on outdated code.
+
+### HIL test frequency (when implemented)
+
+Decision: HIL tests run on every PR (not label-gated, not merge-only). Rationale: the feedback value of hardware tests is highest when they run early, before a PR is approved. If HIL tests become too slow or costly, revisit with label-gating.
+
+### Branch protection
+
+Manual configuration in GitHub Settings (cannot be done via workflow file). Required check: `host-tests` job name. Added after first workflow run registered the check name.
+
+## Consequences
+
+- Every PR now requires `host-tests` to pass before merge
+- CI runs take ~12 seconds on the free hosted runner
+- Adding a new required check requires both a workflow change and a manual branch protection update
+- Node.js 20 deprecation warning in `actions/checkout@v4` — tracked in Issue #89

--- a/docs/wiki/drivers/dma.md
+++ b/docs/wiki/drivers/dma.md
@@ -1,0 +1,69 @@
+# Driver: DMA
+
+**Files:** `drivers/inc/dma.h`, `drivers/src/dma.c`
+
+## Purpose
+
+Generic DMA stream driver for the STM32F411RE. Provides stream allocation, configuration, start/stop, and transfer-complete callbacks. Used internally by the UART and SPI drivers.
+
+## Design
+
+- **Ownership model:** A stream must be explicitly `init`-ed before use and `release`-ed when done. An already-allocated stream returns -1 on `dma_stream_init()`.
+- **Callback-based:** Transfer-complete and error callbacks are registered at init time, called from the DMA ISR.
+
+## API
+
+```c
+int  dma_stream_init(const dma_stream_config_t *cfg);          // allocate + configure
+int  dma_stream_start(dma_stream_id_t id, uint32_t mem_addr, uint16_t count);
+void dma_stream_stop(dma_stream_id_t id);
+void dma_stream_release(dma_stream_id_t id);                   // stop + deallocate
+
+// In-flight operations (stream must be stopped first)
+void dma_stream_set_mem_inc(dma_stream_id_t id, uint8_t enable);
+
+// Fast reconfigure-and-start (avoids separate set_mem_inc + start calls)
+int  dma_stream_start_config(dma_stream_id_t id, uint32_t mem_addr,
+                             uint16_t count, uint8_t mem_inc);
+
+// Status
+int      dma_stream_busy(dma_stream_id_t id);        // 1 if EN bit set
+uint16_t dma_stream_get_ndtr(dma_stream_id_t id);    // remaining items (useful for circular RX)
+```
+
+## Stream identifiers
+
+16 streams total across two controllers:
+
+```
+DMA_STREAM_1_0 .. DMA_STREAM_1_7   (DMA1, streams 0-7)
+DMA_STREAM_2_0 .. DMA_STREAM_2_7   (DMA2, streams 0-7)
+```
+
+## Configuration struct
+
+```c
+typedef struct {
+    dma_stream_id_t   stream;
+    uint8_t           channel;        // 0-7 (CHSEL bits)
+    dma_direction_t   direction;      // PERIPH_TO_MEM, MEM_TO_PERIPH, MEM_TO_MEM
+    uint32_t          periph_addr;    // PAR register value
+    uint8_t           mem_inc;        // 1 = increment memory address (MINC)
+    uint8_t           periph_inc;     // 1 = increment peripheral address
+    uint8_t           circular;       // 1 = circular mode (CIRC)
+    dma_priority_t    priority;       // LOW / MEDIUM / HIGH / VERY_HIGH
+    dma_callback_t    tc_callback;    // transfer-complete (or NULL)
+    dma_callback_t    error_callback; // TE/DME/FE errors (or NULL)
+    void             *cb_ctx;         // opaque context passed to callbacks
+    uint8_t           nvic_priority;  // 0 = highest
+} dma_stream_config_t;
+```
+
+## Stream assignments (current usage)
+
+| Driver | Direction | Stream | Channel |
+|---|---|---|---|
+| UART TX | M→P | DMA1 Stream 6 | Ch 4 |
+| UART RX | P→M | DMA1 Stream 5 | Ch 4 |
+| SPI TX | M→P | _(configured per instance)_ | |
+| SPI RX | P→M | _(configured per instance)_ | |

--- a/docs/wiki/drivers/exti.md
+++ b/docs/wiki/drivers/exti.md
@@ -1,0 +1,72 @@
+# Driver: EXTI
+
+**Files:** `drivers/inc/exti_handler.h`, `drivers/src/exti_handler.c`
+
+## Purpose
+
+Configures GPIO pins as external interrupt sources using the STM32F411 EXTI controller and SYSCFG EXTICR mux. Used by button interrupt and sleep-wakeup examples.
+
+## API
+
+```c
+// Configure a GPIO pin as an EXTI interrupt source and enable it
+int exti_configure_gpio_interrupt(gpio_port_t port, uint8_t pin_num,
+                                  exti_trigger_t trigger, exti_mode_t mode);
+
+// NVIC enable/disable
+int exti_enable_line(uint8_t line);
+int exti_disable_line(uint8_t line);
+
+// Interrupt mask register
+int exti_set_interrupt_mask(uint8_t line, uint8_t enable);
+int exti_set_event_mask(uint8_t line, uint8_t enable);
+
+// Pending flag
+int exti_is_pending(uint8_t line);
+int exti_clear_pending(uint8_t line);
+
+// Software trigger
+int exti_software_trigger(uint8_t line);
+```
+
+## Types
+
+```c
+typedef enum {
+    EXTI_TRIGGER_RISING,
+    EXTI_TRIGGER_FALLING,
+    EXTI_TRIGGER_BOTH
+} exti_trigger_t;
+
+typedef enum {
+    EXTI_MODE_INTERRUPT,
+    EXTI_MODE_EVENT,
+    EXTI_MODE_BOTH
+} exti_mode_t;
+```
+
+## Notes
+
+- EXTI line number maps directly to GPIO pin number (EXTI0 = pin 0, EXTI15 = pin 15).
+- `exti_configure_gpio_interrupt` handles the SYSCFG EXTICR mux, trigger edge selection, mask register, and NVIC enable in one call.
+- The actual ISR handler (e.g. `EXTI15_10_IRQHandler`) must be defined in application code; the driver does not register ISR handlers.
+- `exti_clear_pending` must be called at the start of the ISR to prevent re-triggering.
+
+## Usage pattern
+
+```c
+// Configure PC13 (user button on NUCLEO) as falling-edge interrupt
+gpio_clock_enable(GPIO_PORT_C);
+gpio_configure_pin(GPIO_PORT_C, 13, GPIO_MODE_INPUT);
+exti_configure_gpio_interrupt(GPIO_PORT_C, 13,
+                              EXTI_TRIGGER_FALLING,
+                              EXTI_MODE_INTERRUPT);
+
+// In the ISR:
+void EXTI15_10_IRQHandler(void) {
+    if (exti_is_pending(13)) {
+        exti_clear_pending(13);
+        // handle button press
+    }
+}
+```

--- a/docs/wiki/drivers/gpio.md
+++ b/docs/wiki/drivers/gpio.md
@@ -1,0 +1,62 @@
+# Driver: GPIO
+
+**Files:** `drivers/inc/gpio_handler.h`, `drivers/src/gpio_handler.c`
+
+## Purpose
+
+Abstracts STM32F411 GPIO port/pin configuration and I/O operations. Used by all other drivers that need GPIO pins (UART, SPI, EXTI).
+
+## API
+
+```c
+// Clock
+void gpio_clock_enable(gpio_port_t port);
+void gpio_clock_disable(gpio_port_t port);
+
+// Pin configuration (individual fields)
+void gpio_configure_pin(gpio_port_t port, uint8_t pin_num, gpio_mode_t mode);
+void gpio_set_output_type(gpio_port_t port, uint8_t pin_num, gpio_output_type_t type);
+void gpio_set_speed(gpio_port_t port, uint8_t pin_num, gpio_speed_t speed);
+void gpio_set_pull(gpio_port_t port, uint8_t pin_num, gpio_pull_t pull);
+void gpio_set_af(gpio_port_t port, uint8_t pin_num, uint8_t af);
+
+// Convenience: configure mode + output type + speed + pull in one call
+void gpio_configure_full(gpio_port_t port, uint8_t pin_num, gpio_mode_t mode,
+                         gpio_output_type_t output_type, gpio_speed_t speed,
+                         gpio_pull_t pull);
+
+// I/O
+void    gpio_set_pin(gpio_port_t port, uint8_t pin_num);
+void    gpio_clear_pin(gpio_port_t port, uint8_t pin_num);
+void    gpio_toggle_pin(gpio_port_t port, uint8_t pin_num);
+uint8_t gpio_read_pin(gpio_port_t port, uint8_t pin_num);
+```
+
+## Types
+
+| Type | Values |
+|---|---|
+| `gpio_port_t` | `GPIO_PORT_A` .. `GPIO_PORT_H` |
+| `gpio_mode_t` | `GPIO_MODE_INPUT`, `OUTPUT`, `AF`, `ANALOG` |
+| `gpio_output_type_t` | `GPIO_OUTPUT_PUSH_PULL`, `OPEN_DRAIN` |
+| `gpio_speed_t` | `GPIO_SPEED_LOW`, `MEDIUM`, `FAST`, `HIGH` |
+| `gpio_pull_t` | `GPIO_PULL_NONE`, `PULL_UP`, `PULL_DOWN` |
+
+## Usage pattern
+
+```c
+gpio_clock_enable(GPIO_PORT_A);
+gpio_configure_full(GPIO_PORT_A, 5, GPIO_MODE_OUTPUT,
+                    GPIO_OUTPUT_PUSH_PULL, GPIO_SPEED_LOW, GPIO_PULL_NONE);
+gpio_set_pin(GPIO_PORT_A, 5);    // LED on
+gpio_clear_pin(GPIO_PORT_A, 5);  // LED off
+gpio_toggle_pin(GPIO_PORT_A, 5); // toggle
+```
+
+For alternate function (e.g. SPI, UART):
+```c
+gpio_clock_enable(GPIO_PORT_A);
+gpio_configure_full(GPIO_PORT_A, 2, GPIO_MODE_AF,
+                    GPIO_OUTPUT_PUSH_PULL, GPIO_SPEED_HIGH, GPIO_PULL_NONE);
+gpio_set_af(GPIO_PORT_A, 2, 7);  // AF7 = USART2 TX on PA2
+```

--- a/docs/wiki/drivers/spi.md
+++ b/docs/wiki/drivers/spi.md
@@ -1,0 +1,80 @@
+# Driver: SPI
+
+**Files:** `drivers/inc/spi.h`, `drivers/src/spi.c`
+
+## Purpose
+
+SPI master driver supporting all 5 SPI instances on the STM32F411RE. Used in the CLI for hardware throughput testing and the shift register example.
+
+## Features
+
+- All 5 SPI instances (SPI1–SPI5)
+- Fully configurable: SCK/MISO/MOSI pins, alternate functions, prescaler, CPOL, CPHA
+- **Polled transfer** (`spi_transfer`) — blocking, full-duplex
+- **DMA transfer** (`spi_transfer_dma`) — non-blocking; `spi_transfer_dma_blocking` spins until done
+- SPI1/4/5 on APB2 (100 MHz bus); SPI2/3 on APB1 (50 MHz bus)
+
+## API
+
+```c
+int  spi_init(spi_handle_t *handle, const spi_config_t *config);  // 0=ok, -1=error
+void spi_deinit(spi_handle_t *handle);
+void spi_enable(spi_handle_t *handle);
+void spi_disable(spi_handle_t *handle);
+
+// Polled (blocking)
+int spi_transfer(spi_handle_t *handle,
+                 const uint8_t *tx, uint8_t *rx, uint16_t len);
+
+// DMA (non-blocking; poll handle->dma_busy to know when done)
+int spi_transfer_dma(spi_handle_t *handle,
+                     const uint8_t *tx, uint8_t *rx, uint16_t len);
+
+// DMA (blocking; waits for dma_busy to clear)
+int spi_transfer_dma_blocking(spi_handle_t *handle,
+                              const uint8_t *tx, uint8_t *rx, uint16_t len);
+
+// Helper
+int spi_prescaler_to_br(uint16_t prescaler);  // 2/4/.../256 → BR[2:0] value 0-7
+```
+
+## Configuration struct
+
+```c
+typedef struct {
+    spi_instance_t  instance;     // SPI_INSTANCE_1 .. SPI_INSTANCE_5
+    gpio_port_t     sck_port;
+    uint8_t         sck_pin;
+    gpio_port_t     miso_port;
+    uint8_t         miso_pin;
+    gpio_port_t     mosi_port;
+    uint8_t         mosi_pin;
+    uint8_t         sck_af;       // GPIO alternate function number
+    uint8_t         miso_af;
+    uint8_t         mosi_af;
+    uint8_t         prescaler_br; // BR[2:0] field (use spi_prescaler_to_br())
+    uint8_t         cpol;         // 0 or 1
+    uint8_t         cpha;         // 0 or 1
+} spi_config_t;
+```
+
+## Handle
+
+```c
+typedef struct {
+    void            *regs;        // SPI_TypeDef* — set by spi_init
+    spi_config_t     config;
+    volatile uint8_t dma_busy;   // poll this for non-blocking DMA completion
+} spi_handle_t;
+```
+
+## Transfer semantics
+
+- `tx == NULL` → sends 0xFF for each byte (read-only transfer)
+- `rx == NULL` → received data discarded (write-only transfer)
+- `spi_init` does NOT enable SPE; call `spi_enable()` or let `spi_transfer()` manage it
+- `spi_transfer()` enables SPE before the transfer and disables it after
+
+## Performance
+
+SPI performance testing is built into the CLI via the `spi_perf_test` command, which uses the DWT cycle counter to measure throughput in KB/s. See `drivers/inc/spi_perf.h`.

--- a/docs/wiki/drivers/systick.md
+++ b/docs/wiki/drivers/systick.md
@@ -1,0 +1,19 @@
+# Driver: SysTick
+
+**Files:** `drivers/inc/systick.h`, `drivers/src/systick.c`
+
+## Purpose
+
+Provides a simple millisecond blocking delay using the Cortex-M4 SysTick timer.
+
+## API
+
+```c
+void systick_delay_ms(uint32_t delay);
+```
+
+## Notes
+
+- Blocking delay — occupies the CPU for the full duration.
+- For non-blocking delays or longer intervals, use the general-purpose timer driver (`timer_delay_us` or a timer interrupt callback).
+- Used in simple blink and button examples where a blocking delay is acceptable.

--- a/docs/wiki/drivers/timer.md
+++ b/docs/wiki/drivers/timer.md
@@ -1,0 +1,61 @@
+# Driver: Timer
+
+**Files:** `drivers/inc/timer.h`, `drivers/src/timer.c`
+
+## Purpose
+
+General-purpose timer driver for TIM2–TIM5 on the STM32F411RE. Supports basic timer with update interrupt callback, PWM output, and microsecond delay.
+
+## Instances
+
+| Instance | Counter width | Bus | Notes |
+|---|---|---|---|
+| `TIMER_2` | 32-bit | APB1 (50 MHz) | Used by `timer_delay_us` (one-pulse mode) |
+| `TIMER_3` | 16-bit | APB1 | General use |
+| `TIMER_4` | 16-bit | APB1 | General use |
+| `TIMER_5` | 32-bit | APB1 | Reserved for `timer_delay_us` |
+
+## API
+
+### Basic timer
+
+```c
+void timer_init(timer_instance_t tim, uint32_t prescaler, uint32_t period);
+void timer_start(timer_instance_t tim);
+void timer_stop(timer_instance_t tim);
+void timer_set_period(timer_instance_t tim, uint32_t period);  // change ARR at runtime
+void timer_register_callback(timer_instance_t tim, timer_callback_t cb);
+    // cb != NULL → enables UIE + NVIC; cb == NULL → disables UIE
+```
+
+### PWM output
+
+```c
+void timer_pwm_init(timer_instance_t tim, timer_channel_t ch,
+                    uint32_t pwm_freq_hz, uint32_t steps);
+void timer_pwm_set_duty(timer_instance_t tim, timer_channel_t ch,
+                        uint32_t duty_percent);  // 0-100, clamped
+```
+
+GPIO alternate-function muxing is the caller's responsibility before calling `timer_pwm_init`.
+
+### Microsecond delay
+
+```c
+void timer_delay_us(uint32_t us);  // blocking; uses TIM5 in one-pulse mode
+```
+
+> Do NOT use TIM5 for other purposes when using `timer_delay_us`.
+
+## Channels
+
+`TIMER_CH1` .. `TIMER_CH4` correspond to CCR1–CCR4 on the selected timer.
+
+## Example: 1 Hz blink with interrupt
+
+```c
+// PSC=49999, ARR=1999 → 50 MHz / 50000 / 2000 = 0.5 Hz... adjust as needed
+timer_init(TIMER_2, 49999, 999);   // 1 Hz at 50 MHz APB1 timer clock
+timer_register_callback(TIMER_2, my_blink_callback);
+timer_start(TIMER_2);
+```

--- a/docs/wiki/drivers/uart.md
+++ b/docs/wiki/drivers/uart.md
@@ -1,0 +1,66 @@
+# Driver: UART
+
+**Files:** `drivers/inc/uart.h`, `drivers/src/uart.c`
+
+## Purpose
+
+USART2 driver on the STM32F411RE. Used as the primary serial interface for the CLI and logging.
+
+**Pins:** PA2 (TX), PA3 (RX) — connected to ST-Link virtual COM port on NUCLEO board.
+**Baud rate:** 115200 (fixed at init time).
+
+## Features
+
+- **Blocking TX** (`uart_write`) — single character, CRLF conversion
+- **DMA TX** (`uart_write_dma`) — non-blocking buffer transfer via DMA1 Stream 6
+- **Interrupt RX** (`uart_register_rx_callback`) — per-character callback from USART2 IRQ
+- **DMA RX** (`uart_start_rx_dma`) — circular DMA buffer; callback on IDLE line or DMA TC
+
+## API
+
+```c
+void uart_init(void);
+
+// Blocking TX
+char uart_read(void);
+void uart_write(char ch);                          // '\n' → "\r\n"
+
+// DMA TX (non-blocking)
+void    uart_write_dma(const char *data, uint16_t length);
+uint8_t uart_is_tx_busy(void);
+
+// Callbacks
+void uart_register_rx_callback(uart_rx_callback_t callback);           // per-char ISR RX
+void uart_register_tx_complete_callback(uart_tx_complete_callback_t callback);
+
+// DMA RX (block reception)
+void uart_start_rx_dma(uint8_t *buf, uint16_t size);  // circular DMA
+void uart_stop_rx_dma(void);
+void uart_register_rx_dma_callback(uart_rx_dma_callback_t callback);  // called on IDLE/TC
+
+// Error handling
+uart_error_flags_t uart_get_errors(void);
+void               uart_clear_errors(void);
+```
+
+## Callback types
+
+```c
+typedef void (*uart_rx_callback_t)(char ch);
+typedef void (*uart_tx_complete_callback_t)(void);
+typedef void (*uart_rx_dma_callback_t)(uint8_t *data, uint16_t len);
+```
+
+## DMA assignments
+
+| Direction | DMA | Stream | Channel |
+|---|---|---|---|
+| TX | DMA1 | Stream 6 | Channel 4 |
+| RX | DMA1 | Stream 5 | Channel 4 |
+
+## Usage notes
+
+- When DMA RX is active, the per-character RXNE interrupt is disabled; `uart_rx_callback` is not called.
+- `uart_write_dma` silently drops data if DMA TX is busy (no queuing).
+- Used by `printf_dma` (`utils/src/printf_dma.c`) for non-blocking CLI output.
+- Used by `log_platform` (`drivers/src/log_platform.c`) as the logging backend.

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,0 +1,37 @@
+# Project Wiki — Index
+
+This is the master index of the project knowledge base.
+Claude reads this file at session start via `CLAUDE.md`. Update it whenever a page is added or removed.
+
+## Core
+
+| Page | Summary |
+|---|---|
+| [architecture.md](architecture.md) | Module map, build system, directory layout, design principles |
+| [roadmap.md](roadmap.md) | Open issues by priority, future directions |
+| [testing.md](testing.md) | Test framework, how to add tests, test coverage status |
+| [ci.md](ci.md) | CI pipeline, jobs, required checks, how to extend |
+
+## Drivers
+
+| Page | Summary |
+|---|---|
+| [drivers/gpio.md](drivers/gpio.md) | GPIO port/pin configuration, AF, output type, speed, pull |
+| [drivers/uart.md](drivers/uart.md) | USART2 driver — DMA TX, interrupt RX, DMA RX, callbacks |
+| [drivers/spi.md](drivers/spi.md) | SPI master driver — all 5 instances, polled and DMA transfers |
+| [drivers/dma.md](drivers/dma.md) | Generic DMA driver — stream allocation, start/stop, callbacks |
+| [drivers/timer.md](drivers/timer.md) | General-purpose timers — basic, PWM, microsecond delay |
+| [drivers/systick.md](drivers/systick.md) | SysTick millisecond delay |
+| [drivers/exti.md](drivers/exti.md) | External interrupt configuration on GPIO pins |
+
+## Decisions
+
+| Page | Summary |
+|---|---|
+| [decisions/001-ci-pipeline.md](decisions/001-ci-pipeline.md) | Why GitHub Actions with hosted runners; HIL architecture plan |
+
+## Log
+
+| Page | Summary |
+|---|---|
+| [log.md](log.md) | Chronological record of significant changes (newest first) |

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -1,0 +1,67 @@
+# Project Log
+
+Chronological record of significant changes. Newest entries at the top.
+Format: `## [YYYY-MM-DD] <type> | <title> (<PR/Issue>)`
+Types: `merge`, `decision`, `milestone`, `infra`
+
+---
+
+## [2026-04-12] infra | Add CLAUDE.md and project wiki (#90)
+
+Set up Claude Code project customization. Added `CLAUDE.md` with development workflow rules, build commands, and wiki schema. Created `docs/wiki/` with initial pages covering architecture, roadmap, testing, CI, all drivers, and ADR 001.
+
+## [2026-04-11] merge | Add GitHub Actions CI pipeline (#83)
+
+Created `.github/workflows/ci.yml` with `host-tests` job on `ubuntu-latest`. Runs `make test` on every PR targeting `main` and on every push to `main`. Cancels in-progress runs on new commits. Branch protection on `main` requires `host-tests` to pass. See ADR 001.
+
+## [2026-04-11] merge | Add host unit tests for CLI engine and string utils (#81)
+
+Added Unity-based host unit tests. 41 tests for `utils/src/cli.c` (CLI engine), 23 tests for `utils/src/string_utils.c`. Tests compile with native `gcc` using header stubs for embedded-only includes. Total: 64 tests.
+
+## [2026-02-23] merge | Implement reusable general-purpose timer driver (#80)
+
+Added `drivers/timer.c` covering TIM2–TIM5. Supports basic timer with update interrupt callback, PWM output (mode 1, preload), and `timer_delay_us` using TIM5 in one-pulse mode.
+
+## [2026-02-21] merge | Extract DMA into a reusable generic driver (#79)
+
+Extracted DMA logic from UART/SPI into `drivers/dma.c`. Stream allocation model, transfer-complete and error callbacks, `dma_stream_start_config` fast-path for circular RX.
+
+## [2026-02-21] merge | Harden linker script with stack/heap sections and overflow detection (#78)
+
+Added explicit stack and heap sections to `linker/stm32_ls.ld` with overflow detection symbols. Startup code checks stack canary at boot.
+
+## [2026-02-20] merge | Implement fault handlers with register dump (#77)
+
+Added HardFault, BusFault, UsageFault, MemManage handlers in `drivers/src/fault_handler.c`. On fault: dumps R0–R15, PC, LR, xPSR, and fault status registers over UART.
+
+## [2026-02-20] merge | Enable FPU in startup code (#76)
+
+Enabled the Cortex-M4F hardware FPU (CP10/CP11 coprocessors) in startup code. Added `FPU_ENABLE` build flag (default: 1). Compiler flags: `-mfloat-abi=hard -mfpu=fpv4-sp-d16`.
+
+## [2026-02-18] merge | Enhance GPIO driver with OTYPER, OSPEEDR, PUPDR configuration (#75)
+
+Added `gpio_set_output_type`, `gpio_set_speed`, `gpio_set_pull`, and `gpio_configure_full` to the GPIO driver. Previously only mode and AF were configurable.
+
+## [2026-02-17] merge | Add RCC clock configuration driver with PLL support to reach 100 MHz (#74)
+
+Added `drivers/src/rcc.c`. Configures HSI → PLL → SYSCLK at 100 MHz. APB1 at 50 MHz, APB2 at 100 MHz.
+
+## [2026-02-17] merge | Use DMA to improve SPI throughput in loopback test (#60)
+
+Added `spi_transfer_dma` and `spi_transfer_dma_blocking` to the SPI driver. DMA TX/RX configured per SPI instance.
+
+## [2025-11-05] merge | Add shift register example via SPI (#50)
+
+Added `examples/basic/shift_register_simple` — controls an SN74HC595 shift register using SPI.
+
+## [2025-11-04] merge | Refactor logging module integration (#46–#48)
+
+Switched log_c to a self-contained implementation (no printf dependency, ~1.8 KB). Added `drivers/src/log_platform.c` as the platform integration layer with callback-based backend registration and runtime log level control via `log_platform_set_level()`.
+
+## [2025-10-31] merge | Add PWM example (#44)
+
+Added `examples/basic/blink_pwm` — LED breathing/fade using TIM2 PWM output.
+
+## [2025-10-30] merge | Add timer interrupt example (#43)
+
+Added `examples/basic/timer_interrupt` — TIM2 update interrupt at 1 Hz.

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -1,0 +1,46 @@
+# Roadmap
+
+## Open Issues by Priority
+
+### High — Foundational improvements
+
+| Issue | Title | Notes |
+|---|---|---|
+| #89 | Upgrade GitHub Actions to Node.js 24 | **Deadline: 2026-06-02** (forced). Node.js 20 removed 2026-09-16. Low-risk, quick fix. |
+| #84 | Make Unity a direct project dependency | Unity is currently a submodule-of-submodule. Add as root-level submodule at `3rd_party/unity/`. Unblocks #85 and #88. |
+| #87 | Build all firmware examples in CI | Add `firmware-build` job to CI. Parallel to `host-tests`. Catches cross-compilation errors on PRs. |
+
+### Medium — Developer experience
+
+| Issue | Title | Notes |
+|---|---|---|
+| #85 | Add JUnit XML test reporting to CI | Post-process Unity stdout to JUnit XML; add GitHub Test Summary tab on PRs. Best after #84. |
+| #88 | Add host test code coverage reporting | Use gcov/lcov. Upload HTML report as CI artifact. Best after #84. |
+
+### Low — Hardware integration
+
+| Issue | Title | Notes |
+|---|---|---|
+| #86 | Self-hosted Raspberry Pi runner for HIL tests | Register Pi as `pi-hil` runner. Flash via OpenOCD. Capture serial output. Add `hil-tests` CI job with `needs: host-tests`. |
+
+## Future Directions (not yet in issues)
+
+- **More host unit tests:** Current coverage is CLI engine and string utils only. Drivers have no host tests (they require hardware). Coverage of driver logic would require mocking hardware registers.
+- **RTOS evaluation:** The project is currently bare-metal super-loop. As complexity grows, a lightweight RTOS (e.g. FreeRTOS) may be worth evaluating.
+- **USB CDC:** The NUCLEO board has USB OTG. A USB virtual COM port would remove the dependency on the ST-Link UART bridge.
+- **Bootloader:** A custom bootloader would enable firmware updates without OpenOCD.
+
+## Completed Milestones
+
+See [log.md](log.md) for the full history. Key milestones:
+
+- ✅ GPIO, UART, SPI, Timer, DMA, EXTI, SysTick drivers
+- ✅ RCC clock configuration (100 MHz via PLL)
+- ✅ Hardware FPU enabled in startup
+- ✅ Fault handlers with register dump
+- ✅ Hardened linker script with stack/heap overflow detection
+- ✅ CLI engine with tab completion, command history, ANSI escape handling
+- ✅ DMA-buffered printf (printf_dma)
+- ✅ Logging system (log_c) with runtime log level control
+- ✅ Host unit tests for CLI and string utils (64 tests total)
+- ✅ GitHub Actions CI pipeline with branch protection on `main`

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -1,0 +1,74 @@
+# Testing
+
+## Overview
+
+Tests are split into two categories:
+
+| Type | Location | Toolchain | Runs on |
+|---|---|---|---|
+| Host unit tests | `tests/` | Native `gcc` | Any Linux/macOS host, CI |
+| Hardware-in-the-loop (HIL) | _(future)_ | `arm-none-eabi-gcc` | Raspberry Pi + NUCLEO board |
+
+## Host Unit Tests
+
+### Framework
+
+[Unity](https://github.com/ThrowTheSwitch/Unity) v2.6.2 — lightweight C unit test framework designed for embedded systems.
+
+Unity source lives at `3rd_party/log_c/3rd-party/unity/src/` (nested submodule).
+> Issue #84 tracks moving Unity to a direct root-level submodule at `3rd_party/unity/`.
+
+### Running tests
+
+```sh
+make test        # Build and run all host test suites
+```
+
+### Test suites
+
+| Suite | Location | Tests | What is covered |
+|---|---|---|---|
+| `string_utils` | `tests/string_utils/` | 23 | Custom string functions in `utils/src/string_utils.c` |
+| `cli` | `tests/cli/` | 41 | CLI engine in `utils/src/cli.c` |
+| **Total** | | **64** | |
+
+### Architecture
+
+Each suite is a standalone executable compiled with native `gcc`:
+
+```
+tests/<suite>/
+├── test_<suite>.c      # Unity test file (setUp, tearDown, RUN_TEST macros)
+├── stubs/              # Header stubs for embedded-only includes (printf.h, printf_dma.h)
+└── Makefile            # Compiles test + source under test + unity.c → test_<suite>.out
+```
+
+Stubs allow source files that `#include "printf.h"` or `#include "printf_dma.h"` to compile on the host without the full embedded stack.
+
+### Adding a new test suite
+
+1. Create `tests/<module>/` with a `Makefile` modelled on an existing suite
+2. Add stubs for any embedded-only headers the module depends on
+3. Add the new suite directory to `SUBDIRS` in `tests/Makefile`
+4. Write tests following the Unity pattern: `setUp()`, `tearDown()`, `RUN_TEST(test_fn)` in `main()`
+
+### Test output format
+
+Unity outputs one line per test:
+```
+tests/cli/test_cli.c:45:test_cli_init_registers_commands:PASS
+tests/cli/test_cli.c:46:test_process_char_adds_printable:PASS
+...
+23 Tests 0 Failures 0 Ignored
+OK
+```
+
+Exit code is non-zero on any test failure, which fails the CI job.
+
+## CI Integration
+
+`make test` is the entry point for CI. See [ci.md](ci.md) for the full pipeline.
+
+Planned improvements:
+- Issue #85: JUnit XML output for GitHub PR Test Summary tab
+- Issue #88: gcov/lcov coverage reporting uploaded as CI artifact


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` at the repo root with the development workflow, build commands, and wiki schema
- Creates `docs/wiki/` as the persistent project knowledge base following the LLM Wiki pattern

## What's in CLAUDE.md

- **Development workflow:** check for existing issue → create if needed → branch → implement → `make test` → push PR → verify CI → user merges
- **Build commands:** quick reference for `make test`, `make all`, `make flash`, etc.
- **Wiki imports:** loads `index.md`, `architecture.md`, `roadmap.md` into context at every session start via `@` imports
- **Wiki maintenance rules:** when and what to update

## What's in docs/wiki/

| File | Contents |
|---|---|
| `index.md` | Master index — loaded at session start |
| `architecture.md` | Module map, build system, directory layout, design principles |
| `roadmap.md` | Open issues #84–#89 by priority, future directions |
| `testing.md` | Unity framework, test suite structure, how to add tests |
| `ci.md` | Pipeline jobs, required checks, planned improvements |
| `drivers/` | One page per driver: gpio, uart, spi, dma, timer, systick, exti |
| `decisions/001-ci-pipeline.md` | ADR for CI architecture choices |
| `log.md` | Chronological record of significant changes back to 2025-10 |

## How this changes Claude's behavior in future sessions

- Claude reads `CLAUDE.md` at session start — workflow rules are always in context
- `@` imports pull in `index.md`, `architecture.md`, and `roadmap.md` automatically
- Claude updates relevant wiki pages before pushing any PR
- Claude appends to `log.md` for any significant change

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)