### PR TITLE
Add parallel agent worktree workflow and helper scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,55 @@ Every feature or fix follows this exact sequence:
 7. **Verify CI passes** — check both `host-tests` and `firmware-build` GitHub Actions jobs
 8. **Do NOT merge** — the user reviews and merges all PRs manually
 
+## Parallel Agent Workflow (Worktrees)
+
+When multiple agents work in parallel, each gets an isolated git worktree with its own
+branch. The main working tree is never modified during parallel work.
+
+### When to use
+- You are dispatched alongside other agents on independent issues
+- The `Agent` tool was invoked with `isolation: "worktree"` (harness handles setup automatically)
+- Any time you need a clean branch without affecting the main working tree
+
+### Step-by-step
+
+1. **Confirm or create the GitHub Issue** — every branch needs an issue number.
+
+2. **Create the worktree and branch:**
+   ```sh
+   bash scripts/worktree_new.sh <issue-number> <short-description>
+   # Prints the worktree path, e.g.:
+   # Worktree ready: /path/to/stm32-bare-metal-worktrees/115-add-i2c-driver
+   ```
+
+3. **Enter the worktree** using the `EnterWorktree` tool with the printed path.
+   All work (reads, writes, git commits, make commands) happens inside this directory.
+
+4. **Implement and commit** — commit often with meaningful messages.
+
+5. **Validate locally** — both must pass before pushing:
+   ```sh
+   make test   # host unit tests
+   make all    # all firmware examples
+   ```
+   Do **not** run HIL tests locally — the physical board is a shared resource. CI handles it.
+
+6. **Push and open the PR:**
+   ```sh
+   git push -u origin <branch-name>
+   gh pr create --title "..." --body "..."
+   ```
+
+7. **Report the PR URL to the user and stop.** Do not merge. Do not modify the worktree
+   after the PR is open unless asked to address review feedback or CI failures.
+
+8. **Cleanup after merge** (when the user confirms the PR is merged):
+   ```sh
+   bash scripts/worktree_clean.sh <branch-name>
+   ```
+
+See `docs/wiki/agents.md` for parallelism rules, HIL constraints, and troubleshooting.
+
 ## Build & Test Commands
 
 ```sh

--- a/docs/wiki/agents.md
+++ b/docs/wiki/agents.md
@@ -1,0 +1,112 @@
+# Parallel Agent Workflow
+
+This page describes how Claude Code agents use git worktrees to work in parallel
+on the same codebase without interfering with each other.
+
+## Overview
+
+Each agent task creates an isolated git worktree — a separate directory on disk with its
+own branch, its own build artifacts, and its own working state. The main working tree at
+`stm32-bare-metal/` is never modified by agents during parallel work.
+
+All Make targets (`make test`, `make all`, `make clean`) use relative paths, so they work
+correctly from any worktree directory without modification.
+
+## Worktree Location
+
+Worktrees live in a dedicated sibling directory alongside the repo:
+
+```
+<parent>/
+  stm32-bare-metal/                   ← main working tree (user + manual work)
+  stm32-bare-metal-worktrees/
+    115-add-i2c-driver/               ← agent 1
+    116-add-adc-driver/               ← agent 2
+    117-fix-uart-baud/                ← agent 3
+```
+
+Git does not allow worktrees inside the main working tree, so the sibling directory
+approach keeps them grouped and unambiguous.
+
+## Creating a Worktree
+
+```sh
+bash scripts/worktree_new.sh <issue-number> <short-description>
+```
+
+This script:
+1. Fetches the latest `origin/main`
+2. Creates a new local branch `<issue-number>-<short-description>` based on it
+3. Creates the worktree at `../stm32-bare-metal-worktrees/<branch-name>/`
+4. Prints the worktree path and next steps
+
+After running, use `EnterWorktree <path>` in Claude Code to switch into the worktree.
+
+## Agent Workflow
+
+| Step | Action |
+|---|---|
+| 1 | Confirm or create GitHub Issue — every branch needs an issue number |
+| 2 | `bash scripts/worktree_new.sh <N> <desc>` |
+| 3 | `EnterWorktree <worktree-path>` |
+| 4 | Implement and commit inside the worktree |
+| 5 | `make test && make all` — both must pass |
+| 6 | `git push -u origin <branch>` |
+| 7 | `gh pr create ...` |
+| 8 | Report PR URL to the user; stop — do not merge |
+| 9 | After user confirms merge: `bash scripts/worktree_clean.sh <branch>` |
+
+**Never modify the main working tree during parallel work.** All reads, writes, git
+commits, and make commands happen inside the worktree.
+
+## Parallelism Rules
+
+### Safe to parallelise (no shared resource)
+- `make test` — host unit tests, native gcc, fully isolated per worktree
+- `make all` — firmware build, arm-none-eabi-gcc, fully isolated per worktree
+- All source file editing and git commits
+
+### Must serialise (shared physical device)
+- `python3 scripts/run_hil_tests.py` — requires exclusive access to the STM32 board
+- `make flash` — flashes the board; incompatible with concurrent HIL test runs
+
+In normal agent workflow, HIL tests are handled exclusively by CI. The `hil-tests` CI
+job runs on the `[self-hosted, pi-hil]` runner; GitHub Actions queues jobs when the
+runner is busy, so concurrent PRs from multiple agents are automatically serialised.
+
+Do not run `run_hil_tests.py` locally from a worktree unless no other HIL work is
+running and you have confirmed with the user that the board is free.
+
+## Cleanup After Merge
+
+```sh
+bash scripts/worktree_clean.sh <branch-name>
+```
+
+Removes the worktree directory, prunes the dangling reference, and deletes the local
+branch. Only run after the PR has been merged into `main`.
+
+To inspect all active worktrees at any time:
+```sh
+git -C /path/to/stm32-bare-metal worktree list
+```
+
+## Teams Feature
+
+With `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` enabled, the `Agent` tool accepts
+`isolation: "worktree"`. When used this way, the harness creates and enters an isolated
+worktree automatically — `worktree_new.sh` is not needed.
+
+The manual script is provided for cases where the agent is invoked without team isolation,
+or when the user wants to create a worktree from the command line.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `branch already exists` | Script prints the resume command; run it manually |
+| `path already exists` | Check `git worktree list`; prune stale entry with `git worktree prune` |
+| `make test` fails in worktree | Confirm you are inside the worktree: run `pwd` |
+| Worktree diverged from main | `git -C <worktree> rebase origin/main` — coordinate with user first |
+| Stale worktrees after crash | `git worktree prune` removes references to deleted directories |
+| HIL tests hang | Do not run HIL from a worktree if CI or another session is also running them |

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -12,6 +12,7 @@ Claude reads this file at session start via `CLAUDE.md`. Update it whenever a pa
 | [testing.md](testing.md) | Host unit tests, driver fake-stub testing, HIL on-target testing, coverage |
 | [ci.md](ci.md) | CI pipeline, jobs, required checks, how to extend |
 | [hil-remote-access.md](hil-remote-access.md) | Tailscale remote SSH setup, SSH key auth, MCP HIL server for Claude Code |
+| [agents.md](agents.md) | Parallel agent worktree workflow — creating, using, and cleaning up isolated worktrees |
 
 ## Drivers
 

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -6,6 +6,19 @@ Types: `merge`, `decision`, `milestone`, `infra`
 
 ---
 
+## [2026-04-17] infra | Add parallel agent worktree workflow (#114)
+
+Added `scripts/worktree_new.sh` and `scripts/worktree_clean.sh` for creating and cleaning
+isolated git worktrees for parallel agent work. Each worktree gets its own branch based on
+`origin/main` and lives at `../stm32-bare-metal-worktrees/<branch>/`. Updated `CLAUDE.md`
+with a `## Parallel Agent Workflow (Worktrees)` section covering the full 8-step workflow,
+HIL serialisation constraint, and cleanup procedure. Added `docs/wiki/agents.md` with
+detailed parallelism rules and troubleshooting.
+Compatible with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` and the `Agent` tool's
+`isolation: "worktree"` parameter (harness auto-creates worktrees in that case).
+
+---
+
 ## [2026-04-13] infra | Add Tailscale remote access and MCP HIL server (#109)
 
 Added `scripts/mcp_hil_server.py` — a Python stdio MCP server that exposes `hil_status` and

--- a/scripts/worktree_clean.sh
+++ b/scripts/worktree_clean.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# worktree_clean.sh — Remove a worktree and its branch after the PR is merged.
+#
+# Usage:
+#   bash scripts/worktree_clean.sh <branch-name>
+#
+# Example:
+#   bash scripts/worktree_clean.sh 115-add-i2c-driver
+#
+# ONLY run this after the PR has been merged into main.
+# The local branch is deleted — this cannot be undone.
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <branch-name>" >&2
+    exit 1
+fi
+
+BRANCH="$1"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WORKTREES_BASE="$(dirname "${REPO_ROOT}")/stm32-bare-metal-worktrees"
+WORKTREE_PATH="${WORKTREES_BASE}/${BRANCH}"
+
+# Warn if branch isn't merged into origin/main
+if git -C "${REPO_ROOT}" fetch origin main --quiet 2>/dev/null; then
+    if ! git -C "${REPO_ROOT}" branch --merged origin/main | grep -qE "^[[:space:]]*${BRANCH}$"; then
+        echo "Warning: branch '${BRANCH}' does not appear merged into origin/main." >&2
+        read -r -p "  Proceed anyway? [y/N] " confirm
+        if [[ "${confirm}" != "y" && "${confirm}" != "Y" ]]; then
+            echo "Aborted." >&2
+            exit 1
+        fi
+    fi
+fi
+
+# Remove the worktree
+if [ -d "${WORKTREE_PATH}" ]; then
+    git -C "${REPO_ROOT}" worktree remove "${WORKTREE_PATH}"
+    echo "Removed worktree: ${WORKTREE_PATH}"
+else
+    echo "Worktree path not found (already removed?): ${WORKTREE_PATH}"
+fi
+
+# Prune stale worktree references
+git -C "${REPO_ROOT}" worktree prune
+
+# Delete the local branch
+if git -C "${REPO_ROOT}" show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+    git -C "${REPO_ROOT}" branch -d "${BRANCH}"
+    echo "Deleted local branch: ${BRANCH}"
+fi
+
+echo "Cleanup complete for: ${BRANCH}"

--- a/scripts/worktree_new.sh
+++ b/scripts/worktree_new.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# worktree_new.sh — Create a new git worktree + branch for parallel agent work.
+#
+# Usage:
+#   bash scripts/worktree_new.sh <issue-number> <short-description>
+#
+# Example:
+#   bash scripts/worktree_new.sh 115 add-i2c-driver
+#
+# The new worktree is created at:
+#   <repo-parent>/stm32-bare-metal-worktrees/<issue-number>-<short-description>/
+#
+# The last line of output is the worktree path (parseable by callers).
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <issue-number> <short-description>" >&2
+    exit 1
+fi
+
+ISSUE="$1"
+DESC="$2"
+BRANCH="${ISSUE}-${DESC}"
+
+# Resolve the repo root (safe to call from any directory)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Worktrees live alongside the repo, not inside it (git restriction)
+WORKTREES_BASE="$(dirname "${REPO_ROOT}")/stm32-bare-metal-worktrees"
+WORKTREE_PATH="${WORKTREES_BASE}/${BRANCH}"
+
+# Guard: branch must not already exist
+if git -C "${REPO_ROOT}" show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+    echo "Error: branch '${BRANCH}' already exists." >&2
+    echo "  To resume: git -C ${REPO_ROOT} worktree add ${WORKTREE_PATH} ${BRANCH}" >&2
+    exit 1
+fi
+
+# Guard: worktree path must not already exist
+if [ -e "${WORKTREE_PATH}" ]; then
+    echo "Error: path '${WORKTREE_PATH}' already exists." >&2
+    echo "  Check: git -C ${REPO_ROOT} worktree list" >&2
+    exit 1
+fi
+
+# Create base directory if needed
+mkdir -p "${WORKTREES_BASE}"
+
+# Fetch latest main so the new branch is not stale
+echo "Fetching origin/main..."
+git -C "${REPO_ROOT}" fetch origin main --quiet
+
+# Create the worktree with a new branch based on origin/main
+git -C "${REPO_ROOT}" worktree add -b "${BRANCH}" "${WORKTREE_PATH}" origin/main
+
+echo ""
+echo "Worktree ready: ${WORKTREE_PATH}"
+echo "Branch:         ${BRANCH}"
+echo "Base:           origin/main ($(git -C "${REPO_ROOT}" rev-parse --short origin/main))"
+echo ""
+echo "Next steps:"
+echo "  1. EnterWorktree ${WORKTREE_PATH}"
+echo "  2. Implement and commit"
+echo "  3. make test && make all"
+echo "  4. git push -u origin ${BRANCH}"
+echo "  5. gh pr create ..."


### PR DESCRIPTION
## Summary

- `scripts/worktree_new.sh` — create an isolated git worktree + feature branch from `origin/main` in one command
- `scripts/worktree_clean.sh` — remove worktree + branch after PR is merged
- `docs/wiki/agents.md` — full parallel workflow documentation: step-by-step, parallelism rules, HIL serialisation constraint, cleanup, troubleshooting
- `CLAUDE.md` — new `## Parallel Agent Workflow (Worktrees)` section with 8-step workflow
- `docs/wiki/index.md` / `log.md` — updated index and log

## How it works

Each agent runs `scripts/worktree_new.sh <issue> <desc>`, which fetches the latest `main`, creates a branch, and provisions a worktree at `../stm32-bare-metal-worktrees/<branch>/`. The agent works entirely inside that directory — no interference with the main working tree or other agents. After `make test && make all` pass, the agent pushes and opens a PR, then stops. `worktree_clean.sh` removes the worktree after the user merges.

Compatible with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` and the `Agent` tool's `isolation: "worktree"` parameter (which creates worktrees automatically without needing the script).

## Test plan

- [x] `make test` passes (108 tests, 0 failures)
- [x] `make all` passes (pre-existing `cli_simple` linker error on macOS is unrelated and present on `main`)
- [x] `bash scripts/worktree_new.sh 999 smoke-test` → creates worktree, prints path
- [x] `git worktree list` → shows new worktree alongside main
- [x] `bash scripts/worktree_clean.sh 999-smoke-test` → removes worktree and branch
- [x] `git worktree list` → back to single entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)