### PR TITLE
Add Tailscale remote SSH and MCP HIL server for Claude Code (#109)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "hil": {
+      "type": "stdio",
+      "command": "python3",
+      "args": ["scripts/mcp_hil_server.py"]
+    }
+  }
+}

--- a/docs/wiki/hil-remote-access.md
+++ b/docs/wiki/hil-remote-access.md
@@ -1,0 +1,189 @@
+# HIL Remote Access and MCP Tools
+
+This page covers two related setups that together let you (and Claude) run real hardware tests from anywhere:
+
+1. **Tailscale** — reach the Pi over SSH from any network
+2. **MCP HIL server** — expose `hil_run_tests` and `hil_status` as Claude Code tools
+
+---
+
+## Part 1 — Tailscale Remote SSH
+
+### Why Tailscale
+
+The Pi is normally only reachable on the local network. Tailscale creates a mesh VPN: both machines join the same Tailscale network and each gets a stable MagicDNS hostname. No router port-forwarding needed, works from any network in the world.
+
+### Install on the Pi
+
+```sh
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up
+```
+
+Follow the auth URL printed to the terminal. Once authenticated, the Pi will appear in your Tailscale admin panel.
+
+### Install on macOS (dev machine)
+
+```sh
+brew install tailscale
+sudo tailscale up
+```
+
+Or download the macOS app from tailscale.com. Sign in to the **same Tailscale account**.
+
+### Find the Pi's hostname
+
+```sh
+tailscale status
+```
+
+The Pi will have a MagicDNS name like `raspberrypi.tail-abc123.ts.net` or just `raspberrypi` if MagicDNS is enabled. Either form works with SSH.
+
+### Set up SSH key auth (required)
+
+Automation tools (rsync, the MCP server) need passwordless SSH. Set up a dedicated key:
+
+```sh
+ssh-keygen -t ed25519 -f ~/.ssh/hil_pi -N ""
+ssh-copy-id -i ~/.ssh/hil_pi.pub <user>@<pi-tailscale-hostname>
+```
+
+Optional: add to `~/.ssh/config` to avoid specifying the key each time:
+
+```
+Host hil-pi
+    HostName <pi-tailscale-hostname>
+    User <user>
+    IdentityFile ~/.ssh/hil_pi
+    BatchMode yes
+```
+
+### Set the env var
+
+The MCP server and any scripts read `HIL_PI_SSH`:
+
+```sh
+export HIL_PI_SSH=<user>@<pi-tailscale-hostname>
+```
+
+Add to `~/.zshrc` (or `~/.bashrc`) for persistence.
+
+### Verify
+
+```sh
+ssh $HIL_PI_SSH "uname -a && ls /dev/ttyACM*"
+```
+
+Should print the Pi's kernel string and the NUCLEO board's USB serial device.
+
+---
+
+## Part 2 — MCP HIL Server
+
+### What it does
+
+`scripts/mcp_hil_server.py` is a Python stdio MCP server that Claude Code loads automatically via `.mcp.json`. It exposes two tools:
+
+| Tool | What it does |
+|---|---|
+| `hil_status()` | SSH to Pi, check reachability and `/dev/ttyACM*` presence |
+| `hil_run_tests(skip_build, skip_flash)` | rsync → build → flash → run tests → return structured results |
+
+The server runs locally on your dev machine. It SSH's to the Pi on demand — no daemon is needed on the Pi.
+
+**Code sync**: before every build, the server rsyncs the entire working tree to `~/stm32-bare-metal/` on the Pi. This means uncommitted local changes are included in the test run immediately.
+
+### Install the MCP dependency
+
+```sh
+pip install mcp
+```
+
+This is a dev-only tool; it does not need to be added to any project requirements file.
+
+### Configuration
+
+Claude Code picks up `.mcp.json` at the project root automatically. The `HIL_PI_SSH` env var must be set in the shell that launches Claude Code (set it in `~/.zshrc`).
+
+No hostname or credentials are hard-coded in any repo file.
+
+### Verifying the MCP server
+
+Check imports:
+
+```sh
+cd <project-root>
+python3 -c "import scripts.mcp_hil_server; print('OK')"
+```
+
+Inside a Claude Code session, ask Claude to call `hil_status`. It should return:
+
+```json
+{
+  "pi_reachable": true,
+  "board_connected": true,
+  "error": null
+}
+```
+
+### Running tests through Claude
+
+Once the MCP server is active, Claude can drive the full HIL cycle autonomously:
+
+```
+"Run HIL tests on the current code"
+  → Claude calls hil_run_tests()
+  → rsync, build, flash, serial capture, parse
+  → returns {passed, summary, tests, regressions}
+  → Claude reads results and iterates on the code
+```
+
+For faster iteration when firmware is already flashed:
+
+```
+"Re-run the tests without reflashing"
+  → Claude calls hil_run_tests(skip_build=true, skip_flash=true)
+```
+
+### Tool return format
+
+`hil_run_tests` returns:
+
+```json
+{
+  "passed": true,
+  "summary": { "total": 60, "passed": 60, "failed": 0 },
+  "tests": [
+    { "name": "spi1_dma_psc2_256B", "status": "PASS", "cycles": 4811,
+      "metrics": { "throughput_kbps": 5333 } }
+  ],
+  "regressions": [],
+  "error": null
+}
+```
+
+On infrastructure failure (build error, serial timeout, board not connected):
+
+```json
+{
+  "passed": false,
+  "error": "HIL infrastructure error (exit 2). stdout: ..."
+}
+```
+
+### Rsync excludes
+
+The rsync step skips `build/`, `.git/`, `__pycache__/`, and `*.pyc` to keep transfers fast. Everything else (source files, scripts, baselines, Makefiles) is synced.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `HIL_PI_SSH not set` | `export HIL_PI_SSH=<user>@<pi-hostname>` in `~/.zshrc` |
+| SSH asks for password | Run `ssh-copy-id` to install your key on the Pi |
+| `board_connected: false` | Check USB cable; run `lsusb` on Pi to confirm board is enumerated |
+| rsync slow | Normal on first sync; subsequent runs only transfer diffs |
+| Build fails on Pi | SSH in and run `make EXAMPLE=cli_simple HIL_TEST=1` manually to see error |
+| `pip install mcp` fails | Try `pip3 install mcp` or `python3 -m pip install mcp` |

--- a/docs/wiki/hil-remote-access.md
+++ b/docs/wiki/hil-remote-access.md
@@ -1,62 +1,68 @@
 # HIL Remote Access and MCP Tools
 
-This page covers two related setups that together let you (and Claude) run real hardware tests from anywhere:
+This page covers how to reach the Pi over SSH and expose HIL tests as Claude Code tools.
 
-1. **Tailscale** — reach the Pi over SSH from any network
-2. **MCP HIL server** — expose `hil_run_tests` and `hil_status` as Claude Code tools
+**Current setup: local network only.** The Pi (`pi-hil`) is reachable via mDNS on the local
+network. The SSH config uses `BindAddress` to bypass corporate VPN routing (see below).
 
 ---
 
-## Part 1 — Tailscale Remote SSH
+## Part 1 — SSH Setup (local network)
 
-### Why Tailscale
+### Pi details
 
-The Pi is normally only reachable on the local network. Tailscale creates a mesh VPN: both machines join the same Tailscale network and each gets a stable MagicDNS hostname. No router port-forwarding needed, works from any network in the world.
+- Hostname: `pi-hil.local` (mDNS), IP: `10.0.0.245`
+- Username: `pi`
+- Board: `/dev/ttyACM0`
 
-### Install on the Pi
+### SSH key
 
-```sh
-curl -fsSL https://tailscale.com/install.sh | sh
-sudo tailscale up
-```
-
-Follow the auth URL printed to the terminal. Once authenticated, the Pi will appear in your Tailscale admin panel.
-
-### Install on macOS (dev machine)
-
-```sh
-brew install tailscale
-sudo tailscale up
-```
-
-Or download the macOS app from tailscale.com. Sign in to the **same Tailscale account**.
-
-### Find the Pi's hostname
-
-```sh
-tailscale status
-```
-
-The Pi will have a MagicDNS name like `raspberrypi.tail-abc123.ts.net` or just `raspberrypi` if MagicDNS is enabled. Either form works with SSH.
-
-### Set up SSH key auth (required)
-
-Automation tools (rsync, the MCP server) need passwordless SSH. Set up a dedicated key:
+Generate a dedicated key and install it on the Pi:
 
 ```sh
 ssh-keygen -t ed25519 -f ~/.ssh/hil_pi -N ""
-ssh-copy-id -i ~/.ssh/hil_pi.pub <user>@<pi-tailscale-hostname>
+ssh-copy-id -i ~/.ssh/hil_pi.pub pi@pi-hil.local
 ```
 
-Optional: add to `~/.ssh/config` to avoid specifying the key each time:
+### SSH config entry
+
+Add to `~/.ssh/config`. The `BindAddress` is required on this machine because the corporate
+VPN routes `10.0.0.x` traffic through `utun4` instead of `en0` — binding the source IP forces
+the connection through the local network interface.
 
 ```
 Host hil-pi
-    HostName <pi-tailscale-hostname>
-    User <user>
+    HostName 10.0.0.245
+    User pi
     IdentityFile ~/.ssh/hil_pi
+    BindAddress 10.0.0.218
     BatchMode yes
+    ConnectTimeout 10
 ```
+
+> **Note:** `BindAddress 10.0.0.218` is the dev machine's local IP. If it changes (DHCP),
+> update this line. To make it stable, reserve the MAC address in your router's DHCP config.
+
+### Verify
+
+```sh
+ssh hil-pi "uname -a && ls /dev/ttyACM*"
+```
+
+Should print the Pi's kernel string and `/dev/ttyACM0`.
+
+### Set the env var
+
+```sh
+echo 'export HIL_PI_SSH=hil-pi' >> ~/.zshrc
+export HIL_PI_SSH=hil-pi
+```
+
+### Future: remote access
+
+If remote access is ever needed from the work laptop, the recommended option for
+corporate environments is **Cloudflare Tunnel** (`cloudflared`) — outbound HTTPS from the Pi,
+no VPN or port-forwarding required. See Cloudflare Zero Trust docs for setup.
 
 ### Set the env var
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -11,6 +11,7 @@ Claude reads this file at session start via `CLAUDE.md`. Update it whenever a pa
 | [roadmap.md](roadmap.md) | Open issues by priority, future directions |
 | [testing.md](testing.md) | Host unit tests, driver fake-stub testing, HIL on-target testing, coverage |
 | [ci.md](ci.md) | CI pipeline, jobs, required checks, how to extend |
+| [hil-remote-access.md](hil-remote-access.md) | Tailscale remote SSH setup, SSH key auth, MCP HIL server for Claude Code |
 
 ## Drivers
 

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -6,6 +6,17 @@ Types: `merge`, `decision`, `milestone`, `infra`
 
 ---
 
+## [2026-04-13] infra | Add Tailscale remote access and MCP HIL server (#109)
+
+Added `scripts/mcp_hil_server.py` — a Python stdio MCP server that exposes `hil_status` and
+`hil_run_tests` tools to Claude Code. Claude can now autonomously build, flash, and run HIL
+tests on the real NUCLEO board during development: it rsyncs the working tree to the Pi (so
+uncommitted changes are included), runs `run_hil_tests.py` remotely, and receives structured
+JSON results (pass/fail, metrics, regressions). Reuses `parse_test_output` and `load_baselines`
+from the existing script without duplication. Registered via `.mcp.json` at project root.
+Remote access enabled by Tailscale mesh VPN; configuration via `HIL_PI_SSH` env var.
+See `docs/wiki/hil-remote-access.md`.
+
 ## [2026-04-13] infra | Add hil-tests CI job on self-hosted Pi runner (#86, #105)
 
 Added `hil-tests` job to `.github/workflows/ci.yml` running on `[self-hosted, pi-hil]`

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -240,6 +240,17 @@ Options: `--skip-build`, `--skip-flash`, `--timeout <seconds>`.
 
 The HIL runner validates measured values against baselines. Regressions outside tolerance cause exit code 1. See `tests/baselines/README.md` for the update process.
 
-### Future: CI integration (Issue #86)
+### Remote HIL via MCP tools (Claude Code)
 
-When a Raspberry Pi self-hosted runner is set up, `scripts/run_hil_tests.py` will be called from a `hil-tests` CI job. All infrastructure is in place; only the runner registration and CI workflow addition remain.
+`scripts/mcp_hil_server.py` exposes HIL tests as Claude Code tools via `.mcp.json`. Claude can build, flash, and run tests on the real board autonomously during development.
+
+**Tools available:**
+
+| Tool | Description |
+|---|---|
+| `hil_status()` | Check Pi reachability and board presence |
+| `hil_run_tests(skip_build, skip_flash)` | rsync → build → flash → run → return structured results |
+
+Before each build the server rsyncs the local working tree to the Pi, so uncommitted changes are tested immediately. Requires Tailscale for remote access and `HIL_PI_SSH` env var set to the Pi's Tailscale hostname.
+
+See [hil-remote-access.md](hil-remote-access.md) for full setup instructions.

--- a/scripts/mcp_hil_server.py
+++ b/scripts/mcp_hil_server.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""
+MCP HIL server for STM32 bare-metal project.
+
+Exposes two tools to Claude Code:
+  - hil_status()                          check Pi reachability + board presence
+  - hil_run_tests(skip_build, skip_flash) sync code, build, flash, run, return results
+
+Runs on the dev machine (macOS). SSH's to the Pi to execute build/flash/test.
+Rsyncs the working tree to the Pi before building so uncommitted changes are tested.
+
+Requirements:
+  pip install mcp
+
+Configuration:
+  export HIL_PI_SSH=<user>@<pi-tailscale-hostname>   # e.g. pi@raspberrypi.tail-abc123.ts.net
+
+Usage (invoked automatically by Claude Code via .mcp.json):
+  python3 scripts/mcp_hil_server.py
+"""
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import mcp.server.stdio
+import mcp.types as types
+from mcp.server import Server
+
+# Import shared helpers from existing test runner — no duplication
+sys.path.insert(0, str(Path(__file__).parent))
+from run_hil_tests import load_baselines, parse_test_output
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+REMOTE_DIR = "~/stm32-bare-metal"
+BASELINE_REL = "tests/baselines/performance.json"
+RSYNC_TIMEOUT = 60   # seconds
+SSH_TIMEOUT = 15     # seconds for simple connectivity checks
+TEST_TIMEOUT = 180   # seconds for full build + flash + test cycle
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def get_pi_ssh() -> str:
+    val = os.environ.get("HIL_PI_SSH", "").strip()
+    if not val:
+        raise RuntimeError(
+            "HIL_PI_SSH environment variable not set.\n"
+            "Example: export HIL_PI_SSH=pi@raspberrypi.tail-abc123.ts.net\n"
+            "See docs/wiki/hil-remote-access.md for setup instructions."
+        )
+    return val
+
+
+def get_project_root() -> Path:
+    return Path(__file__).parent.parent.resolve()
+
+
+def ssh_run(pi_ssh: str, cmd: str, timeout: int = SSH_TIMEOUT) -> subprocess.CompletedProcess:
+    """Run a single command on the Pi over SSH. Returns CompletedProcess."""
+    return subprocess.run(
+        ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", pi_ssh, cmd],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def rsync_to_pi(pi_ssh: str, local_root: Path) -> tuple[bool, str]:
+    """
+    Rsync local project tree to Pi:~/stm32-bare-metal/.
+    Excludes build artifacts and .git to keep the transfer fast.
+    Returns (success, error_message).
+    """
+    remote_target = f"{pi_ssh}:{REMOTE_DIR}/"
+    result = subprocess.run(
+        [
+            "rsync", "-az", "--delete",
+            "--exclude=build/",
+            "--exclude=.git/",
+            "--exclude=__pycache__/",
+            "--exclude=*.pyc",
+            f"{local_root}/",
+            remote_target,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=RSYNC_TIMEOUT,
+    )
+    if result.returncode != 0:
+        return False, f"rsync failed (exit {result.returncode}): {result.stderr.strip()}"
+    return True, ""
+
+
+def build_regressions(results: dict, baselines: dict) -> list[dict]:
+    """
+    Compare parsed test results against baselines.
+    Returns a list of regression dicts instead of printing to stdout.
+    """
+    regressions = []
+    for test in results.get("tests", []):
+        name = test["name"]
+        if name not in baselines:
+            continue
+        baseline = baselines[name]
+        if baseline.get("cycles") is None:
+            continue
+        tolerance_pct = baseline.get("tolerance_percent", 10)
+
+        # Check cycle count
+        if "cycles" in test:
+            expected = baseline["cycles"]
+            actual = test["cycles"]
+            lo = expected * (100 - tolerance_pct) / 100
+            hi = expected * (100 + tolerance_pct) / 100
+            if not (lo <= actual <= hi):
+                regressions.append({
+                    "test_name": name,
+                    "metric": "cycles",
+                    "expected": expected,
+                    "actual": actual,
+                    "tolerance_pct": tolerance_pct,
+                })
+
+        # Check additional metrics (e.g. throughput_kbps)
+        for metric_name, metric_value in test.get("metrics", {}).items():
+            if metric_name not in baseline or baseline[metric_name] is None:
+                continue
+            expected = baseline[metric_name]
+            lo = expected * (100 - tolerance_pct) / 100
+            hi = expected * (100 + tolerance_pct) / 100
+            if not (lo <= metric_value <= hi):
+                regressions.append({
+                    "test_name": name,
+                    "metric": metric_name,
+                    "expected": expected,
+                    "actual": metric_value,
+                    "tolerance_pct": tolerance_pct,
+                })
+    return regressions
+
+
+# ── MCP Server ────────────────────────────────────────────────────────────────
+
+app = Server("hil-server")
+
+
+@app.list_tools()
+async def list_tools() -> list[types.Tool]:
+    return [
+        types.Tool(
+            name="hil_status",
+            description=(
+                "Check whether the Raspberry Pi HIL runner is reachable over SSH "
+                "and the STM32 NUCLEO board is connected (looks for /dev/ttyACM* on Pi). "
+                "Returns JSON: {pi_reachable: bool, board_connected: bool, error: str|null}. "
+                "Call this first to verify the setup before running tests."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
+        types.Tool(
+            name="hil_run_tests",
+            description=(
+                "Sync the current working tree to the Pi, then build + flash + run HIL tests "
+                "on the connected STM32 NUCLEO-F411RE board. Uncommitted local changes are "
+                "included via rsync. Returns structured JSON results with pass/fail, metrics, "
+                "and any performance regressions. "
+                "Use skip_build=true when only re-running tests without firmware changes. "
+                "Use skip_flash=true when firmware is already loaded from a previous run."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "skip_build": {
+                        "type": "boolean",
+                        "description": "Skip make clean + make. Reuse existing binary on Pi.",
+                        "default": False,
+                    },
+                    "skip_flash": {
+                        "type": "boolean",
+                        "description": "Skip OpenOCD flash step. Assumes firmware is already loaded.",
+                        "default": False,
+                    },
+                },
+                "required": [],
+            },
+        ),
+    ]
+
+
+@app.call_tool()
+async def call_tool(name: str, arguments: dict[str, Any]) -> list[types.TextContent]:
+    try:
+        if name == "hil_status":
+            result = await _hil_status()
+        elif name == "hil_run_tests":
+            result = await _hil_run_tests(
+                skip_build=arguments.get("skip_build", False),
+                skip_flash=arguments.get("skip_flash", False),
+            )
+        else:
+            result = {"error": f"Unknown tool: {name}"}
+    except Exception as exc:
+        result = {"error": str(exc)}
+
+    return [types.TextContent(type="text", text=json.dumps(result, indent=2))]
+
+
+async def _hil_status() -> dict:
+    try:
+        pi_ssh = get_pi_ssh()
+    except RuntimeError as exc:
+        return {"pi_reachable": False, "board_connected": False, "error": str(exc)}
+
+    # Check SSH reachability
+    try:
+        proc = ssh_run(pi_ssh, "true", timeout=15)
+        pi_reachable = proc.returncode == 0
+    except subprocess.TimeoutExpired:
+        return {"pi_reachable": False, "board_connected": False, "error": "SSH timed out"}
+    except Exception as exc:
+        return {"pi_reachable": False, "board_connected": False, "error": str(exc)}
+
+    if not pi_reachable:
+        return {
+            "pi_reachable": False,
+            "board_connected": False,
+            "error": f"SSH failed: {proc.stderr.strip()}",
+        }
+
+    # Check for connected NUCLEO board
+    try:
+        proc = ssh_run(
+            pi_ssh,
+            "ls /dev/ttyACM* 2>/dev/null && echo BOARD_OK || echo BOARD_NONE",
+            timeout=10,
+        )
+        board_connected = "BOARD_OK" in proc.stdout
+    except Exception:
+        board_connected = False
+
+    return {"pi_reachable": True, "board_connected": board_connected, "error": None}
+
+
+async def _hil_run_tests(skip_build: bool = False, skip_flash: bool = False) -> dict:
+    _empty = {"passed": False, "summary": {}, "tests": [], "regressions": []}
+
+    try:
+        pi_ssh = get_pi_ssh()
+    except RuntimeError as exc:
+        return {**_empty, "error": str(exc)}
+
+    local_root = get_project_root()
+
+    # 1. Rsync working tree to Pi (includes uncommitted changes)
+    ok, err = rsync_to_pi(pi_ssh, local_root)
+    if not ok:
+        return {**_empty, "error": err}
+
+    # 2. Build remote command
+    flags = []
+    if skip_build:
+        flags.append("--skip-build")
+    if skip_flash:
+        flags.append("--skip-flash")
+    flags_str = " ".join(flags)
+
+    remote_cmd = (
+        f"cd {REMOTE_DIR} && "
+        f"python3 scripts/run_hil_tests.py --timeout 120 {flags_str}"
+    )
+
+    # 3. Run on Pi — capture stdout for parsing
+    try:
+        proc = ssh_run(pi_ssh, remote_cmd, timeout=TEST_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        return {**_empty, "error": f"Remote command timed out after {TEST_TIMEOUT}s"}
+
+    # Exit code 2 = infrastructure failure (build error, no serial port, etc.)
+    if proc.returncode == 2:
+        return {
+            **_empty,
+            "error": (
+                f"HIL infrastructure error (exit 2).\n"
+                f"stdout: {proc.stdout.strip()}\n"
+                f"stderr: {proc.stderr.strip()}"
+            ),
+        }
+
+    # Exit codes 0 (all pass) and 1 (test failures) both produce parseable output.
+
+    # 4. Parse results from captured stdout
+    output_lines = proc.stdout.splitlines()
+    results = parse_test_output(output_lines)
+
+    if results["summary"]["total"] == 0:
+        return {
+            **_empty,
+            "error": (
+                "No test results found in output — board may not have responded.\n"
+                f"stdout: {proc.stdout.strip()}"
+            ),
+        }
+
+    # 5. Load baselines and check regressions
+    baselines = load_baselines(local_root / BASELINE_REL)
+    regressions = build_regressions(results, baselines)
+
+    passed = (
+        proc.returncode == 0
+        and results["summary"]["failed"] == 0
+        and len(regressions) == 0
+    )
+
+    return {
+        "passed": passed,
+        "summary": results["summary"],
+        "tests": results["tests"],
+        "regressions": regressions,
+        "error": None,
+    }
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+async def main():
+    async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
+        await app.run(read_stream, write_stream, app.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- **`scripts/mcp_hil_server.py`** — Python stdio MCP server registered via `.mcp.json`. Exposes two tools to Claude Code: `hil_status` (checks Pi + board reachability) and `hil_run_tests` (rsync → build → flash → run → return structured JSON). Rsyncs the working tree before every build so uncommitted changes are included. Reuses `parse_test_output` and `load_baselines` from the existing `run_hil_tests.py` without duplication.
- **`.mcp.json`** — project-level MCP registration. Configuration via `HIL_PI_SSH` env var (no hard-coded hostname).
- **`docs/wiki/hil-remote-access.md`** — new wiki page covering Tailscale setup, SSH key auth, and MCP tool usage.
- Wiki updates: `index.md`, `testing.md` (new MCP subsection), `log.md`.

## Developer setup (one-time)

```sh
# 1. Install Tailscale on Pi and macOS, join same account
# 2. Set up SSH key auth
ssh-keygen -t ed25519 -f ~/.ssh/hil_pi -N ""
ssh-copy-id -i ~/.ssh/hil_pi.pub <user>@<pi-tailscale-hostname>
# 3. Set env var in ~/.zshrc
export HIL_PI_SSH=<user>@<pi-tailscale-hostname>
# 4. Install MCP dependency
pip install mcp
```

## Test plan

- [x] `make test` — 108 host tests, all pass
- [x] `make all` — all firmware examples build
- [x] MCP server syntax and shared imports verified (`ast.parse` + `from run_hil_tests import ...`)
- [ ] End-to-end: in a Claude Code session with Tailscale active, call `hil_status` and verify it returns `pi_reachable: true, board_connected: true`
- [ ] Call `hil_run_tests()` and verify structured results returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)