### PR TITLE
Add JUnit XML test reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
   host-tests:
     name: Host Tests
     runs-on: ubuntu-latest
+    permissions:
+      checks: write  # required by dorny/test-reporter to publish results
 
     steps:
       - name: Checkout repository
@@ -30,4 +32,18 @@ jobs:
           make --version
 
       - name: Run host tests
-        run: make test
+        run: |
+          set -o pipefail
+          make test | tee test-output.txt
+
+      - name: Convert test output to JUnit XML
+        if: always()
+        run: python3 tests/unity_to_junit.py test-output.txt test-results.xml
+
+      - name: Publish test results
+        if: always()
+        uses: dorny/test-reporter@v3
+        with:
+          name: Unity Tests
+          path: test-results.xml
+          reporter: java-junit

--- a/docs/wiki/ci.md
+++ b/docs/wiki/ci.md
@@ -44,7 +44,7 @@ When `hil-tests` is added: register it as a second required status check in the 
 | Issue | Change |
 |---|---|
 | ~~#89~~ | ~~Upgrade `actions/checkout` to Node.js 24-compatible version~~ — **Done**: upgraded to `actions/checkout@v6` |
-| #85 | Add JUnit XML test reporting — GitHub PR Test Summary tab |
+| ~~#85~~ | ~~Add JUnit XML test reporting~~ — **Done**: `tests/unity_to_junit.py` + `dorny/test-reporter@v3` |
 | #87 | Add `firmware-build` job — installs `arm-none-eabi-gcc`, runs `make all` |
 | #88 | Add code coverage step — gcov/lcov HTML report uploaded as artifact |
 | #86 | Add `hil-tests` job — self-hosted Pi runner, OpenOCD flash, serial assertion |

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -6,6 +6,10 @@ Types: `merge`, `decision`, `milestone`, `infra`
 
 ---
 
+## [2026-04-12] merge | Add JUnit XML test reporting to CI (#85)
+
+Added `tests/unity_to_junit.py` to convert Unity stdout (`file:line:name:PASS/FAIL`) to JUnit XML. Updated `ci.yml` to capture `make test` output with `tee` (preserving exit code via `set -o pipefail`), convert to XML, and publish via `dorny/test-reporter@v3` (Node.js 24). Every PR now shows a Test Summary tab with per-test pass/fail detail.
+
 ## [2026-04-12] merge | Upgrade actions/checkout to v6 (Node.js 24) (#89)
 
 Replaced `actions/checkout@v4` (Node.js 20, deprecated) with `actions/checkout@v6.0.2` (Node.js 24). Eliminates the deprecation warning that appeared in every CI run. Resolves before the forced cutover deadline of 2026-06-02.

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -14,7 +14,7 @@
 
 | Issue | Title | Notes |
 |---|---|---|
-| #85 | Add JUnit XML test reporting to CI | Post-process Unity stdout to JUnit XML; add GitHub Test Summary tab on PRs. Best after #84. |
+| ~~#85~~ | ~~Add JUnit XML test reporting to CI~~ | **Done** — `unity_to_junit.py` + `dorny/test-reporter@v3`. |
 | #88 | Add host test code coverage reporting | Use gcov/lcov. Upload HTML report as CI artifact. Best after #84. |
 
 ### Low — Hardware integration

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -70,5 +70,5 @@ Exit code is non-zero on any test failure, which fails the CI job.
 `make test` is the entry point for CI. See [ci.md](ci.md) for the full pipeline.
 
 Planned improvements:
-- Issue #85: JUnit XML output for GitHub PR Test Summary tab
+- ~~Issue #85: JUnit XML output~~ — **Done**: `tests/unity_to_junit.py` converts Unity stdout to JUnit XML; `dorny/test-reporter@v3` publishes a Test Summary tab on every PR
 - Issue #88: gcov/lcov coverage reporting uploaded as CI artifact

--- a/tests/unity_to_junit.py
+++ b/tests/unity_to_junit.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Convert Unity test output to JUnit XML.
+
+Usage:
+    python3 unity_to_junit.py <input_file> <output_file>
+
+Unity output format (one line per test):
+    filename.c:line:test_name:PASS
+    filename.c:line:test_name:FAIL:message
+
+Groups tests into <testsuite> elements by source filename.
+"""
+
+import sys
+import re
+from collections import defaultdict
+from xml.etree.ElementTree import Element, SubElement, ElementTree, indent
+
+
+def parse_unity_output(text):
+    """Parse Unity stdout and return suites dict keyed by suite name."""
+    suites = defaultdict(lambda: {"tests": [], "failures": 0})
+
+    for line in text.splitlines():
+        m = re.match(r"^([^:\s]+\.c):(\d+):(\w+):(PASS|FAIL)(.*)$", line)
+        if not m:
+            continue
+        source, lineno, test_name, result, rest = m.groups()
+        suite_name = source.rsplit("/", 1)[-1].removesuffix(".c")
+        message = rest.lstrip(":") if rest else ""
+
+        suites[suite_name]["tests"].append(
+            {
+                "name": test_name,
+                "result": result,
+                "message": message,
+                "source": source,
+                "line": lineno,
+            }
+        )
+        if result == "FAIL":
+            suites[suite_name]["failures"] += 1
+
+    return suites
+
+
+def build_junit_xml(suites):
+    """Build a <testsuites> ElementTree from the parsed suites dict."""
+    testsuites = Element("testsuites")
+
+    for suite_name, data in suites.items():
+        tests = data["tests"]
+        ts = SubElement(
+            testsuites,
+            "testsuite",
+            name=suite_name,
+            tests=str(len(tests)),
+            failures=str(data["failures"]),
+            errors="0",
+            time="0",
+        )
+        for t in tests:
+            tc = SubElement(
+                ts,
+                "testcase",
+                name=t["name"],
+                classname=suite_name,
+                time="0",
+            )
+            if t["result"] == "FAIL":
+                failure = SubElement(
+                    tc,
+                    "failure",
+                    message=t["message"],
+                    type="AssertionError",
+                )
+                failure.text = f"{t['source']}:{t['line']}: {t['message']}"
+
+    return testsuites
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <input_file> <output_file>", file=sys.stderr)
+        sys.exit(1)
+
+    input_file, output_file = sys.argv[1], sys.argv[2]
+
+    with open(input_file) as f:
+        text = f.read()
+
+    suites = parse_unity_output(text)
+
+    if not suites:
+        print("Warning: no test results found in input", file=sys.stderr)
+
+    root = build_junit_xml(suites)
+    indent(root)
+
+    tree = ElementTree(root)
+    tree.write(output_file, encoding="unicode", xml_declaration=True)
+
+    total = sum(len(s["tests"]) for s in suites.values())
+    failures = sum(s["failures"] for s in suites.values())
+    print(f"Wrote {total} test results ({failures} failures) to {output_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds per-test pass/fail reporting to every PR via a GitHub Test Summary tab.

## Changes

**`tests/unity_to_junit.py`** — new converter script
- Reads Unity stdout from a file (`file:line:name:PASS/FAIL` format)
- Groups tests into `<testsuite>` elements by source filename
- Outputs valid JUnit XML with `<failure>` elements for failing tests
- Tested locally against real Unity output (64 tests, 2 suites)

**`.github/workflows/ci.yml`**
- `permissions: checks: write` — required by the reporter action
- "Run host tests" now uses `set -o pipefail` + `tee test-output.txt` to capture output while preserving the non-zero exit code on test failure
- New step: "Convert test output to JUnit XML" (`if: always()` — runs even on failure)
- New step: "Publish test results" using `dorny/test-reporter@v3` (Node.js 24 native)

## What you'll see after merge

Every PR will show a **"Unity Tests" check** in the PR checks list. Clicking it opens a Test Summary with each test listed individually, failures highlighted with their assertion message.

## Exit code safety

`set -o pipefail` ensures `make test | tee ...` exits non-zero if `make test` fails. The CI step still fails and blocks merge — the converter and reporter run after via `if: always()` but don't affect the required check outcome.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)