### PR TITLE
Update wiki to reflect HIL work and closed issues

### DIFF
--- a/docs/wiki/ci.md
+++ b/docs/wiki/ci.md
@@ -29,7 +29,7 @@ GitHub Actions workflow at `.github/workflows/ci.yml`.
 | Property | Value |
 |---|---|
 | Runner | `ubuntu-latest` (GitHub-hosted, free) |
-| Required check | Yes — add to branch protection after first run on `main` |
+| Required check | Yes — blocks PR merge |
 | Dependency | none (runs in parallel with `host-tests`) |
 
 **Steps:**
@@ -43,7 +43,7 @@ GitHub Actions workflow at `.github/workflows/ci.yml`.
 | Property | Value |
 |---|---|
 | Runner | `[self-hosted, pi-hil]` (Raspberry Pi on local network) |
-| Required check | Yes — add to branch protection after first run on `main` |
+| Required check | Yes — blocks PR merge |
 | Dependency | `needs: host-tests` |
 
 **Steps:**
@@ -53,12 +53,10 @@ GitHub Actions workflow at `.github/workflows/ci.yml`.
 
 ## Branch Protection
 
-`main` branch requires `host-tests` to pass before merge. Configured in:
+`main` requires all three jobs to pass. Configured in:
 **GitHub → Settings → Branches → Branch protection rules → main**
 
-After PR #94 merges and `firmware-build` runs on `main` for the first time, add `Firmware Build` as a second required status check in the same rule.
-
-When `hil-tests` is added: register it as a third required status check in the same rule.
+Required checks: `Host Tests`, `Firmware Build`, `HIL Tests`.
 
 ## Planned Improvements
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -9,7 +9,7 @@ Claude reads this file at session start via `CLAUDE.md`. Update it whenever a pa
 |---|---|
 | [architecture.md](architecture.md) | Module map, build system, directory layout, design principles |
 | [roadmap.md](roadmap.md) | Open issues by priority, future directions |
-| [testing.md](testing.md) | Test framework, how to add tests, test coverage status |
+| [testing.md](testing.md) | Host unit tests, driver fake-stub testing, HIL on-target testing, coverage |
 | [ci.md](ci.md) | CI pipeline, jobs, required checks, how to extend |
 
 ## Drivers

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -6,17 +6,9 @@
 
 | Issue | Title | Notes |
 |---|---|---|
-| #98 | Build driver host test infrastructure | Fake `stm32f4xx.h` + CMSIS stubs. **Prerequisite for all driver tests.** |
-| #99 | Driver host tests: GPIO and EXTI | Tier 1 register config tests. Validates infrastructure. |
-| #100 | Driver host tests: UART | Tier 1 + Tier 2. Circular buffer wrap logic, baud divisor. |
+| #99 | Driver host tests: GPIO and EXTI | Tier 1 register config tests. EXTI validates SYSCFG port mapping + NVIC enable. |
+| #100 | Driver host tests: UART | Tier 1 + Tier 2. Circular buffer wrap logic, baud divisor, init register setup. |
 | #101 | Driver host tests: RCC and Timer | Tier 1 + Tier 2. PLL solver — most complex logic in codebase. |
-
-### CI / Hardware
-
-| Issue | Title | Notes |
-|---|---|---|
-| ~~#86~~ | ~~Self-hosted Raspberry Pi runner for HIL tests~~ | **Done** — Pi registered with `pi-hil` label, `hil-tests` job added to CI, `needs: host-tests`. |
-| #105 | GCC 14 linker compat + HIL script fixes | PR #106 open — `.ARM.exidx` section, throughput formula fix, baseline updates. |
 
 ### Architecture / Quality
 
@@ -51,16 +43,15 @@
 
 ## Suggested Priority Order
 
-1. **#98** — driver test infrastructure (all other driver tests depend on this)
-2. **#99** — GPIO/EXTI tests (simplest drivers; validates the new infrastructure)
-3. **#100** — UART tests (circular buffer has non-obvious wrap edge cases)
-4. **#101** — RCC/Timer tests (PLL solver is the most complex logic in the codebase)
-5. **#62** — non-blocking SysTick tick counter
-6. **#26** — unified error codes
-7. **#69** — multi-instance UART
-8. **#73** — NVIC priority scheme
-9. Remaining drivers (#66, #67, #68, #70, #71, #72) after #26 and #73
-11. Examples (#14, #16, #22, #45) driven by driver availability
+1. **#99** — GPIO/EXTI driver tests (simplest drivers; validate the fake stub infrastructure)
+2. **#100** — UART driver tests (circular buffer has non-obvious wrap edge cases)
+3. **#101** — RCC/Timer driver tests (PLL solver is the most complex logic in the codebase)
+4. **#62** — non-blocking SysTick tick counter
+5. **#26** — unified error codes
+6. **#69** — multi-instance UART
+7. **#73** — NVIC priority scheme
+8. Remaining drivers (#66, #67, #68, #70, #71, #72) after #26 and #73
+9. Examples (#14, #16, #22, #45) driven by driver availability
 
 ---
 
@@ -72,15 +63,16 @@ See [log.md](log.md) for the full history. Key milestones:
 - ✅ RCC clock configuration (100 MHz via PLL)
 - ✅ Hardware FPU enabled in startup
 - ✅ Fault handlers with register dump
-- ✅ Hardened linker script with stack/heap overflow detection
+- ✅ Hardened linker script with stack/heap overflow detection + GCC 14 `.ARM.exidx` fix
 - ✅ CLI engine with tab completion, command history, ANSI escape handling
 - ✅ DMA-buffered printf (printf_dma)
 - ✅ Logging system (log_c) with runtime log level control
-- ✅ Host unit tests for CLI and string utils (64 tests total)
-- ✅ GitHub Actions CI pipeline: `host-tests` + `firmware-build`, branch protection
+- ✅ Host unit tests: CLI (41), string utils (23), GPIO driver (44) — 108 total
+- ✅ Driver host test infrastructure: fake `stm32f4xx.h` + `core_cm4.h` stubs, `test_periph_reset()`
+- ✅ GitHub Actions CI pipeline: `host-tests` + `firmware-build` + `hil-tests`, branch protection
 - ✅ JUnit XML test reporting (Unity → `unity_to_junit.py` → `dorny/test-reporter@v3`)
 - ✅ lcov code coverage report uploaded as CI artifact
 - ✅ Unity as direct root-level submodule (`3rd_party/unity/`)
 - ✅ All GitHub Actions upgraded to Node.js 24
-- ✅ HIL test infrastructure: Unity on target, parameterized SPI test sweep (60 tests), machine-parseable output, Python automation script, performance baselines
-- ✅ Self-hosted Raspberry Pi HIL runner with `pi-hil` label, `hil-tests` CI job
+- ✅ HIL test infrastructure: Unity on target (60 tests), machine-parseable output, Python automation, performance baselines
+- ✅ Self-hosted Raspberry Pi HIL runner (`pi-hil` label), `hil-tests` CI job with `needs: host-tests`


### PR DESCRIPTION
## Summary

Brings the project wiki up to date after PRs #103–#107 were merged.

## Changes

**`docs/wiki/roadmap.md`**
- Removed #98 (driver host test infra) — closed by PR #103 ✅
- Removed #105 (GCC 14 linker compat) — closed by PR #106 ✅
- Removed CI/Hardware section — #86 fully done, no open CI issues remain
- Updated priority order: starts at #99 (GPIO/EXTI tests)
- Updated Completed Milestones: added driver host test infra (108 tests), GCC 14 fix, full three-job CI pipeline

**`docs/wiki/ci.md`**
- `firmware-build` and `hil-tests` required check rows: updated from "add to branch protection after first run" → "Yes — blocks PR merge" (it's already configured)
- Branch Protection section: updated from stale "future work" instructions → current state (all three checks required)

**`docs/wiki/index.md`**
- Updated `testing.md` description to mention HIL testing alongside host tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)