### PR TITLE
Make Unity a direct root-level submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "3rd_party/log_c"]
 	path = 3rd_party/log_c
 	url = git@github.com:ViniBR01/log-c.git
+[submodule "3rd_party/unity"]
+	path = 3rd_party/unity
+	url = git@github.com:ViniBR01/Unity.git

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -82,9 +82,7 @@ Application (examples/)
 | STM32F4xx headers | `chip_headers/CMSIS/Device/ST/STM32F4xx/` | Register definitions |
 | printf (mpaland) | `3rd_party/printf/` | Lightweight printf, no stdlib dependency |
 | log_c | `3rd_party/log_c/` | Minimal levelled logging (~1.8 KB) |
-| Unity | `3rd_party/log_c/3rd-party/unity/` | C unit test framework (for host tests) |
-
-> **Note:** Unity is a nested submodule inside log_c. Issue #84 tracks making it a direct root-level submodule.
+| Unity | `3rd_party/unity/` | C unit test framework (for host tests) |
 
 ## RCC / Clock
 

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -6,6 +6,10 @@ Types: `merge`, `decision`, `milestone`, `infra`
 
 ---
 
+## [2026-04-12] merge | Make Unity a direct root-level submodule (#84)
+
+Added `3rd_party/unity/` as a direct submodule (ViniBR01/Unity fork, commit 36e9b19), replacing the fragile nested path `3rd_party/log_c/3rd-party/unity/`. Updated both test Makefiles. The Unity copy inside log_c is untouched.
+
 ## [2026-04-12] merge | Add JUnit XML test reporting to CI (#85)
 
 Added `tests/unity_to_junit.py` to convert Unity stdout (`file:line:name:PASS/FAIL`) to JUnit XML. Updated `ci.yml` to capture `make test` output with `tee` (preserving exit code via `set -o pipefail`), convert to XML, and publish via `dorny/test-reporter@v3` (Node.js 24). Every PR now shows a Test Summary tab with per-test pass/fail detail.

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -7,7 +7,7 @@
 | Issue | Title | Notes |
 |---|---|---|
 | ~~#89~~ | ~~Upgrade GitHub Actions to Node.js 24~~ | **Done** — `actions/checkout@v6` merged. |
-| #84 | Make Unity a direct project dependency | Unity is currently a submodule-of-submodule. Add as root-level submodule at `3rd_party/unity/`. Unblocks #85 and #88. |
+| ~~#84~~ | ~~Make Unity a direct project dependency~~ | **Done** — `3rd_party/unity/` added as direct submodule, test Makefiles updated. |
 | #87 | Build all firmware examples in CI | Add `firmware-build` job to CI. Parallel to `host-tests`. Catches cross-compilation errors on PRs. |
 
 ### Medium — Developer experience

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -15,8 +15,7 @@ Tests are split into two categories:
 
 [Unity](https://github.com/ThrowTheSwitch/Unity) v2.6.2 — lightweight C unit test framework designed for embedded systems.
 
-Unity source lives at `3rd_party/log_c/3rd-party/unity/src/` (nested submodule).
-> Issue #84 tracks moving Unity to a direct root-level submodule at `3rd_party/unity/`.
+Unity source lives at `3rd_party/unity/src/` (direct root-level submodule, same fork as used internally by log_c, pinned to the same commit).
 
 ### Running tests
 

--- a/tests/cli/Makefile
+++ b/tests/cli/Makefile
@@ -2,9 +2,9 @@ CC      = gcc
 CFLAGS  = -Wall -Wextra -Wno-unknown-pragmas -Wno-unknown-warning-option \
           -I./stubs \
           -I../../utils/inc \
-          -I../../3rd_party/log_c/3rd-party/unity/src
+          -I../../3rd_party/unity/src
 
-UNITY_SRC = ../../3rd_party/log_c/3rd-party/unity/src/unity.c
+UNITY_SRC = ../../3rd_party/unity/src/unity.c
 CLI_SRC   = ../../utils/src/cli.c
 
 .PHONY: all run clean

--- a/tests/string_utils/Makefile
+++ b/tests/string_utils/Makefile
@@ -1,9 +1,9 @@
 CC      = gcc
 CFLAGS  = -Wall -Wextra -Wno-unknown-pragmas -Wno-unknown-warning-option \
           -I../../utils/inc \
-          -I../../3rd_party/log_c/3rd-party/unity/src
+          -I../../3rd_party/unity/src
 
-UNITY_SRC = ../../3rd_party/log_c/3rd-party/unity/src/unity.c
+UNITY_SRC = ../../3rd_party/unity/src/unity.c
 
 .PHONY: all run clean
 


### PR DESCRIPTION
## Summary

Unity was accessed via `3rd_party/log_c/3rd-party/unity/` — a nested submodule two levels deep. This made the dependency invisible at the project root and fragile against any restructuring of `log_c`.

## Changes

- **`.gitmodules`** — adds `3rd_party/unity` submodule entry pointing to `git@github.com:ViniBR01/Unity.git`
- **`3rd_party/unity/`** — new direct submodule, pinned to commit `36e9b19` (same commit currently used by `log_c` internally)
- **`tests/cli/Makefile`** — updated include path and `UNITY_SRC`
- **`tests/string_utils/Makefile`** — updated include path and `UNITY_SRC`

The Unity copy inside `log_c` is **untouched** — it remains as `log_c`'s internal dependency.

## Why the same commit?

Pinning to `36e9b19` (Unity v2.6.2) ensures no behaviour change — the tests run against exactly the same framework version as before.

## Verification

`make test` passes locally (64/64) after a clean rebuild from the new path.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)