### PR TITLE
Add host test code coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,18 @@ jobs:
           path: test-results.xml
           reporter: java-junit
 
+      - name: Install lcov
+        run: sudo apt-get install -y --no-install-recommends lcov
+
+      - name: Generate coverage report
+        run: make -C tests coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-report
+          path: tests/coverage-html/
+
   firmware-build:
     name: Firmware Build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,10 @@ dkms.conf
 .vscode/
 *~
 \#*\#
+
+# Test coverage artifacts
+tests/**/*.gcda
+tests/**/*.gcno
+tests/coverage.info
+tests/coverage-filtered.info
+tests/coverage-html/

--- a/docs/wiki/ci.md
+++ b/docs/wiki/ci.md
@@ -62,7 +62,7 @@ When `hil-tests` is added: register it as a third required status check in the s
 | ~~#89~~ | ~~Upgrade `actions/checkout` to Node.js 24-compatible version~~ — **Done**: upgraded to `actions/checkout@v6` |
 | ~~#85~~ | ~~Add JUnit XML test reporting~~ — **Done**: `tests/unity_to_junit.py` + `dorny/test-reporter@v3` |
 | ~~#87~~ | ~~Add `firmware-build` job~~ — **Done**: parallel job, `apt` ARM toolchain, `make all` |
-| #88 | Add code coverage step — gcov/lcov HTML report uploaded as artifact |
+| ~~#88~~ | ~~Add code coverage~~ — **Done**: `lcov` + `genhtml`, uploaded via `actions/upload-artifact@v6` |
 | #86 | Add `hil-tests` job — self-hosted Pi runner, OpenOCD flash, serial assertion |
 
 ## Adding a New Required Check

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -6,6 +6,10 @@ Types: `merge`, `decision`, `milestone`, `infra`
 
 ---
 
+## [2026-04-12] merge | Add host test coverage reporting (#88)
+
+Test Makefiles now accept `EXTRA_CFLAGS`. `tests/Makefile` gains a `coverage` target: clean rebuild with `--coverage`, `lcov --capture`, `lcov --extract '*/utils/src/*'`, `genhtml`. CI installs `lcov` and runs `make -C tests coverage` after tests pass, uploading `tests/coverage-html/` as the `coverage-report` artifact via `actions/upload-artifact@v6` (Node.js 24). Coverage artifacts added to `.gitignore`.
+
 ## [2026-04-12] merge | Add firmware-build CI job; update CLAUDE.md pre-push rules (#87)
 
 Added `firmware-build` job to `ci.yml` — installs `gcc-arm-none-eabi` via apt, runs `make all` in parallel with `host-tests`. Catches cross-compilation errors on every PR. Updated `CLAUDE.md` to require both `make test` and `make all` to pass before pushing. `firmware-build` still needs to be added as a required check in branch protection after its first run on `main`.

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -15,7 +15,7 @@
 | Issue | Title | Notes |
 |---|---|---|
 | ~~#85~~ | ~~Add JUnit XML test reporting to CI~~ | **Done** — `unity_to_junit.py` + `dorny/test-reporter@v3`. |
-| #88 | Add host test code coverage reporting | Use gcov/lcov. Upload HTML report as CI artifact. Best after #84. |
+| ~~#88~~ | ~~Add host test code coverage reporting~~ | **Done** — `make coverage` + lcov HTML artifact. |
 
 ### Low — Hardware integration
 

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -44,6 +44,18 @@ tests/<suite>/
 
 Stubs allow source files that `#include "printf.h"` or `#include "printf_dma.h"` to compile on the host without the full embedded stack.
 
+### Coverage reporting
+
+Run coverage locally (requires `lcov` and `genhtml`):
+
+```sh
+make -C tests coverage      # generates tests/coverage-html/index.html
+```
+
+In CI, the HTML report is uploaded as the `coverage-report` artifact on every successful run. Download it from the Actions run page to browse coverage interactively.
+
+The report covers `utils/src/cli.c` and `utils/src/string_utils.c` only — Unity and test files are excluded by `lcov --extract '*/utils/src/*'`.
+
 ### Adding a new test suite
 
 1. Create `tests/<module>/` with a `Makefile` modelled on an existing suite
@@ -70,4 +82,4 @@ Exit code is non-zero on any test failure, which fails the CI job.
 
 Planned improvements:
 - ~~Issue #85: JUnit XML output~~ — **Done**: `tests/unity_to_junit.py` converts Unity stdout to JUnit XML; `dorny/test-reporter@v3` publishes a Test Summary tab on every PR
-- Issue #88: gcov/lcov coverage reporting uploaded as CI artifact
+- ~~Issue #88: gcov/lcov coverage reporting~~ — **Done**: `make -C tests coverage` generates HTML via lcov; uploaded as `coverage-report` artifact on every CI run

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,10 @@
 SUBDIRS = string_utils cli
 
-.PHONY: all run clean
+COVERAGE_INFO = coverage.info
+COVERAGE_FILT = coverage-filtered.info
+COVERAGE_HTML = coverage-html
+
+.PHONY: all run clean coverage
 
 all:
 	@for dir in $(SUBDIRS); do \
@@ -24,3 +28,25 @@ clean:
 	@for dir in $(SUBDIRS); do \
 		$(MAKE) -C $$dir clean; \
 	done
+	@rm -f $(COVERAGE_INFO) $(COVERAGE_FILT)
+	@rm -rf $(COVERAGE_HTML)
+
+coverage: clean
+	@echo "========================================"
+	@echo "Building with coverage instrumentation"
+	@echo "========================================"
+	@for dir in $(SUBDIRS); do \
+		$(MAKE) -C $$dir run EXTRA_CFLAGS="--coverage" || exit 1; \
+	done
+	@echo "========================================"
+	@echo "Generating coverage report"
+	@echo "========================================"
+	lcov --capture --directory . --output-file $(COVERAGE_INFO)
+	lcov --extract $(COVERAGE_INFO) '*/utils/src/*' \
+		--output-file $(COVERAGE_FILT)
+	genhtml $(COVERAGE_FILT) \
+		--output-directory $(COVERAGE_HTML) \
+		--title "STM32 Bare Metal Host Tests"
+	@echo "========================================"
+	@echo "Coverage report: tests/$(COVERAGE_HTML)/"
+	@echo "========================================"

--- a/tests/cli/Makefile
+++ b/tests/cli/Makefile
@@ -2,7 +2,8 @@ CC      = gcc
 CFLAGS  = -Wall -Wextra -Wno-unknown-pragmas -Wno-unknown-warning-option \
           -I./stubs \
           -I../../utils/inc \
-          -I../../3rd_party/unity/src
+          -I../../3rd_party/unity/src \
+          $(EXTRA_CFLAGS)
 
 UNITY_SRC = ../../3rd_party/unity/src/unity.c
 CLI_SRC   = ../../utils/src/cli.c

--- a/tests/string_utils/Makefile
+++ b/tests/string_utils/Makefile
@@ -1,7 +1,8 @@
 CC      = gcc
 CFLAGS  = -Wall -Wextra -Wno-unknown-pragmas -Wno-unknown-warning-option \
           -I../../utils/inc \
-          -I../../3rd_party/unity/src
+          -I../../3rd_party/unity/src \
+          $(EXTRA_CFLAGS)
 
 UNITY_SRC = ../../3rd_party/unity/src/unity.c
 


### PR DESCRIPTION
## Summary

Adds `gcov`/`lcov` coverage reporting for the host unit tests. After every successful CI run, an HTML coverage report is available as a downloadable artifact — useful for identifying gaps before expanding the test suite.

## Changes

**`tests/cli/Makefile` and `tests/string_utils/Makefile`**
- Append `$(EXTRA_CFLAGS)` to `CFLAGS` (empty by default — no behaviour change for `make test`)

**`tests/Makefile`**
- `clean` target also removes coverage intermediates
- New `coverage` target:
  1. Clean and rebuild all suites with `EXTRA_CFLAGS="--coverage"`
  2. `lcov --capture --directory .` collects all `.gcda` data
  3. `lcov --extract ... '*/utils/src/*'` keeps only the code under test (cli.c, string_utils.c); excludes Unity and test files
  4. `genhtml` produces `tests/coverage-html/`

**`.github/workflows/ci.yml`**
- Installs `lcov` via apt after tests pass
- Runs `make -C tests coverage`
- Uploads `tests/coverage-html/` as `coverage-report` artifact via `actions/upload-artifact@v6` (Node.js 24)

**`.gitignore`**
- Ignores `*.gcda`, `*.gcno`, `coverage.info`, `coverage-filtered.info`, `coverage-html/`

## Running locally

```sh
# Requires: sudo apt install lcov  (or brew install lcov on macOS)
make -C tests coverage
open tests/coverage-html/index.html
```

## What the report covers

Only `utils/src/cli.c` and `utils/src/string_utils.c` — the source files under test. Unity framework and test files themselves are excluded from the report.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)