### PR TITLE
Build driver host test infrastructure and GPIO test suite

### DIFF
--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -6,6 +6,10 @@ Types: `merge`, `decision`, `milestone`, `infra`
 
 ---
 
+## [2026-04-12] merge | Build driver host test infrastructure + GPIO tests (#98)
+
+Created `tests/driver_stubs/` — a test-only header layer that intercepts `#include "stm32f4xx.h"` via include path ordering, includes the real `stm32f411xe.h` for accurate TypeDefs and bit-flag constants, then overrides all peripheral instance macros to point at global fake structs in SRAM. Companion `core_cm4.h` stub provides fake NVIC (inspectable struct), SysTick, SCB, DWT and stubs for Cortex-M intrinsics. `test_periph_reset()` zeroes all fakes in setUp(). GPIO driver test suite: 44 tests covering clock enable/disable, MODER, BSRR, ODR, IDR, AFR, OTYPER, OSPEEDR, PUPDR and port routing. Driver code is unchanged. Total host tests: 108.
+
 ## [2026-04-12] infra | Refresh roadmap + define driver host testing strategy (#97)
 
 Rewrote `roadmap.md` with all 15 open GitHub issues categorised and prioritised. Added "Testing Architecture" section to `architecture.md` documenting the three-layer test pyramid and the fake peripheral stub mechanism. Added "Driver Testing Strategy" section to `testing.md` covering both tiers (fake stubs + pure function extraction) with the include-path override mechanism and pre-seeding pattern. Opened 4 new issues: #98 (infra), #99 (GPIO/EXTI), #100 (UART), #101 (RCC/Timer).

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -29,7 +29,8 @@ make test        # Build and run all host test suites
 |---|---|---|---|
 | `string_utils` | `tests/string_utils/` | 23 | Custom string functions in `utils/src/string_utils.c` |
 | `cli` | `tests/cli/` | 41 | CLI engine in `utils/src/cli.c` |
-| **Total** | | **64** | |
+| `gpio` | `tests/gpio/` | 44 | GPIO driver in `drivers/src/gpio_handler.c` |
+| **Total** | | **108** | |
 
 ### Architecture
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS = string_utils cli
+SUBDIRS = string_utils cli gpio
 
 COVERAGE_INFO = coverage.info
 COVERAGE_FILT = coverage-filtered.info
@@ -21,6 +21,10 @@ run: all
 	@echo "========================================"
 	@$(MAKE) -C cli run
 	@echo "========================================"
+	@echo "Running gpio tests"
+	@echo "========================================"
+	@$(MAKE) -C gpio run
+	@echo "========================================"
 	@echo "All test suites passed"
 	@echo "========================================"
 
@@ -42,7 +46,7 @@ coverage: clean
 	@echo "Generating coverage report"
 	@echo "========================================"
 	lcov --capture --directory . --output-file $(COVERAGE_INFO)
-	lcov --extract $(COVERAGE_INFO) '*/utils/src/*' \
+	lcov --extract $(COVERAGE_INFO) '*/utils/src/*' '*/drivers/src/*' \
 		--output-file $(COVERAGE_FILT)
 	genhtml $(COVERAGE_FILT) \
 		--output-directory $(COVERAGE_HTML) \

--- a/tests/driver_stubs/core_cm4.h
+++ b/tests/driver_stubs/core_cm4.h
@@ -1,0 +1,194 @@
+/*
+ * Stub core_cm4.h for driver host unit tests.
+ *
+ * Replaces the real CMSIS Cortex-M4 core header via include path ordering.
+ * tests/driver_stubs/ must appear before chip_headers/CMSIS/Include/ in the
+ * test Makefile -I flags so that #include "core_cm4.h" (inside stm32f411xe.h)
+ * resolves here instead.
+ *
+ * Provides:
+ *  - Volatile qualifier macros (__IO, __I, __O, __IM, __OM, __IOM)
+ *  - Core peripheral structs: NVIC_Type, SCB_Type, SysTick_Type, DWT_Type,
+ *    CoreDebug_Type
+ *  - Peripheral instance pointers pointing at fake in-SRAM structs
+ *  - NVIC control inline functions operating on fake_NVIC
+ *  - Cortex-M intrinsic stubs (__get_PRIMASK, __disable_irq, __enable_irq)
+ *
+ * Note: IRQn_Type is defined in stm32f411xe.h BEFORE this file is included,
+ * so NVIC inline functions can reference it directly.
+ */
+
+#ifndef STUB_CORE_CM4_H
+#define STUB_CORE_CM4_H
+
+#include <stdint.h>
+
+/*
+ * IRQn_Type is defined by stm32f411xe.h (as a typedef enum) BEFORE that
+ * header includes this file. This is identical to how the real CMSIS
+ * core_cm4.h works. The fallback below is only for static analysis tools
+ * that inspect this file in isolation.
+ */
+#ifndef __STM32F411xE_H
+typedef int32_t IRQn_Type;
+#endif
+
+/* ---- Volatile qualifier macros (used by stm32f411xe.h TypeDef structs) -- */
+
+#define __I    volatile const
+#define __O    volatile
+#define __IO   volatile
+#define __IM   volatile const
+#define __OM   volatile
+#define __IOM  volatile
+
+/* ---- Inline function macros --------------------------------------------- */
+
+#define __STATIC_INLINE       static inline
+#define __STATIC_FORCEINLINE  static inline __attribute__((always_inline))
+#define __WEAK                __attribute__((weak))
+
+/* ---- NVIC_Type ----------------------------------------------------------- */
+
+typedef struct {
+    __IOM uint32_t ISER[8U];
+          uint32_t RESERVED0[24U];
+    __IOM uint32_t ICER[8U];
+          uint32_t RESERVED1[24U];
+    __IOM uint32_t ISPR[8U];
+          uint32_t RESERVED2[24U];
+    __IOM uint32_t ICPR[8U];
+          uint32_t RESERVED3[24U];
+    __IOM uint32_t IABR[8U];
+          uint32_t RESERVED4[56U];
+    __IOM uint8_t  IP[240U];
+          uint32_t RESERVED5[644U];
+    __OM  uint32_t STIR;
+} NVIC_Type;
+
+/* ---- SCB_Type ------------------------------------------------------------ */
+
+typedef struct {
+    __IM  uint32_t CPUID;
+    __IOM uint32_t ICSR;
+    __IOM uint32_t VTOR;
+    __IOM uint32_t AIRCR;
+    __IOM uint32_t SCR;
+    __IOM uint32_t CCR;
+    __IOM uint8_t  SHP[12U];
+    __IOM uint32_t SHCSR;
+    __IOM uint32_t CFSR;
+    __IOM uint32_t HFSR;
+    __IOM uint32_t DFSR;
+    __IOM uint32_t MMFAR;
+    __IOM uint32_t BFAR;
+    __IOM uint32_t AFSR;
+    __IM  uint32_t PFR[2U];
+    __IM  uint32_t DFR;
+    __IM  uint32_t ADR;
+    __IM  uint32_t MMFR[4U];
+    __IM  uint32_t ISAR[5U];
+          uint32_t RESERVED0[5U];
+    __IOM uint32_t CPACR;
+} SCB_Type;
+
+/* ---- SysTick_Type -------------------------------------------------------- */
+
+typedef struct {
+    __IOM uint32_t CTRL;
+    __IOM uint32_t LOAD;
+    __IOM uint32_t VAL;
+    __IM  uint32_t CALIB;
+} SysTick_Type;
+
+/* ---- DWT_Type (used by spi_perf.c for cycle counting) ------------------- */
+
+typedef struct {
+    __IOM uint32_t CTRL;
+    __IOM uint32_t CYCCNT;
+    __IOM uint32_t CPICNT;
+    __IOM uint32_t EXCCNT;
+    __IOM uint32_t SLEEPCNT;
+    __IOM uint32_t LSUCNT;
+    __IOM uint32_t FOLDCNT;
+    __IM  uint32_t PCSR;
+} DWT_Type;
+
+/* ---- CoreDebug_Type (used by spi_perf.c) -------------------------------- */
+
+typedef struct {
+    __IOM uint32_t DHCSR;
+    __OM  uint32_t DCRSR;
+    __IOM uint32_t DCRDR;
+    __IOM uint32_t DEMCR;
+} CoreDebug_Type;
+
+/* ---- Fake core peripheral instances (defined in test_periph.c) ---------- */
+
+extern NVIC_Type        fake_NVIC;
+extern SCB_Type         fake_SCB;
+extern SysTick_Type     fake_SysTick;
+extern DWT_Type         fake_DWT;
+extern CoreDebug_Type   fake_CoreDebug;
+
+/* ---- Instance macros (override real CMSIS hardware addresses) ----------- */
+
+#define NVIC        (&fake_NVIC)
+#define SCB         (&fake_SCB)
+#define SysTick     (&fake_SysTick)
+#define DWT         (&fake_DWT)
+#define CoreDebug   (&fake_CoreDebug)
+
+/* ---- NVIC priority bits ------------------------------------------------- */
+
+#define __NVIC_PRIO_BITS    4U
+
+/* ---- NVIC inline functions (operate on fake_NVIC) ----------------------- */
+
+static inline void NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+    if ((int32_t)IRQn >= 0)
+        fake_NVIC.ISER[(uint32_t)IRQn >> 5U] |= (1U << ((uint32_t)IRQn & 0x1FU));
+}
+
+static inline void NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+    if ((int32_t)IRQn >= 0)
+        fake_NVIC.ICER[(uint32_t)IRQn >> 5U] = (1U << ((uint32_t)IRQn & 0x1FU));
+}
+
+static inline void NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+    if ((int32_t)IRQn >= 0)
+        fake_NVIC.IP[(uint32_t)IRQn] =
+            (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & 0xFFU);
+}
+
+static inline uint32_t NVIC_GetPriority(IRQn_Type IRQn)
+{
+    if ((int32_t)IRQn >= 0)
+        return (uint32_t)(fake_NVIC.IP[(uint32_t)IRQn] >> (8U - __NVIC_PRIO_BITS));
+    return 0U;
+}
+
+/* ---- Cortex-M intrinsic stubs ------------------------------------------- */
+
+static inline uint32_t __get_PRIMASK(void) { return 0U; }
+static inline void     __disable_irq(void) {}
+static inline void     __enable_irq(void)  {}
+static inline void     __DSB(void)         {}
+static inline void     __ISB(void)         {}
+static inline void     __NOP(void)         {}
+static inline void     __WFI(void)         {}
+
+/* ---- DWT / CoreDebug bit constants (used by spi_perf.c) ----------------- */
+
+#define DWT_CTRL_CYCCNTENA_Msk        (1UL << 0)
+#define CoreDebug_DEMCR_TRCENA_Msk    (1UL << 24)
+
+/* ---- SCB bit constants (used by fault_handler.c, sleep_mode.c) ---------- */
+
+#define SCB_SCR_SLEEPDEEP_Msk         (1UL << 2)
+#define SCB_SCR_SLEEPONEXIT_Msk       (1UL << 1)
+
+#endif /* STUB_CORE_CM4_H */

--- a/tests/driver_stubs/stm32f4xx.h
+++ b/tests/driver_stubs/stm32f4xx.h
@@ -1,0 +1,46 @@
+/*
+ * Stub stm32f4xx.h for driver host unit tests.
+ *
+ * Shadows the real chip header via include path ordering:
+ *   tests/driver_stubs/ must come BEFORE chip_headers/ in -I flags.
+ *
+ * Strategy: include the REAL stm32f411xe.h device header to get all
+ * TypeDef structs and bit-flag constants exactly as they appear in
+ * production (accurate, zero maintenance). Then include test_periph.h
+ * which #undef/#redefine all peripheral instance macros to point at
+ * global fake structs in SRAM.
+ *
+ * Include chain:
+ *   driver.c
+ *     #include "stm32f4xx.h"          ← this file (from driver_stubs/)
+ *       #include "stm32f411xe.h"       ← real device header (chip_headers/)
+ *         #include "core_cm4.h"        ← our stub (from driver_stubs/)
+ *         #include "system_stm32f4xx.h" ← real system header (chip_headers/)
+ *       #include "test_periph.h"       ← fake instances + macro overrides
+ */
+
+#ifndef STUB_STM32F4XX_H
+#define STUB_STM32F4XX_H
+
+/* Select the STM32F411xE device variant — required by stm32f411xe.h */
+#ifndef STM32F411xE
+#define STM32F411xE
+#endif
+
+/*
+ * Include the real device header. It will pull in:
+ *  - our core_cm4.h stub (for NVIC/SysTick structs and intrinsics)
+ *  - system_stm32f4xx.h (real, just declares SystemCoreClock and SystemInit)
+ *  - All peripheral TypeDef structs (GPIO_TypeDef, RCC_TypeDef, etc.)
+ *  - All bit-flag constants (RCC_AHB1ENR_GPIOAEN, SPI_CR1_MSTR, etc.)
+ *  - Peripheral BASE macros and instance macros (GPIOA, RCC, SPI2, ...)
+ */
+#include "stm32f411xe.h"
+
+/*
+ * Override all peripheral instance macros to point at fake structs.
+ * Must come AFTER stm32f411xe.h so the TypeDef types are already defined.
+ */
+#include "test_periph.h"
+
+#endif /* STUB_STM32F4XX_H */

--- a/tests/driver_stubs/test_periph.c
+++ b/tests/driver_stubs/test_periph.c
@@ -1,0 +1,133 @@
+/*
+ * test_periph.c — Definitions of all fake STM32 peripheral instances.
+ *
+ * Compiled into every driver test suite executable alongside the driver
+ * source under test and the Unity test file.
+ *
+ * All instances are zero-initialised at program start (C static storage).
+ * Call test_periph_reset() in setUp() before each Unity test case to
+ * ensure a clean, predictable state between tests.
+ */
+
+#include "stm32f4xx.h"  /* TypeDef types via our stub */
+#include "test_periph.h"
+#include <string.h>
+
+/* ---- STM32 peripheral fake instances ------------------------------------ */
+
+GPIO_TypeDef    fake_GPIOA;
+GPIO_TypeDef    fake_GPIOB;
+GPIO_TypeDef    fake_GPIOC;
+GPIO_TypeDef    fake_GPIOD;
+GPIO_TypeDef    fake_GPIOE;
+GPIO_TypeDef    fake_GPIOH;
+
+RCC_TypeDef     fake_RCC;
+
+USART_TypeDef   fake_USART2;
+
+SPI_TypeDef     fake_SPI1;
+SPI_TypeDef     fake_SPI2;
+SPI_TypeDef     fake_SPI3;
+SPI_TypeDef     fake_SPI4;
+SPI_TypeDef     fake_SPI5;
+
+TIM_TypeDef     fake_TIM2;
+TIM_TypeDef     fake_TIM3;
+TIM_TypeDef     fake_TIM4;
+TIM_TypeDef     fake_TIM5;
+
+EXTI_TypeDef    fake_EXTI;
+SYSCFG_TypeDef  fake_SYSCFG;
+FLASH_TypeDef   fake_FLASH;
+
+DMA_TypeDef     fake_DMA1;
+DMA_TypeDef     fake_DMA2;
+
+DMA_Stream_TypeDef fake_DMA1_S0;
+DMA_Stream_TypeDef fake_DMA1_S1;
+DMA_Stream_TypeDef fake_DMA1_S2;
+DMA_Stream_TypeDef fake_DMA1_S3;
+DMA_Stream_TypeDef fake_DMA1_S4;
+DMA_Stream_TypeDef fake_DMA1_S5;
+DMA_Stream_TypeDef fake_DMA1_S6;
+DMA_Stream_TypeDef fake_DMA1_S7;
+DMA_Stream_TypeDef fake_DMA2_S0;
+DMA_Stream_TypeDef fake_DMA2_S1;
+DMA_Stream_TypeDef fake_DMA2_S2;
+DMA_Stream_TypeDef fake_DMA2_S3;
+DMA_Stream_TypeDef fake_DMA2_S4;
+DMA_Stream_TypeDef fake_DMA2_S5;
+DMA_Stream_TypeDef fake_DMA2_S6;
+DMA_Stream_TypeDef fake_DMA2_S7;
+
+/* ---- Cortex-M4 core peripheral fake instances (declared in core_cm4.h) - */
+
+NVIC_Type        fake_NVIC;
+SCB_Type         fake_SCB;
+SysTick_Type     fake_SysTick;
+DWT_Type         fake_DWT;
+CoreDebug_Type   fake_CoreDebug;
+
+/* ---- System clock (declared in system_stm32f4xx.h) --------------------- */
+
+uint32_t SystemCoreClock = 100000000U;  /* 100 MHz */
+
+void SystemInit(void)             {}
+void SystemCoreClockUpdate(void)  {}
+
+/* ---- Reset all fake peripherals to power-on defaults (all zeros) -------- */
+
+void test_periph_reset(void)
+{
+    memset(&fake_GPIOA,  0, sizeof(fake_GPIOA));
+    memset(&fake_GPIOB,  0, sizeof(fake_GPIOB));
+    memset(&fake_GPIOC,  0, sizeof(fake_GPIOC));
+    memset(&fake_GPIOD,  0, sizeof(fake_GPIOD));
+    memset(&fake_GPIOE,  0, sizeof(fake_GPIOE));
+    memset(&fake_GPIOH,  0, sizeof(fake_GPIOH));
+
+    memset(&fake_RCC,    0, sizeof(fake_RCC));
+    memset(&fake_USART2, 0, sizeof(fake_USART2));
+
+    memset(&fake_SPI1,   0, sizeof(fake_SPI1));
+    memset(&fake_SPI2,   0, sizeof(fake_SPI2));
+    memset(&fake_SPI3,   0, sizeof(fake_SPI3));
+    memset(&fake_SPI4,   0, sizeof(fake_SPI4));
+    memset(&fake_SPI5,   0, sizeof(fake_SPI5));
+
+    memset(&fake_TIM2,   0, sizeof(fake_TIM2));
+    memset(&fake_TIM3,   0, sizeof(fake_TIM3));
+    memset(&fake_TIM4,   0, sizeof(fake_TIM4));
+    memset(&fake_TIM5,   0, sizeof(fake_TIM5));
+
+    memset(&fake_EXTI,   0, sizeof(fake_EXTI));
+    memset(&fake_SYSCFG, 0, sizeof(fake_SYSCFG));
+    memset(&fake_FLASH,  0, sizeof(fake_FLASH));
+
+    memset(&fake_DMA1,   0, sizeof(fake_DMA1));
+    memset(&fake_DMA2,   0, sizeof(fake_DMA2));
+
+    memset(&fake_DMA1_S0, 0, sizeof(fake_DMA1_S0));
+    memset(&fake_DMA1_S1, 0, sizeof(fake_DMA1_S1));
+    memset(&fake_DMA1_S2, 0, sizeof(fake_DMA1_S2));
+    memset(&fake_DMA1_S3, 0, sizeof(fake_DMA1_S3));
+    memset(&fake_DMA1_S4, 0, sizeof(fake_DMA1_S4));
+    memset(&fake_DMA1_S5, 0, sizeof(fake_DMA1_S5));
+    memset(&fake_DMA1_S6, 0, sizeof(fake_DMA1_S6));
+    memset(&fake_DMA1_S7, 0, sizeof(fake_DMA1_S7));
+    memset(&fake_DMA2_S0, 0, sizeof(fake_DMA2_S0));
+    memset(&fake_DMA2_S1, 0, sizeof(fake_DMA2_S1));
+    memset(&fake_DMA2_S2, 0, sizeof(fake_DMA2_S2));
+    memset(&fake_DMA2_S3, 0, sizeof(fake_DMA2_S3));
+    memset(&fake_DMA2_S4, 0, sizeof(fake_DMA2_S4));
+    memset(&fake_DMA2_S5, 0, sizeof(fake_DMA2_S5));
+    memset(&fake_DMA2_S6, 0, sizeof(fake_DMA2_S6));
+    memset(&fake_DMA2_S7, 0, sizeof(fake_DMA2_S7));
+
+    memset(&fake_NVIC,       0, sizeof(fake_NVIC));
+    memset(&fake_SCB,        0, sizeof(fake_SCB));
+    memset(&fake_SysTick,    0, sizeof(fake_SysTick));
+    memset(&fake_DWT,        0, sizeof(fake_DWT));
+    memset(&fake_CoreDebug,  0, sizeof(fake_CoreDebug));
+}

--- a/tests/driver_stubs/test_periph.h
+++ b/tests/driver_stubs/test_periph.h
@@ -1,0 +1,170 @@
+/*
+ * test_periph.h — Fake STM32 peripheral instances for driver host tests.
+ *
+ * Included by tests/driver_stubs/stm32f4xx.h AFTER the real stm32f411xe.h,
+ * so all TypeDef types (GPIO_TypeDef, RCC_TypeDef, ...) are already defined.
+ *
+ * Two things this file does:
+ *  1. Declares extern fake peripheral struct instances (defined in test_periph.c)
+ *  2. #undef/#redefine all peripheral instance macros to point at those fakes
+ *
+ * Usage in test setUp():
+ *   test_periph_reset();    // zero all fake structs before each test case
+ *
+ * Usage in assertions:
+ *   TEST_ASSERT_BITS_HIGH(RCC_AHB1ENR_GPIOAEN, fake_RCC.AHB1ENR);
+ *   TEST_ASSERT_EQUAL_HEX32(1U << 10, fake_GPIOA.MODER);
+ */
+
+#ifndef TEST_PERIPH_H
+#define TEST_PERIPH_H
+
+/* ---- STM32 peripheral fake instances ------------------------------------ */
+
+extern GPIO_TypeDef    fake_GPIOA;
+extern GPIO_TypeDef    fake_GPIOB;
+extern GPIO_TypeDef    fake_GPIOC;
+extern GPIO_TypeDef    fake_GPIOD;
+extern GPIO_TypeDef    fake_GPIOE;
+extern GPIO_TypeDef    fake_GPIOH;
+
+extern RCC_TypeDef     fake_RCC;
+
+extern USART_TypeDef   fake_USART2;
+
+extern SPI_TypeDef     fake_SPI1;
+extern SPI_TypeDef     fake_SPI2;
+extern SPI_TypeDef     fake_SPI3;
+extern SPI_TypeDef     fake_SPI4;
+extern SPI_TypeDef     fake_SPI5;
+
+extern TIM_TypeDef     fake_TIM2;
+extern TIM_TypeDef     fake_TIM3;
+extern TIM_TypeDef     fake_TIM4;
+extern TIM_TypeDef     fake_TIM5;
+
+extern EXTI_TypeDef    fake_EXTI;
+extern SYSCFG_TypeDef  fake_SYSCFG;
+extern FLASH_TypeDef   fake_FLASH;
+
+extern DMA_TypeDef     fake_DMA1;
+extern DMA_TypeDef     fake_DMA2;
+
+extern DMA_Stream_TypeDef fake_DMA1_S0;
+extern DMA_Stream_TypeDef fake_DMA1_S1;
+extern DMA_Stream_TypeDef fake_DMA1_S2;
+extern DMA_Stream_TypeDef fake_DMA1_S3;
+extern DMA_Stream_TypeDef fake_DMA1_S4;
+extern DMA_Stream_TypeDef fake_DMA1_S5;
+extern DMA_Stream_TypeDef fake_DMA1_S6;
+extern DMA_Stream_TypeDef fake_DMA1_S7;
+extern DMA_Stream_TypeDef fake_DMA2_S0;
+extern DMA_Stream_TypeDef fake_DMA2_S1;
+extern DMA_Stream_TypeDef fake_DMA2_S2;
+extern DMA_Stream_TypeDef fake_DMA2_S3;
+extern DMA_Stream_TypeDef fake_DMA2_S4;
+extern DMA_Stream_TypeDef fake_DMA2_S5;
+extern DMA_Stream_TypeDef fake_DMA2_S6;
+extern DMA_Stream_TypeDef fake_DMA2_S7;
+
+/* ---- Cortex-M4 core peripheral fakes (declared in core_cm4.h stub) ------ */
+/* fake_NVIC, fake_SCB, fake_SysTick, fake_DWT, fake_CoreDebug             */
+
+/* ---- Override STM32 peripheral instance macros -------------------------- */
+
+#undef GPIOA
+#define GPIOA    (&fake_GPIOA)
+#undef GPIOB
+#define GPIOB    (&fake_GPIOB)
+#undef GPIOC
+#define GPIOC    (&fake_GPIOC)
+#undef GPIOD
+#define GPIOD    (&fake_GPIOD)
+#undef GPIOE
+#define GPIOE    (&fake_GPIOE)
+#undef GPIOH
+#define GPIOH    (&fake_GPIOH)
+
+#undef RCC
+#define RCC      (&fake_RCC)
+
+#undef USART2
+#define USART2   (&fake_USART2)
+
+#undef SPI1
+#define SPI1     (&fake_SPI1)
+#undef SPI2
+#define SPI2     (&fake_SPI2)
+#undef SPI3
+#define SPI3     (&fake_SPI3)
+#undef SPI4
+#define SPI4     (&fake_SPI4)
+#undef SPI5
+#define SPI5     (&fake_SPI5)
+
+#undef TIM2
+#define TIM2     (&fake_TIM2)
+#undef TIM3
+#define TIM3     (&fake_TIM3)
+#undef TIM4
+#define TIM4     (&fake_TIM4)
+#undef TIM5
+#define TIM5     (&fake_TIM5)
+
+#undef EXTI
+#define EXTI     (&fake_EXTI)
+#undef SYSCFG
+#define SYSCFG   (&fake_SYSCFG)
+#undef FLASH
+#define FLASH    (&fake_FLASH)
+
+#undef DMA1
+#define DMA1     (&fake_DMA1)
+#undef DMA2
+#define DMA2     (&fake_DMA2)
+
+#undef DMA1_Stream0
+#define DMA1_Stream0  (&fake_DMA1_S0)
+#undef DMA1_Stream1
+#define DMA1_Stream1  (&fake_DMA1_S1)
+#undef DMA1_Stream2
+#define DMA1_Stream2  (&fake_DMA1_S2)
+#undef DMA1_Stream3
+#define DMA1_Stream3  (&fake_DMA1_S3)
+#undef DMA1_Stream4
+#define DMA1_Stream4  (&fake_DMA1_S4)
+#undef DMA1_Stream5
+#define DMA1_Stream5  (&fake_DMA1_S5)
+#undef DMA1_Stream6
+#define DMA1_Stream6  (&fake_DMA1_S6)
+#undef DMA1_Stream7
+#define DMA1_Stream7  (&fake_DMA1_S7)
+
+#undef DMA2_Stream0
+#define DMA2_Stream0  (&fake_DMA2_S0)
+#undef DMA2_Stream1
+#define DMA2_Stream1  (&fake_DMA2_S1)
+#undef DMA2_Stream2
+#define DMA2_Stream2  (&fake_DMA2_S2)
+#undef DMA2_Stream3
+#define DMA2_Stream3  (&fake_DMA2_S3)
+#undef DMA2_Stream4
+#define DMA2_Stream4  (&fake_DMA2_S4)
+#undef DMA2_Stream5
+#define DMA2_Stream5  (&fake_DMA2_S5)
+#undef DMA2_Stream6
+#define DMA2_Stream6  (&fake_DMA2_S6)
+#undef DMA2_Stream7
+#define DMA2_Stream7  (&fake_DMA2_S7)
+
+/* ---- Reset helper ------------------------------------------------------- */
+
+/**
+ * @brief Zero all fake peripheral structs to power-on defaults.
+ *
+ * Call in setUp() before each test case to ensure a clean state.
+ * Also resets Cortex-M4 core fakes (NVIC, SCB, SysTick, DWT, CoreDebug).
+ */
+void test_periph_reset(void);
+
+#endif /* TEST_PERIPH_H */

--- a/tests/gpio/Makefile
+++ b/tests/gpio/Makefile
@@ -1,0 +1,25 @@
+CC     = gcc
+CFLAGS = -Wall -Wextra -Wno-unknown-pragmas -Wno-unknown-warning-option \
+         -I../../tests/driver_stubs \
+         -I../../drivers/inc \
+         -I../../chip_headers/CMSIS/Include \
+         -I../../chip_headers/CMSIS/Device/ST/STM32F4xx/Include \
+         -I../../3rd_party/unity/src \
+         $(EXTRA_CFLAGS)
+
+UNITY_SRC       = ../../3rd_party/unity/src/unity.c
+GPIO_DRIVER_SRC = ../../drivers/src/gpio_handler.c
+TEST_PERIPH_SRC = ../../tests/driver_stubs/test_periph.c
+
+.PHONY: all run clean
+
+all: test_gpio.out
+
+run: all
+	./test_gpio.out
+
+test_gpio.out: test_gpio.c $(GPIO_DRIVER_SRC) $(TEST_PERIPH_SRC) $(UNITY_SRC)
+	$(CC) $(CFLAGS) $^ -o $@
+
+clean:
+	rm -f *.out *.o *.gcda *.gcno

--- a/tests/gpio/test_gpio.c
+++ b/tests/gpio/test_gpio.c
@@ -1,0 +1,459 @@
+/*
+ * test_gpio.c — Host unit tests for drivers/src/gpio_handler.c
+ *
+ * Uses fake peripheral structs from tests/driver_stubs/ to intercept all
+ * register accesses. The GPIO driver runs unmodified on the host — it still
+ * writes GPIOA->MODER, RCC->AHB1ENR etc., but those macros now point at
+ * global fake structs in SRAM that tests can inspect.
+ *
+ * setUp() zeroes all fake structs via test_periph_reset() before each test.
+ *
+ * Bit-flag constants (RCC_AHB1ENR_GPIOAEN, etc.) come from the real
+ * stm32f411xe.h device header — they are guaranteed to match hardware values.
+ */
+
+#include "unity.h"
+#include "stm32f4xx.h"    /* stub: TypeDefs + fake peripheral declarations */
+#include "gpio_handler.h" /* GPIO driver API */
+
+/* ---- Test lifecycle ----------------------------------------------------- */
+
+void setUp(void)
+{
+    test_periph_reset();
+}
+
+void tearDown(void) {}
+
+/* ======================================================================== */
+/* gpio_clock_enable / gpio_clock_disable                                    */
+/* ======================================================================== */
+
+void test_clock_enable_port_a_sets_gpioaen(void)
+{
+    gpio_clock_enable(GPIO_PORT_A);
+    TEST_ASSERT_BITS_HIGH(RCC_AHB1ENR_GPIOAEN, fake_RCC.AHB1ENR);
+}
+
+void test_clock_enable_port_b_sets_gpioben(void)
+{
+    gpio_clock_enable(GPIO_PORT_B);
+    TEST_ASSERT_BITS_HIGH(RCC_AHB1ENR_GPIOBEN, fake_RCC.AHB1ENR);
+}
+
+void test_clock_enable_port_c_sets_gpiocen(void)
+{
+    gpio_clock_enable(GPIO_PORT_C);
+    TEST_ASSERT_BITS_HIGH(RCC_AHB1ENR_GPIOCEN, fake_RCC.AHB1ENR);
+}
+
+void test_clock_enable_does_not_clear_other_bits(void)
+{
+    /* Pre-set some other bits */
+    fake_RCC.AHB1ENR = RCC_AHB1ENR_GPIOBEN;
+    gpio_clock_enable(GPIO_PORT_A);
+    /* Both A and B should be set */
+    TEST_ASSERT_BITS_HIGH(RCC_AHB1ENR_GPIOAEN | RCC_AHB1ENR_GPIOBEN,
+                          fake_RCC.AHB1ENR);
+}
+
+void test_clock_disable_port_a_clears_gpioaen(void)
+{
+    fake_RCC.AHB1ENR = RCC_AHB1ENR_GPIOAEN;
+    gpio_clock_disable(GPIO_PORT_A);
+    TEST_ASSERT_BITS_LOW(RCC_AHB1ENR_GPIOAEN, fake_RCC.AHB1ENR);
+}
+
+void test_clock_disable_does_not_clear_other_bits(void)
+{
+    fake_RCC.AHB1ENR = RCC_AHB1ENR_GPIOAEN | RCC_AHB1ENR_GPIOBEN;
+    gpio_clock_disable(GPIO_PORT_A);
+    TEST_ASSERT_BITS_HIGH(RCC_AHB1ENR_GPIOBEN, fake_RCC.AHB1ENR);
+    TEST_ASSERT_BITS_LOW(RCC_AHB1ENR_GPIOAEN,  fake_RCC.AHB1ENR);
+}
+
+/* ======================================================================== */
+/* gpio_configure_pin — MODER register                                       */
+/* ======================================================================== */
+
+void test_configure_pin_input_clears_moder_bits(void)
+{
+    /* Start dirty: pre-set pin 5 to output mode */
+    fake_GPIOA.MODER = (1U << (5 * 2));
+    gpio_configure_pin(GPIO_PORT_A, 5, GPIO_MODE_INPUT);
+    /* Input = 00 → both bits of pin 5 must be 0 */
+    TEST_ASSERT_EQUAL_HEX32(0U, fake_GPIOA.MODER);
+}
+
+void test_configure_pin_output_sets_moder_01(void)
+{
+    gpio_configure_pin(GPIO_PORT_A, 5, GPIO_MODE_OUTPUT);
+    /* Pin 5 bits [11:10] = 01 */
+    TEST_ASSERT_EQUAL_HEX32(1U << (5 * 2), fake_GPIOA.MODER);
+}
+
+void test_configure_pin_af_sets_moder_10(void)
+{
+    gpio_configure_pin(GPIO_PORT_A, 5, GPIO_MODE_AF);
+    /* Pin 5 bits [11:10] = 10 */
+    TEST_ASSERT_EQUAL_HEX32(2U << (5 * 2), fake_GPIOA.MODER);
+}
+
+void test_configure_pin_analog_sets_moder_11(void)
+{
+    gpio_configure_pin(GPIO_PORT_A, 5, GPIO_MODE_ANALOG);
+    /* Pin 5 bits [11:10] = 11 */
+    TEST_ASSERT_EQUAL_HEX32(3U << (5 * 2), fake_GPIOA.MODER);
+}
+
+void test_configure_pin_clears_previous_mode(void)
+{
+    gpio_configure_pin(GPIO_PORT_A, 5, GPIO_MODE_OUTPUT);
+    gpio_configure_pin(GPIO_PORT_A, 5, GPIO_MODE_INPUT);
+    TEST_ASSERT_EQUAL_HEX32(0U, fake_GPIOA.MODER);
+}
+
+void test_configure_pin_does_not_affect_other_pins(void)
+{
+    /* Set pin 3 to output, then configure pin 5 */
+    gpio_configure_pin(GPIO_PORT_A, 3, GPIO_MODE_OUTPUT);
+    gpio_configure_pin(GPIO_PORT_A, 5, GPIO_MODE_AF);
+    /* Pin 3 bits [7:6] = 01, pin 5 bits [11:10] = 10 */
+    uint32_t expected = (1U << (3 * 2)) | (2U << (5 * 2));
+    TEST_ASSERT_EQUAL_HEX32(expected, fake_GPIOA.MODER);
+}
+
+void test_configure_pin_invalid_pin_is_noop(void)
+{
+    gpio_configure_pin(GPIO_PORT_A, 16, GPIO_MODE_OUTPUT);
+    TEST_ASSERT_EQUAL_HEX32(0U, fake_GPIOA.MODER);
+}
+
+void test_configure_pin_invalid_mode_is_noop(void)
+{
+    gpio_configure_pin(GPIO_PORT_A, 5, GPIO_MODE_INVALID);
+    TEST_ASSERT_EQUAL_HEX32(0U, fake_GPIOA.MODER);
+}
+
+/* ======================================================================== */
+/* gpio_set_pin / gpio_clear_pin / gpio_toggle_pin                           */
+/* ======================================================================== */
+
+void test_set_pin_writes_bsrr_set_bit(void)
+{
+    gpio_set_pin(GPIO_PORT_A, 5);
+    TEST_ASSERT_BITS_HIGH(1U << 5, fake_GPIOA.BSRR);
+    /* Clear bit (upper 16) must not be set */
+    TEST_ASSERT_BITS_LOW(1U << (5 + 16), fake_GPIOA.BSRR);
+}
+
+void test_clear_pin_writes_bsrr_reset_bit(void)
+{
+    gpio_clear_pin(GPIO_PORT_A, 5);
+    TEST_ASSERT_BITS_HIGH(1U << (5 + 16), fake_GPIOA.BSRR);
+    TEST_ASSERT_BITS_LOW(1U << 5, fake_GPIOA.BSRR);
+}
+
+void test_set_pin_invalid_pin_is_noop(void)
+{
+    gpio_set_pin(GPIO_PORT_A, 16);
+    TEST_ASSERT_EQUAL_HEX32(0U, fake_GPIOA.BSRR);
+}
+
+void test_toggle_pin_flips_odr_bit(void)
+{
+    fake_GPIOA.ODR = 0U;
+    gpio_toggle_pin(GPIO_PORT_A, 5);
+    TEST_ASSERT_BITS_HIGH(1U << 5, fake_GPIOA.ODR);
+    gpio_toggle_pin(GPIO_PORT_A, 5);
+    TEST_ASSERT_BITS_LOW(1U << 5, fake_GPIOA.ODR);
+}
+
+void test_toggle_pin_does_not_affect_other_bits(void)
+{
+    fake_GPIOA.ODR = (1U << 3);  /* pin 3 already high */
+    gpio_toggle_pin(GPIO_PORT_A, 5);
+    TEST_ASSERT_BITS_HIGH(1U << 3, fake_GPIOA.ODR);  /* pin 3 unchanged */
+    TEST_ASSERT_BITS_HIGH(1U << 5, fake_GPIOA.ODR);  /* pin 5 toggled */
+}
+
+/* ======================================================================== */
+/* gpio_read_pin — IDR register                                              */
+/* ======================================================================== */
+
+void test_read_pin_returns_1_when_idr_bit_set(void)
+{
+    fake_GPIOA.IDR = (1U << 5);
+    TEST_ASSERT_EQUAL(1, gpio_read_pin(GPIO_PORT_A, 5));
+}
+
+void test_read_pin_returns_0_when_idr_bit_clear(void)
+{
+    fake_GPIOA.IDR = 0U;
+    TEST_ASSERT_EQUAL(0, gpio_read_pin(GPIO_PORT_A, 5));
+}
+
+void test_read_pin_only_reads_requested_bit(void)
+{
+    fake_GPIOA.IDR = (1U << 3);  /* pin 3 high, pin 5 low */
+    TEST_ASSERT_EQUAL(0, gpio_read_pin(GPIO_PORT_A, 5));
+    TEST_ASSERT_EQUAL(1, gpio_read_pin(GPIO_PORT_A, 3));
+}
+
+void test_read_pin_invalid_pin_returns_0(void)
+{
+    fake_GPIOA.IDR = 0xFFFFFFFFU;
+    TEST_ASSERT_EQUAL(0, gpio_read_pin(GPIO_PORT_A, 16));
+}
+
+/* ======================================================================== */
+/* gpio_set_af — AFR registers                                               */
+/* ======================================================================== */
+
+void test_set_af_low_pin_uses_afr0(void)
+{
+    /* Pin 5, AF7: reg=0, pos=5%8*4=20, bits [23:20] = 7 */
+    gpio_set_af(GPIO_PORT_A, 5, 7);
+    TEST_ASSERT_EQUAL_HEX32(7U << 20, fake_GPIOA.AFR[0]);
+    TEST_ASSERT_EQUAL_HEX32(0U,       fake_GPIOA.AFR[1]);
+}
+
+void test_set_af_high_pin_uses_afr1(void)
+{
+    /* Pin 10, AF7: reg=1, pos=10%8*4=8, bits [11:8] = 7 */
+    gpio_set_af(GPIO_PORT_A, 10, 7);
+    TEST_ASSERT_EQUAL_HEX32(0U,       fake_GPIOA.AFR[0]);
+    TEST_ASSERT_EQUAL_HEX32(7U << 8,  fake_GPIOA.AFR[1]);
+}
+
+void test_set_af_pin_0_afr0_bits_3_0(void)
+{
+    gpio_set_af(GPIO_PORT_A, 0, 5);
+    TEST_ASSERT_EQUAL_HEX32(5U, fake_GPIOA.AFR[0]);
+}
+
+void test_set_af_pin_15_afr1_bits_31_28(void)
+{
+    gpio_set_af(GPIO_PORT_A, 15, 14);
+    TEST_ASSERT_EQUAL_HEX32(14U << 28, fake_GPIOA.AFR[1]);
+}
+
+void test_set_af_clears_previous_value(void)
+{
+    gpio_set_af(GPIO_PORT_A, 5, 5);   /* set AF5 */
+    gpio_set_af(GPIO_PORT_A, 5, 7);   /* overwrite with AF7 */
+    TEST_ASSERT_EQUAL_HEX32(7U << 20, fake_GPIOA.AFR[0]);
+}
+
+void test_set_af_does_not_affect_adjacent_pin(void)
+{
+    gpio_set_af(GPIO_PORT_A, 4, 3);   /* pin 4: bits [19:16] = 3 */
+    gpio_set_af(GPIO_PORT_A, 5, 7);   /* pin 5: bits [23:20] = 7 */
+    uint32_t expected = (3U << 16) | (7U << 20);
+    TEST_ASSERT_EQUAL_HEX32(expected, fake_GPIOA.AFR[0]);
+}
+
+void test_set_af_invalid_pin_is_noop(void)
+{
+    gpio_set_af(GPIO_PORT_A, 16, 7);
+    TEST_ASSERT_EQUAL_HEX32(0U, fake_GPIOA.AFR[0]);
+    TEST_ASSERT_EQUAL_HEX32(0U, fake_GPIOA.AFR[1]);
+}
+
+void test_set_af_invalid_af_is_noop(void)
+{
+    gpio_set_af(GPIO_PORT_A, 5, 16);
+    TEST_ASSERT_EQUAL_HEX32(0U, fake_GPIOA.AFR[0]);
+}
+
+/* ======================================================================== */
+/* gpio_set_output_type — OTYPER register                                    */
+/* ======================================================================== */
+
+void test_set_output_type_push_pull_clears_bit(void)
+{
+    fake_GPIOA.OTYPER = (1U << 5);  /* pre-set to open-drain */
+    gpio_set_output_type(GPIO_PORT_A, 5, GPIO_OUTPUT_PUSH_PULL);
+    TEST_ASSERT_BITS_LOW(1U << 5, fake_GPIOA.OTYPER);
+}
+
+void test_set_output_type_open_drain_sets_bit(void)
+{
+    gpio_set_output_type(GPIO_PORT_A, 5, GPIO_OUTPUT_OPEN_DRAIN);
+    TEST_ASSERT_BITS_HIGH(1U << 5, fake_GPIOA.OTYPER);
+}
+
+void test_set_output_type_does_not_affect_other_pins(void)
+{
+    fake_GPIOA.OTYPER = (1U << 3);
+    gpio_set_output_type(GPIO_PORT_A, 5, GPIO_OUTPUT_OPEN_DRAIN);
+    TEST_ASSERT_BITS_HIGH(1U << 3, fake_GPIOA.OTYPER);
+    TEST_ASSERT_BITS_HIGH(1U << 5, fake_GPIOA.OTYPER);
+}
+
+/* ======================================================================== */
+/* gpio_set_speed — OSPEEDR register                                         */
+/* ======================================================================== */
+
+void test_set_speed_low_clears_ospeedr_bits(void)
+{
+    fake_GPIOA.OSPEEDR = (3U << (5 * 2));  /* pre-set to HIGH */
+    gpio_set_speed(GPIO_PORT_A, 5, GPIO_SPEED_LOW);
+    TEST_ASSERT_EQUAL_HEX32(0U, fake_GPIOA.OSPEEDR);
+}
+
+void test_set_speed_medium_sets_ospeedr_01(void)
+{
+    gpio_set_speed(GPIO_PORT_A, 5, GPIO_SPEED_MEDIUM);
+    TEST_ASSERT_EQUAL_HEX32(1U << (5 * 2), fake_GPIOA.OSPEEDR);
+}
+
+void test_set_speed_high_sets_ospeedr_11(void)
+{
+    gpio_set_speed(GPIO_PORT_A, 5, GPIO_SPEED_HIGH);
+    TEST_ASSERT_EQUAL_HEX32(3U << (5 * 2), fake_GPIOA.OSPEEDR);
+}
+
+/* ======================================================================== */
+/* gpio_set_pull — PUPDR register                                            */
+/* ======================================================================== */
+
+void test_set_pull_none_clears_pupdr_bits(void)
+{
+    fake_GPIOA.PUPDR = (1U << (5 * 2));
+    gpio_set_pull(GPIO_PORT_A, 5, GPIO_PULL_NONE);
+    TEST_ASSERT_EQUAL_HEX32(0U, fake_GPIOA.PUPDR);
+}
+
+void test_set_pull_up_sets_pupdr_01(void)
+{
+    gpio_set_pull(GPIO_PORT_A, 5, GPIO_PULL_UP);
+    TEST_ASSERT_EQUAL_HEX32(1U << (5 * 2), fake_GPIOA.PUPDR);
+}
+
+void test_set_pull_down_sets_pupdr_10(void)
+{
+    gpio_set_pull(GPIO_PORT_A, 5, GPIO_PULL_DOWN);
+    TEST_ASSERT_EQUAL_HEX32(2U << (5 * 2), fake_GPIOA.PUPDR);
+}
+
+/* ======================================================================== */
+/* gpio_configure_full — all registers in one call                           */
+/* ======================================================================== */
+
+void test_configure_full_sets_all_four_registers(void)
+{
+    gpio_configure_full(GPIO_PORT_A, 5,
+                        GPIO_MODE_AF,
+                        GPIO_OUTPUT_PUSH_PULL,
+                        GPIO_SPEED_HIGH,
+                        GPIO_PULL_UP);
+
+    TEST_ASSERT_EQUAL_HEX32(2U << (5 * 2), fake_GPIOA.MODER);     /* AF = 10 */
+    TEST_ASSERT_BITS_LOW(1U << 5,           fake_GPIOA.OTYPER);    /* push-pull */
+    TEST_ASSERT_EQUAL_HEX32(3U << (5 * 2), fake_GPIOA.OSPEEDR);   /* HIGH = 11 */
+    TEST_ASSERT_EQUAL_HEX32(1U << (5 * 2), fake_GPIOA.PUPDR);     /* pull-up = 01 */
+}
+
+/* ======================================================================== */
+/* Port routing — each port maps to its own fake struct                      */
+/* ======================================================================== */
+
+void test_configure_port_b_modifies_gpiob_not_gpioa(void)
+{
+    gpio_configure_pin(GPIO_PORT_B, 3, GPIO_MODE_OUTPUT);
+    TEST_ASSERT_EQUAL_HEX32(1U << (3 * 2), fake_GPIOB.MODER);
+    TEST_ASSERT_EQUAL_HEX32(0U,             fake_GPIOA.MODER);
+}
+
+void test_configure_port_c_modifies_gpioc(void)
+{
+    gpio_configure_pin(GPIO_PORT_C, 13, GPIO_MODE_INPUT);
+    /* Input clears bits — starting from 0, still 0 */
+    TEST_ASSERT_EQUAL_HEX32(0U, fake_GPIOC.MODER);
+    /* Verify pin 13 can be read back */
+    fake_GPIOC.IDR = (1U << 13);
+    TEST_ASSERT_EQUAL(1, gpio_read_pin(GPIO_PORT_C, 13));
+}
+
+void test_set_pin_port_h_modifies_gpioh(void)
+{
+    gpio_set_pin(GPIO_PORT_H, 0);
+    TEST_ASSERT_BITS_HIGH(1U << 0, fake_GPIOH.BSRR);
+    TEST_ASSERT_EQUAL_HEX32(0U,    fake_GPIOA.BSRR);
+}
+
+/* ======================================================================== */
+/* main                                                                      */
+/* ======================================================================== */
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    /* Clock enable / disable */
+    RUN_TEST(test_clock_enable_port_a_sets_gpioaen);
+    RUN_TEST(test_clock_enable_port_b_sets_gpioben);
+    RUN_TEST(test_clock_enable_port_c_sets_gpiocen);
+    RUN_TEST(test_clock_enable_does_not_clear_other_bits);
+    RUN_TEST(test_clock_disable_port_a_clears_gpioaen);
+    RUN_TEST(test_clock_disable_does_not_clear_other_bits);
+
+    /* gpio_configure_pin — MODER */
+    RUN_TEST(test_configure_pin_input_clears_moder_bits);
+    RUN_TEST(test_configure_pin_output_sets_moder_01);
+    RUN_TEST(test_configure_pin_af_sets_moder_10);
+    RUN_TEST(test_configure_pin_analog_sets_moder_11);
+    RUN_TEST(test_configure_pin_clears_previous_mode);
+    RUN_TEST(test_configure_pin_does_not_affect_other_pins);
+    RUN_TEST(test_configure_pin_invalid_pin_is_noop);
+    RUN_TEST(test_configure_pin_invalid_mode_is_noop);
+
+    /* gpio_set/clear/toggle */
+    RUN_TEST(test_set_pin_writes_bsrr_set_bit);
+    RUN_TEST(test_clear_pin_writes_bsrr_reset_bit);
+    RUN_TEST(test_set_pin_invalid_pin_is_noop);
+    RUN_TEST(test_toggle_pin_flips_odr_bit);
+    RUN_TEST(test_toggle_pin_does_not_affect_other_bits);
+
+    /* gpio_read_pin */
+    RUN_TEST(test_read_pin_returns_1_when_idr_bit_set);
+    RUN_TEST(test_read_pin_returns_0_when_idr_bit_clear);
+    RUN_TEST(test_read_pin_only_reads_requested_bit);
+    RUN_TEST(test_read_pin_invalid_pin_returns_0);
+
+    /* gpio_set_af */
+    RUN_TEST(test_set_af_low_pin_uses_afr0);
+    RUN_TEST(test_set_af_high_pin_uses_afr1);
+    RUN_TEST(test_set_af_pin_0_afr0_bits_3_0);
+    RUN_TEST(test_set_af_pin_15_afr1_bits_31_28);
+    RUN_TEST(test_set_af_clears_previous_value);
+    RUN_TEST(test_set_af_does_not_affect_adjacent_pin);
+    RUN_TEST(test_set_af_invalid_pin_is_noop);
+    RUN_TEST(test_set_af_invalid_af_is_noop);
+
+    /* gpio_set_output_type */
+    RUN_TEST(test_set_output_type_push_pull_clears_bit);
+    RUN_TEST(test_set_output_type_open_drain_sets_bit);
+    RUN_TEST(test_set_output_type_does_not_affect_other_pins);
+
+    /* gpio_set_speed */
+    RUN_TEST(test_set_speed_low_clears_ospeedr_bits);
+    RUN_TEST(test_set_speed_medium_sets_ospeedr_01);
+    RUN_TEST(test_set_speed_high_sets_ospeedr_11);
+
+    /* gpio_set_pull */
+    RUN_TEST(test_set_pull_none_clears_pupdr_bits);
+    RUN_TEST(test_set_pull_up_sets_pupdr_01);
+    RUN_TEST(test_set_pull_down_sets_pupdr_10);
+
+    /* gpio_configure_full */
+    RUN_TEST(test_configure_full_sets_all_four_registers);
+
+    /* Port routing */
+    RUN_TEST(test_configure_port_b_modifies_gpiob_not_gpioa);
+    RUN_TEST(test_configure_port_c_modifies_gpioc);
+    RUN_TEST(test_set_pin_port_h_modifies_gpioh);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Implements the driver host testing infrastructure described in #98, validated with a complete GPIO test suite (44 tests).

## How it works

All 11 driver `.c` files use `#include "stm32f4xx.h"`. The test build puts `tests/driver_stubs/` **before** `chip_headers/` in `-I` flags, so the compiler finds our stub first.

**`tests/driver_stubs/stm32f4xx.h`** — thin shim:
1. Includes the REAL `stm32f411xe.h` → gets all TypeDef structs and bit-flag constants with guaranteed accuracy
2. `stm32f411xe.h` includes `core_cm4.h` → resolves to our stub
3. Includes `test_periph.h` → `#undef`/`#redefine` all peripheral instance macros to fake structs

**`tests/driver_stubs/core_cm4.h`** — CMSIS stub:
- NVIC_Type struct + `fake_NVIC` (inspectable: tests assert which IRQn was enabled)
- SysTick_Type, SCB_Type, DWT_Type, CoreDebug_Type stubs
- NVIC_EnableIRQ/DisableIRQ/SetPriority operating on `fake_NVIC`
- `__get_PRIMASK`, `__disable_irq`, `__enable_irq` no-ops

**`tests/driver_stubs/test_periph.h/c`** — 10 STM32 peripheral fakes + 16 DMA streams + 5 Cortex-M4 core fakes + `test_periph_reset()`

Driver code is **completely unchanged**.

## GPIO test suite (44 tests)

Covers every public function in `drivers/src/gpio_handler.c`:
- `gpio_clock_enable/disable` → asserts `fake_RCC.AHB1ENR` bits
- `gpio_configure_pin` → asserts `fake_GPIOx.MODER` 2-bit fields
- `gpio_set/clear/toggle_pin` → asserts `fake_GPIOx.BSRR` / `ODR`
- `gpio_read_pin` → pre-seeds `fake_GPIOx.IDR`, asserts return value
- `gpio_set_af` → asserts `fake_GPIOx.AFR[0/1]` nibble (low/high pins)
- `gpio_set_output_type/speed/pull` → asserts OTYPER/OSPEEDR/PUPDR fields
- `gpio_configure_full` → asserts all 4 registers in one call
- Invalid input boundary tests (pin > 15, mode = INVALID) → no-op
- Port routing tests (GPIOB/C/H isolation)

## Pattern for future driver test suites

Each new driver test only needs:
1. A `tests/<driver>/Makefile` following the GPIO pattern (include paths + sources)
2. A test file including `stm32f4xx.h` (gets all fakes + overrides automatically)
3. 4 lines in `test_periph.h/c` if the driver uses a peripheral not yet declared

## Test count

64 → **108 host tests** (string_utils: 23, cli: 41, gpio: 44)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)