### PR TITLE
Add firmware-build CI job and update CLAUDE.md pre-push validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           submodules: recursive
 
       - name: Install ARM toolchain
-        run: sudo apt-get install -y --no-install-recommends gcc-arm-none-eabi
+        run: sudo apt-get install -y --no-install-recommends gcc-arm-none-eabi libnewlib-arm-none-eabi
 
       - name: Print toolchain version
         run: arm-none-eabi-gcc --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,22 @@ jobs:
           name: Unity Tests
           path: test-results.xml
           reporter: java-junit
+
+  firmware-build:
+    name: Firmware Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install ARM toolchain
+        run: sudo apt-get install -y --no-install-recommends gcc-arm-none-eabi
+
+      - name: Print toolchain version
+        run: arm-none-eabi-gcc --version
+
+      - name: Build all firmware examples
+        run: make all

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,9 @@ Every feature or fix follows this exact sequence:
 2. **Open a GitHub Issue** if none exists, describing the work clearly
 3. **Create a branch:** `git checkout -b <issue-number>-<short-description>`
 4. **Implement locally** — commit often with meaningful messages
-5. **Run `make test`** — all host tests must pass before pushing
-6. **Push branch and open PR** — only after local tests pass
-7. **Verify CI passes** — check the `host-tests` GitHub Actions job
+5. **Run `make test` and `make all`** — both must pass before pushing
+6. **Push branch and open PR** — only after local validation passes
+7. **Verify CI passes** — check both `host-tests` and `firmware-build` GitHub Actions jobs
 8. **Do NOT merge** — the user reviews and merges all PRs manually
 
 ## Build & Test Commands

--- a/docs/wiki/ci.md
+++ b/docs/wiki/ci.md
@@ -24,6 +24,20 @@ GitHub Actions workflow at `.github/workflows/ci.yml`.
 2. Print `gcc` and `make` versions
 3. `make test`
 
+### `firmware-build` (active)
+
+| Property | Value |
+|---|---|
+| Runner | `ubuntu-latest` (GitHub-hosted, free) |
+| Required check | Yes — add to branch protection after first run on `main` |
+| Dependency | none (runs in parallel with `host-tests`) |
+
+**Steps:**
+1. Checkout with `submodules: recursive`
+2. `apt-get install gcc-arm-none-eabi`
+3. Print `arm-none-eabi-gcc --version`
+4. `make all` (builds all examples; exits non-zero on any failure)
+
 ### `hil-tests` (planned — Issue #86)
 
 | Property | Value |
@@ -37,7 +51,9 @@ GitHub Actions workflow at `.github/workflows/ci.yml`.
 `main` branch requires `host-tests` to pass before merge. Configured in:
 **GitHub → Settings → Branches → Branch protection rules → main**
 
-When `hil-tests` is added: register it as a second required status check in the same rule.
+After PR #94 merges and `firmware-build` runs on `main` for the first time, add `Firmware Build` as a second required status check in the same rule.
+
+When `hil-tests` is added: register it as a third required status check in the same rule.
 
 ## Planned Improvements
 
@@ -45,7 +61,7 @@ When `hil-tests` is added: register it as a second required status check in the 
 |---|---|
 | ~~#89~~ | ~~Upgrade `actions/checkout` to Node.js 24-compatible version~~ — **Done**: upgraded to `actions/checkout@v6` |
 | ~~#85~~ | ~~Add JUnit XML test reporting~~ — **Done**: `tests/unity_to_junit.py` + `dorny/test-reporter@v3` |
-| #87 | Add `firmware-build` job — installs `arm-none-eabi-gcc`, runs `make all` |
+| ~~#87~~ | ~~Add `firmware-build` job~~ — **Done**: parallel job, `apt` ARM toolchain, `make all` |
 | #88 | Add code coverage step — gcov/lcov HTML report uploaded as artifact |
 | #86 | Add `hil-tests` job — self-hosted Pi runner, OpenOCD flash, serial assertion |
 

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -6,6 +6,10 @@ Types: `merge`, `decision`, `milestone`, `infra`
 
 ---
 
+## [2026-04-12] merge | Add firmware-build CI job; update CLAUDE.md pre-push rules (#87)
+
+Added `firmware-build` job to `ci.yml` — installs `gcc-arm-none-eabi` via apt, runs `make all` in parallel with `host-tests`. Catches cross-compilation errors on every PR. Updated `CLAUDE.md` to require both `make test` and `make all` to pass before pushing. `firmware-build` still needs to be added as a required check in branch protection after its first run on `main`.
+
 ## [2026-04-12] merge | Make Unity a direct root-level submodule (#84)
 
 Added `3rd_party/unity/` as a direct submodule (ViniBR01/Unity fork, commit 36e9b19), replacing the fragile nested path `3rd_party/log_c/3rd-party/unity/`. Updated both test Makefiles. The Unity copy inside log_c is untouched.

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -8,7 +8,7 @@
 |---|---|---|
 | ~~#89~~ | ~~Upgrade GitHub Actions to Node.js 24~~ | **Done** — `actions/checkout@v6` merged. |
 | ~~#84~~ | ~~Make Unity a direct project dependency~~ | **Done** — `3rd_party/unity/` added as direct submodule, test Makefiles updated. |
-| #87 | Build all firmware examples in CI | Add `firmware-build` job to CI. Parallel to `host-tests`. Catches cross-compilation errors on PRs. |
+| ~~#87~~ | ~~Build all firmware examples in CI~~ | **Done** — `firmware-build` job added, parallel to `host-tests`. |
 
 ### Medium — Developer experience
 


### PR DESCRIPTION
## Summary

Two related changes: a new parallel CI job that cross-compiles all firmware examples, and an update to the documented pre-push workflow.

## Changes

**`.github/workflows/ci.yml`** — new `firmware-build` job
- Runs in parallel with `host-tests` (no dependency between them)
- Installs `gcc-arm-none-eabi` via `apt-get` on `ubuntu-latest`
- Runs `make all`, which builds every example and exits non-zero on any failure
- Uses `actions/checkout@v6` with `submodules: recursive` (consistent with `host-tests`)

**`CLAUDE.md`** — updated step 5 of the development workflow
- Before: "Run `make test` — all host tests must pass before pushing"
- After: "Run `make test` and `make all` — both must pass before pushing"

## After merging — action required

Once this PR merges and CI runs on `main`, the `Firmware Build` check name will be registered with GitHub. At that point, add it as a required status check:

**Settings → Branches → edit `main` rule → Add checks → `Firmware Build`**

## Verification

Both `make test` (64/64) and `make all` (all examples) pass locally.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)