### PR TITLE
Add hil-tests CI job on self-hosted Pi runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,20 @@ jobs:
 
       - name: Build all firmware examples
         run: make all
+
+  hil-tests:
+    name: HIL Tests
+    runs-on: [self-hosted, pi-hil]
+    needs: host-tests
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Print toolchain version
+        run: arm-none-eabi-gcc --version
+
+      - name: Run HIL tests
+        run: python3 scripts/run_hil_tests.py --timeout 120 --baseline tests/baselines/performance.json

--- a/docs/wiki/ci.md
+++ b/docs/wiki/ci.md
@@ -38,15 +38,18 @@ GitHub Actions workflow at `.github/workflows/ci.yml`.
 3. Print `arm-none-eabi-gcc --version`
 4. `make all` (builds all examples; exits non-zero on any failure)
 
-### `hil-tests` (planned — Issue #86)
+### `hil-tests` (active)
 
 | Property | Value |
 |---|---|
-| Runner | `[self-hosted, pi-hil]` (Raspberry Pi on local server) |
-| Required check | Yes — will be added to branch protection when implemented |
+| Runner | `[self-hosted, pi-hil]` (Raspberry Pi on local network) |
+| Required check | Yes — add to branch protection after first run on `main` |
 | Dependency | `needs: host-tests` |
 
-**Infrastructure ready:** The HIL test harness, machine-parseable output format, automation script (`scripts/run_hil_tests.py`), and performance baselines (`tests/baselines/performance.json`) are all implemented and validated locally. Only the Pi runner registration and CI workflow job addition remain.
+**Steps:**
+1. Checkout with `submodules: recursive`
+2. Print `arm-none-eabi-gcc --version`
+3. `python3 scripts/run_hil_tests.py --timeout 120 --baseline tests/baselines/performance.json` (build → flash → run 60 Unity tests → validate baselines)
 
 ## Branch Protection
 
@@ -65,7 +68,7 @@ When `hil-tests` is added: register it as a third required status check in the s
 | ~~#85~~ | ~~Add JUnit XML test reporting~~ — **Done**: `tests/unity_to_junit.py` + `dorny/test-reporter@v3` |
 | ~~#87~~ | ~~Add `firmware-build` job~~ — **Done**: parallel job, `apt` ARM toolchain, `make all` |
 | ~~#88~~ | ~~Add code coverage~~ — **Done**: `lcov` + `genhtml`, uploaded via `actions/upload-artifact@v6` |
-| #86 | Add `hil-tests` job — self-hosted Pi runner, OpenOCD flash, serial assertion |
+| ~~#86~~ | ~~Add `hil-tests` job — self-hosted Pi runner, OpenOCD flash, serial assertion~~ — **Done**: `[self-hosted, pi-hil]`, `needs: host-tests`, `run_hil_tests.py` |
 
 ## Adding a New Required Check
 

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -6,6 +6,13 @@ Types: `merge`, `decision`, `milestone`, `infra`
 
 ---
 
+## [2026-04-13] infra | Add hil-tests CI job on self-hosted Pi runner (#86, #105)
+
+Added `hil-tests` job to `.github/workflows/ci.yml` running on `[self-hosted, pi-hil]`
+with `needs: host-tests`. The Pi runner is registered and idle. Also fixed GCC 14 linker
+compatibility (`.ARM.exidx` section), throughput calculation truncation (switched to float),
+and updated all performance baselines. PR #106.
+
 ## [2026-04-12] milestone | HIL test infrastructure with Unity on target (#86)
 
 Implemented hardware-in-the-loop testing framework. Unity compiled for ARM target with `UNITY_OUTPUT_CHAR=_putchar` to route output through UART (avoids libc putchar Hard Fault on bare-metal). Build controlled by `HIL_TEST=1` flag — production builds unchanged (~19 KB), HIL builds ~24 KB. Test harness uses parameterized `RUN_SPI_TEST` macro for 60 tests: all 5 SPI interfaces at max speed (Tier 1), deep prescaler/buffer-size sweep on SPI2 (APB1) and SPI1 (APB2) (Tier 2), plus FPU tests (Tier 3). Machine-parseable output format (`TEST:name:PASS:cycles=N:metric=N`) with `START_TESTS`/`END_TESTS` markers. Python automation script (`scripts/run_hil_tests.py`) handles build → flash → serial capture → parse → baseline validation. Performance baselines stored in `tests/baselines/performance.json` with per-test tolerance thresholds. Key finding: DMA crossover at ~16 bytes (below that, polled is faster due to DMA setup overhead). All infrastructure ready for CI integration — only Pi runner registration remains (#86).

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -15,7 +15,8 @@
 
 | Issue | Title | Notes |
 |---|---|---|
-| #86 | Self-hosted Raspberry Pi runner for HIL tests | **HIL test infra done** (test harness, automation script, baselines). Only Pi runner setup + CI job addition remain. |
+| ~~#86~~ | ~~Self-hosted Raspberry Pi runner for HIL tests~~ | **Done** — Pi registered with `pi-hil` label, `hil-tests` job added to CI, `needs: host-tests`. |
+| #105 | GCC 14 linker compat + HIL script fixes | PR #106 open — `.ARM.exidx` section, throughput formula fix, baseline updates. |
 
 ### Architecture / Quality
 
@@ -58,8 +59,7 @@
 6. **#26** — unified error codes
 7. **#69** — multi-instance UART
 8. **#73** — NVIC priority scheme
-9. **#86** — HIL Pi runner
-10. Remaining drivers (#66, #67, #68, #70, #71, #72) after #26 and #73
+9. Remaining drivers (#66, #67, #68, #70, #71, #72) after #26 and #73
 11. Examples (#14, #16, #22, #45) driven by driver availability
 
 ---
@@ -83,3 +83,4 @@ See [log.md](log.md) for the full history. Key milestones:
 - ✅ Unity as direct root-level submodule (`3rd_party/unity/`)
 - ✅ All GitHub Actions upgraded to Node.js 24
 - ✅ HIL test infrastructure: Unity on target, parameterized SPI test sweep (60 tests), machine-parseable output, Python automation script, performance baselines
+- ✅ Self-hosted Raspberry Pi HIL runner with `pi-hil` label, `hil-tests` CI job


### PR DESCRIPTION
## Summary

- Add `hil-tests` job to `.github/workflows/ci.yml` running on `[self-hosted, pi-hil]` with `needs: host-tests`. Runs `scripts/run_hil_tests.py` for the full HIL pipeline (build, flash, 60 Unity tests, baseline validation).
- Update `docs/wiki/ci.md` to mark hil-tests as active, `docs/wiki/roadmap.md` to mark #86 done, and `docs/wiki/log.md` with the new entry.

## Test plan

- [x] `make test` — host tests pass
- [x] `make all` — all firmware examples build
- [ ] CI triggers `hil-tests` job on the Pi runner after `host-tests` passes
- After merge: add `HIL Tests` as required status check in branch protection

Closes #86

Made with [Cursor](https://cursor.com)