### PR TITLE
Upgrade actions/checkout from v4 to v6 (Node.js 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Submodules use SSH URLs in .gitmodules; actions/checkout rewrites
           # them to HTTPS automatically using the default GITHUB_TOKEN.

--- a/docs/wiki/ci.md
+++ b/docs/wiki/ci.md
@@ -43,7 +43,7 @@ When `hil-tests` is added: register it as a second required status check in the 
 
 | Issue | Change |
 |---|---|
-| #89 | Upgrade `actions/checkout` to Node.js 24-compatible version (deadline: 2026-06-02) |
+| ~~#89~~ | ~~Upgrade `actions/checkout` to Node.js 24-compatible version~~ — **Done**: upgraded to `actions/checkout@v6` |
 | #85 | Add JUnit XML test reporting — GitHub PR Test Summary tab |
 | #87 | Add `firmware-build` job — installs `arm-none-eabi-gcc`, runs `make all` |
 | #88 | Add code coverage step — gcov/lcov HTML report uploaded as artifact |

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -6,6 +6,10 @@ Types: `merge`, `decision`, `milestone`, `infra`
 
 ---
 
+## [2026-04-12] merge | Upgrade actions/checkout to v6 (Node.js 24) (#89)
+
+Replaced `actions/checkout@v4` (Node.js 20, deprecated) with `actions/checkout@v6.0.2` (Node.js 24). Eliminates the deprecation warning that appeared in every CI run. Resolves before the forced cutover deadline of 2026-06-02.
+
 ## [2026-04-12] infra | Add CLAUDE.md and project wiki (#90)
 
 Set up Claude Code project customization. Added `CLAUDE.md` with development workflow rules, build commands, and wiki schema. Created `docs/wiki/` with initial pages covering architecture, roadmap, testing, CI, all drivers, and ADR 001.

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -6,7 +6,7 @@
 
 | Issue | Title | Notes |
 |---|---|---|
-| #89 | Upgrade GitHub Actions to Node.js 24 | **Deadline: 2026-06-02** (forced). Node.js 20 removed 2026-09-16. Low-risk, quick fix. |
+| ~~#89~~ | ~~Upgrade GitHub Actions to Node.js 24~~ | **Done** — `actions/checkout@v6` merged. |
 | #84 | Make Unity a direct project dependency | Unity is currently a submodule-of-submodule. Add as root-level submodule at `3rd_party/unity/`. Unblocks #85 and #88. |
 | #87 | Build all firmware examples in CI | Add `firmware-build` job to CI. Parallel to `host-tests`. Catches cross-compilation errors on PRs. |
 


### PR DESCRIPTION
## Summary

Replaces `actions/checkout@v4` with `actions/checkout@v6.0.2`.

## Why

`actions/checkout@v4` runs on the deprecated Node.js 20 runtime. A deprecation warning appeared in every CI run since #83:

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

`v6.0.0` is the first release with Node.js 24 support (released 2025-11-20). `v6.0.2` is the current latest.

## Change

`.github/workflows/ci.yml`: `actions/checkout@v4` → `actions/checkout@v6`

One line change. Behaviour is identical — `submodules: recursive` and SSH→HTTPS URL rewriting work the same way.

## Deadlines avoided

- **2026-06-02:** Node.js 24 becomes the forced default
- **2026-09-16:** Node.js 20 removed from runners entirely

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)