### PR TITLE
Refresh roadmap and document driver host testing strategy

### DIFF
--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -84,6 +84,67 @@ Application (examples/)
 | log_c | `3rd_party/log_c/` | Minimal levelled logging (~1.8 KB) |
 | Unity | `3rd_party/unity/` | C unit test framework (for host tests) |
 
+## Testing Architecture
+
+### Three-layer test pyramid
+
+```
+┌─────────────────────────────────────────────┐
+│  Layer 3: HIL tests (future, Issue #86)     │  Real board + Pi runner
+│  Flash firmware → assert serial output      │  Catches hardware-specific bugs
+├─────────────────────────────────────────────┤
+│  Layer 2: Driver logic tests (Issues #98–101)│  Host, native gcc
+│  Fake peripheral stubs + pure fn extraction │  Catches register config bugs
+├─────────────────────────────────────────────┤
+│  Layer 1: Pure unit tests (existing)        │  Host, native gcc, no mocking
+│  CLI engine, string utils                   │  Catches algorithmic bugs
+└─────────────────────────────────────────────┘
+```
+
+### Layer 2: Fake peripheral stubs mechanism
+
+Every driver uses peripheral instance macros from `stm32f4xx.h` (e.g. `GPIOA`, `RCC`, `USART2`) that resolve to fixed hardware addresses. In a host process, those addresses crash.
+
+The solution: shadow the chip header at the include path level. Driver test Makefiles put `tests/driver_stubs/` **before** `chip_headers/` in their `-I` flags. When a driver `.c` does `#include "stm32f4xx.h"`, the stub is found first.
+
+```
+tests/driver_stubs/
+├── stm32f4xx.h      ← includes real stm32f411xe.h (for TypeDefs + bit flags),
+│                      then #undef/#define all peripheral instance macros to
+│                      point at global fake structs in SRAM
+├── core_cm4.h       ← stubs NVIC (with inspectable fake struct), SysTick,
+│                      and all Cortex-M intrinsics (__get_PRIMASK etc.)
+├── test_periph.h    ← declares fake_GPIOA, fake_RCC, fake_USART2 ... (extern)
+└── test_periph.c    ← defines all fake struct instances + test_periph_reset()
+```
+
+Driver code is **completely unchanged**. Tests pre-seed fake struct fields to simulate hardware state (e.g. set ready flags before init functions that busy-wait), call the driver function, then assert on the fake struct fields.
+
+### Layer 2: Pure function extraction (Tier 2)
+
+For complex computation logic buried in register-writing functions, the logic is extracted into standalone pure functions declared in `drivers/inc/<driver>_calc.h`. These functions take plain values and return plain values — no register access, no mocking required.
+
+Examples:
+- `rcc_calc.h`: `rcc_compute_pll_config(src_hz, target_hz, *out)` — PLL factor solver
+- `uart_calc.h`: `uart_compute_baud_divisor(periph_clk, baudrate)`, `uart_circular_bytes_available(ndtr, last_ndtr, buf_size)`
+- `timer_calc.h`: `timer_compute_pwm_psc(timer_clk, freq, steps)`, `timer_compute_duty_ccr(arr, duty_pct)`
+
+The shell functions (hardware init/control) call the pure functions and apply their results to registers. Tests call the pure functions directly.
+
+### Directory layout (with driver tests)
+
+```
+tests/
+├── cli/               Existing — tests utils/src/cli.c
+├── string_utils/      Existing — tests utils/src/string_utils.c
+├── driver_stubs/      New — fake peripheral headers (shared by all driver test suites)
+├── gpio/              New — tests drivers/src/gpio_handler.c
+├── exti/              New — tests drivers/src/exti_handler.c
+├── uart/              New — tests drivers/src/uart.c
+├── rcc/               New — tests drivers/src/rcc.c
+└── timer/             New — tests drivers/src/timer.c
+```
+
 ## RCC / Clock
 
 - System clock: 100 MHz via PLL (HSI → PLL → SYSCLK)

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -6,6 +6,10 @@ Types: `merge`, `decision`, `milestone`, `infra`
 
 ---
 
+## [2026-04-12] infra | Refresh roadmap + define driver host testing strategy (#97)
+
+Rewrote `roadmap.md` with all 15 open GitHub issues categorised and prioritised. Added "Testing Architecture" section to `architecture.md` documenting the three-layer test pyramid and the fake peripheral stub mechanism. Added "Driver Testing Strategy" section to `testing.md` covering both tiers (fake stubs + pure function extraction) with the include-path override mechanism and pre-seeding pattern. Opened 4 new issues: #98 (infra), #99 (GPIO/EXTI), #100 (UART), #101 (RCC/Timer).
+
 ## [2026-04-12] merge | Add host test coverage reporting (#88)
 
 Test Makefiles now accept `EXTRA_CFLAGS`. `tests/Makefile` gains a `coverage` target: clean rebuild with `--coverage`, `lcov --capture`, `lcov --extract '*/utils/src/*'`, `genhtml`. CI installs `lcov` and runs `make -C tests coverage` after tests pass, uploading `tests/coverage-html/` as the `coverage-report` artifact via `actions/upload-artifact@v6` (Node.js 24). Coverage artifacts added to `.gitignore`.

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -2,33 +2,67 @@
 
 ## Open Issues by Priority
 
-### High — Foundational improvements
+### Testing & Quality (highest priority)
 
 | Issue | Title | Notes |
 |---|---|---|
-| ~~#89~~ | ~~Upgrade GitHub Actions to Node.js 24~~ | **Done** — `actions/checkout@v6` merged. |
-| ~~#84~~ | ~~Make Unity a direct project dependency~~ | **Done** — `3rd_party/unity/` added as direct submodule, test Makefiles updated. |
-| ~~#87~~ | ~~Build all firmware examples in CI~~ | **Done** — `firmware-build` job added, parallel to `host-tests`. |
+| #98 | Build driver host test infrastructure | Fake `stm32f4xx.h` + CMSIS stubs. **Prerequisite for all driver tests.** |
+| #99 | Driver host tests: GPIO and EXTI | Tier 1 register config tests. Validates infrastructure. |
+| #100 | Driver host tests: UART | Tier 1 + Tier 2. Circular buffer wrap logic, baud divisor. |
+| #101 | Driver host tests: RCC and Timer | Tier 1 + Tier 2. PLL solver — most complex logic in codebase. |
 
-### Medium — Developer experience
-
-| Issue | Title | Notes |
-|---|---|---|
-| ~~#85~~ | ~~Add JUnit XML test reporting to CI~~ | **Done** — `unity_to_junit.py` + `dorny/test-reporter@v3`. |
-| ~~#88~~ | ~~Add host test code coverage reporting~~ | **Done** — `make coverage` + lcov HTML artifact. |
-
-### Low — Hardware integration
+### CI / Hardware
 
 | Issue | Title | Notes |
 |---|---|---|
-| #86 | Self-hosted Raspberry Pi runner for HIL tests | Register Pi as `pi-hil` runner. Flash via OpenOCD. Capture serial output. Add `hil-tests` CI job with `needs: host-tests`. |
+| #86 | Self-hosted Raspberry Pi runner for HIL tests | Needed once hardware-only behaviour must be verified in CI. |
 
-## Future Directions (not yet in issues)
+### Architecture / Quality
 
-- **More host unit tests:** Current coverage is CLI engine and string utils only. Drivers have no host tests (they require hardware). Coverage of driver logic would require mocking hardware registers.
-- **RTOS evaluation:** The project is currently bare-metal super-loop. As complexity grows, a lightweight RTOS (e.g. FreeRTOS) may be worth evaluating.
-- **USB CDC:** The NUCLEO board has USB OTG. A USB virtual COM port would remove the dependency on the ST-Link UART bridge.
-- **Bootloader:** A custom bootloader would enable firmware updates without OpenOCD.
+| Issue | Title | Notes |
+|---|---|---|
+| #26 | Unified error code scheme | Prerequisite for clean APIs on all new drivers. |
+| #73 | Centralise NVIC interrupt priority scheme | Quality gate before adding more interrupt-driven drivers. |
+
+### Driver Development
+
+| Issue | Title | Notes |
+|---|---|---|
+| #62 | SysTick-based tick counter with non-blocking API | Small. Enables time-based patterns. |
+| #69 | Enhance UART: multiple instances + configurable baud rate | High utility. Depends on #26. |
+| #66 | Implement I2C master driver | Depends on #26 and #73. |
+| #67 | Implement ADC driver | Depends on #26. |
+| #68 | Implement IWDG watchdog driver | Depends on #26. |
+| #70 | Implement Stop and Standby low-power modes | Depends on #26. |
+| #71 | Implement internal flash read/write driver | Depends on #26. |
+| #72 | Implement hardware CRC driver | Depends on #26. |
+
+### Examples
+
+| Issue | Title | Notes |
+|---|---|---|
+| #14 | GPIO input debouncing | Driven by GPIO driver maturity. |
+| #16 | Watchdog timer example | Blocked on #68. |
+| #22 | Flash memory write/erase example | Blocked on #71. |
+| #45 | Large-scale LED array example | Driven by SPI/GPIO driver maturity. |
+
+---
+
+## Suggested Priority Order
+
+1. **#98** — driver test infrastructure (all other driver tests depend on this)
+2. **#99** — GPIO/EXTI tests (simplest drivers; validates the new infrastructure)
+3. **#100** — UART tests (circular buffer has non-obvious wrap edge cases)
+4. **#101** — RCC/Timer tests (PLL solver is the most complex logic in the codebase)
+5. **#62** — non-blocking SysTick tick counter
+6. **#26** — unified error codes
+7. **#69** — multi-instance UART
+8. **#73** — NVIC priority scheme
+9. **#86** — HIL Pi runner
+10. Remaining drivers (#66, #67, #68, #70, #71, #72) after #26 and #73
+11. Examples (#14, #16, #22, #45) driven by driver availability
+
+---
 
 ## Completed Milestones
 
@@ -43,4 +77,8 @@ See [log.md](log.md) for the full history. Key milestones:
 - ✅ DMA-buffered printf (printf_dma)
 - ✅ Logging system (log_c) with runtime log level control
 - ✅ Host unit tests for CLI and string utils (64 tests total)
-- ✅ GitHub Actions CI pipeline with branch protection on `main`
+- ✅ GitHub Actions CI pipeline: `host-tests` + `firmware-build`, branch protection
+- ✅ JUnit XML test reporting (Unity → `unity_to_junit.py` → `dorny/test-reporter@v3`)
+- ✅ lcov code coverage report uploaded as CI artifact
+- ✅ Unity as direct root-level submodule (`3rd_party/unity/`)
+- ✅ All GitHub Actions upgraded to Node.js 24

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -76,6 +76,73 @@ OK
 
 Exit code is non-zero on any test failure, which fails the CI job.
 
+## Driver Testing Strategy
+
+Driver source files mix two kinds of code: pure computation (testable anywhere) and register I/O (requires hardware). Two tiers address these separately.
+
+### Tier 1 — Fake peripheral stubs (register configuration)
+
+The chip headers define peripheral instance macros as fixed hardware addresses (e.g. `#define GPIOA ((GPIO_TypeDef *) 0x40020000)`). A test-only stub layer in `tests/driver_stubs/` shadows the chip header via include path ordering, redirecting these macros to global fake structs in SRAM.
+
+**Include path in driver test Makefiles:**
+```makefile
+CFLAGS = -I../../tests/driver_stubs   # stubs/ first — shadows chip headers
+         -I../../drivers/inc
+         -I../../chip_headers/CMSIS/Include
+         -I../../chip_headers/CMSIS/Device/ST/STM32F4xx/Include
+         -I../../3rd_party/unity/src
+```
+
+**`tests/driver_stubs/stm32f4xx.h`** — includes the real `stm32f411xe.h` (for all TypeDefs and bit-flag constants), then overrides all peripheral instances:
+```c
+#include "stm32f411xe.h"   // real types + bit flags
+#include "test_periph.h"   // #undef GPIOA; #define GPIOA (&fake_GPIOA); etc.
+```
+
+**`tests/driver_stubs/core_cm4.h`** — stubs all Cortex-M intrinsics:
+- `NVIC_EnableIRQ` / `NVIC_DisableIRQ` / `NVIC_SetPriority` — operate on `fake_NVIC` struct
+- `__get_PRIMASK()` returns 0; `__disable_irq()` / `__enable_irq()` are no-ops
+
+**Pre-seeding pattern for busy-wait loops:**
+Driver functions that poll hardware flags (e.g. `while (!(RCC->CR & RCC_CR_PLLRDY))`) would hang indefinitely in a test. Pre-seed the fake struct before calling:
+```c
+// Before calling rcc_init():
+fake_RCC.CR |= RCC_CR_PLLRDY | RCC_CR_HSERDY;
+fake_FLASH.ACR = FLASH_ACR_LATENCY_3WS;
+```
+
+**What Tier 1 tests:**
+- Register fields after driver init calls (correct bit patterns)
+- Which NVIC IRQn numbers got enabled/disabled
+- SYSCFG EXTICR port mapping for EXTI
+- BSRR / MODER / AFR / BRR values set by GPIO/UART/SPI/Timer drivers
+
+### Tier 2 — Pure function extraction
+
+Complex computation buried in register-writing functions is extracted into standalone pure functions declared in `drivers/inc/<driver>_calc.h`. These take plain values, return plain values, and never touch a register — no mocking needed.
+
+**Convention:** Pure functions live in the existing driver `.c` file but are declared in a companion `<driver>_calc.h` header (not the main public header) to signal they are implementation-level utilities exposed for testing.
+
+**High-value extractions planned:**
+
+| Driver | Pure function | What it tests |
+|---|---|---|
+| `rcc.c` | `rcc_compute_pll_config(src_hz, target_hz, *out)` | Multi-constraint PLL factor solver |
+| `rcc.c` | `rcc_compute_apb_prescaler(hclk, max)` | Prescaler search algorithm |
+| `rcc.c` | `rcc_compute_flash_latency(hclk)` | Wait-state lookup table |
+| `uart.c` | `uart_compute_baud_divisor(periph_clk, baudrate)` | Integer rounding |
+| `uart.c` | `uart_circular_bytes_available(ndtr, last_ndtr, buf_size)` | Wrap-around arithmetic |
+| `timer.c` | `timer_compute_pwm_psc(clk, freq, steps)` | PWM prescaler math |
+| `timer.c` | `timer_compute_duty_ccr(arr, duty_pct)` | Duty cycle mapping |
+
+### Adding a driver test suite
+
+1. Create `tests/<driver>/` with a `Makefile` that puts `driver_stubs/` first in `-I`
+2. For Tier 1: include the driver `.c` source directly in the test executable
+3. For Tier 2: include `drivers/inc/<driver>_calc.h` directly
+4. Pre-seed any busy-wait flags in `setUp()`; call `test_periph_reset()` in `tearDown()`
+5. Add the suite to `SUBDIRS` in `tests/Makefile`
+
 ## CI Integration
 
 `make test` is the entry point for CI. See [ci.md](ci.md) for the full pipeline.


### PR DESCRIPTION
## Summary

Brings the project wiki up to date after completing all CI issues, and establishes the architectural direction for expanding host test coverage to driver code.

## Changes

**`docs/wiki/roadmap.md`** — complete rewrite
- All 15 open GitHub issues organised in 5 categories (Testing & Quality, CI/Hardware, Driver Development, Architecture/Quality, Examples)
- Priority ordering: driver test infrastructure (#98–#101) first, then foundational quality (#26, #73), then new drivers, then examples
- Completed CI milestones moved to the "Completed" section

**`docs/wiki/architecture.md`** — new Testing Architecture section
- Three-layer pyramid: pure unit tests → driver logic tests → HIL tests
- Fake peripheral stub mechanism: `tests/driver_stubs/` shadows `chip_headers/` via include path ordering; driver code is **unchanged**
- Pure function extraction convention: `drivers/inc/<driver>_calc.h` companion headers
- Updated directory layout showing new `tests/gpio/`, `tests/exti/`, `tests/uart/`, `tests/rcc/`, `tests/timer/`

**`docs/wiki/testing.md`** — new Driver Testing Strategy section
- Tier 1 (fake peripheral stubs): include path override, `stm32f4xx.h` stub design, `core_cm4.h` NVIC stubs, pre-seeding pattern for busy-wait loops
- Tier 2 (pure function extraction): `_calc.h` convention, table of high-value extractions per driver
- Guide for adding a new driver test suite

## New GitHub issues opened
- #98 — Build driver host test infrastructure (fake stm32f4xx.h + CMSIS stubs)
- #99 — Driver host tests: GPIO and EXTI
- #100 — Driver host tests: UART
- #101 — Driver host tests: RCC and Timer

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)