### PR TITLE
Update wiki and roadmap to reflect recently merged issues

### DIFF
--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -37,9 +37,18 @@ stm32-bare-metal/
 ├── tests/                 Host unit tests (compiled with native gcc, not ARM toolchain)
 │   ├── cli/               Tests for utils/src/cli.c
 │   ├── string_utils/      Tests for utils/src/string_utils.c
+│   ├── driver_stubs/      Fake peripheral headers shared by all driver test suites
+│   ├── gpio/              Tests for drivers/src/gpio_handler.c
+│   ├── exti/              Tests for drivers/src/exti_handler.c
+│   ├── uart/              Tests for drivers/src/uart.c
+│   ├── rcc/               Tests for drivers/src/rcc.c
+│   ├── timer/             Tests for drivers/src/timer.c
 │   └── baselines/         Performance baseline JSON for HIL regression detection
 ├── scripts/               Automation scripts
-│   └── run_hil_tests.py   HIL test runner (build → flash → serial → validate)
+│   ├── run_hil_tests.py   HIL test runner (build → flash → serial → validate)
+│   ├── mcp_hil_server.py  MCP server exposing HIL tools to Claude Code
+│   ├── worktree_new.sh    Create an isolated git worktree for parallel agent work
+│   └── worktree_clean.sh  Remove a merged worktree and its branch
 ├── docs/wiki/             Project knowledge base (this wiki)
 ├── .github/workflows/     CI pipeline
 ├── Makefile               Root build orchestrator
@@ -97,15 +106,15 @@ Application (examples/)
 
 ```
 ┌─────────────────────────────────────────────┐
-│  Layer 3: HIL tests (implemented)           │  Real board + serial capture
+│  Layer 3: HIL tests (77 tests)              │  Real board + serial capture
 │  Unity on target → assert via UART output   │  Catches hardware-specific bugs
-│  60 tests: SPI sweep (all 5 instances,      │  + performance regression detection
-│  prescaler/size matrix) + FPU               │
+│  SPI sweep, FPU, RCC/Timer accuracy,        │  + performance regression detection
+│  UART/GPIO/EXTI loopback                    │
 ├─────────────────────────────────────────────┤
-│  Layer 2: Driver logic tests (Issues #98–101)│  Host, native gcc
+│  Layer 2: Driver logic tests (298 tests)    │  Host, native gcc
 │  Fake peripheral stubs + pure fn extraction │  Catches register config bugs
 ├─────────────────────────────────────────────┤
-│  Layer 1: Pure unit tests (existing)        │  Host, native gcc, no mocking
+│  Layer 1: Pure unit tests (64 tests)        │  Host, native gcc, no mocking
 │  CLI engine, string utils                   │  Catches algorithmic bugs
 └─────────────────────────────────────────────┘
 ```
@@ -140,18 +149,18 @@ Examples:
 
 The shell functions (hardware init/control) call the pure functions and apply their results to registers. Tests call the pure functions directly.
 
-### Directory layout (with driver tests)
+### Directory layout (driver tests)
 
 ```
 tests/
-├── cli/               Existing — tests utils/src/cli.c
-├── string_utils/      Existing — tests utils/src/string_utils.c
-├── driver_stubs/      New — fake peripheral headers (shared by all driver test suites)
-├── gpio/              New — tests drivers/src/gpio_handler.c
-├── exti/              New — tests drivers/src/exti_handler.c
-├── uart/              New — tests drivers/src/uart.c
-├── rcc/               New — tests drivers/src/rcc.c
-└── timer/             New — tests drivers/src/timer.c
+├── cli/               Tests utils/src/cli.c (41 tests)
+├── string_utils/      Tests utils/src/string_utils.c (23 tests)
+├── driver_stubs/      Fake peripheral headers shared by all driver suites
+├── gpio/              Tests drivers/src/gpio_handler.c (44 tests)
+├── exti/              Tests drivers/src/exti_handler.c (56 tests)
+├── uart/              Tests drivers/src/uart.c (46 tests)
+├── rcc/               Tests drivers/src/rcc.c (36 tests)
+└── timer/             Tests drivers/src/timer.c (52 tests)
 ```
 
 ## RCC / Clock

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -6,6 +6,55 @@ Types: `merge`, `decision`, `milestone`, `infra`
 
 ---
 
+## [2026-04-20] milestone | HIL SPI throughput: warm-up run + 5-sample median (#112)
+
+Made HIL SPI performance tests robust against transient loopback corruption and measurement
+variance. Two changes: (1) each test now runs 5 back-to-back transfers and reports the
+median cycle count, with a majority-vote integrity check (≥4/5 byte-match passes required);
+(2) one untimed warm-up transfer runs before the 5 measured samples to pay the one-time
+`spi_dma_init_streams()` cost (DMA clock enable, stream CR/PAR config, NVIC setup) outside
+the measurement window — all 5 samples then reflect steady-state per-transfer cost, matching
+production usage where DMA is initialised once at startup. Extended `TEST:` output format
+adds `:samples=N:integrity_passes=M` fields. All 57 baselines recalibrated from warm hardware
+runs; small-buffer DMA entries (1B/4B) dropped ~2% vs prior median, confirming the cold first
+sample was inflating previous values. Total HIL tests: 73 (SPI/FPU/RCC/Timer/UART unchanged).
+
+## [2026-04-20] milestone | HIL Tier 5: GPIO and EXTI loopback tests (#99)
+
+Added GPIO output/input and EXTI interrupt tests to the HIL harness, reusing the UART
+loopback cables already wired on the board (PA9↔PB7 for UART1, PC6↔PC7 for UART6).
+GPIO tests: configure one pin as push-pull output and the other as floating input; assert
+HIGH, LOW, and toggle propagate through the cable. EXTI tests: arm EXTI line 7 (port B,
+PB7) with a minimal `EXTI9_5_IRQHandler` that increments a volatile counter; drive PA9 to
+trigger rising and falling edges; assert counter increments; also tests `exti_software_trigger`.
+Implemented as 4 consolidated test functions (2 GPIO + 2 EXTI) to minimise serial output and
+pin reconfiguration overhead — each function covers all conditions for one loopback pair in a
+single init/settle/deinit cycle. Total HIL tests: 77.
+
+## [2026-04-15] milestone | Driver host tests: UART (#100)
+
+Added `tests/uart/` with 46 tests covering the UART driver in `drivers/src/uart.c`.
+Tier 1 (register config): `uart_init` CR1/CR2/BRR setup, DMA TX/RX enable, NVIC configuration,
+GPIO alternate function pinout for USART2. Tier 2 (pure functions via `uart_calc.h`):
+`uart_compute_baud_divisor` rounding at multiple clock/baud combinations; `uart_circular_bytes_available`
+wrap-around arithmetic for all cases (no wrap, single wrap, full buffer, empty buffer).
+ISR path tests: RXNE callback dispatch, DMA-RX active suppression, error flag handling
+(ORE/FE/NF), `uart_clear_errors` reset. Total host tests: 298.
+
+## [2026-04-14] milestone | Driver host tests: RCC and Timer (#101)
+
+Added `tests/rcc/` (36 tests) and `tests/timer/` (52 tests).
+RCC Tier 1: `rcc_init` register sequence (HSI→PLL→SYSCLK, AHB/APB prescalers, Flash latency,
+PWR voltage scaling), clock getter functions (`rcc_get_sysclk`, `rcc_get_apb1_clk` etc.).
+RCC Tier 2 via `rcc_calc.h`: `rcc_compute_pll_config` PLL factor solver across multiple
+source/target combinations; `rcc_compute_apb_prescaler`; `rcc_compute_flash_latency` wait-state
+lookup. Timer Tier 1: TIM2–TIM5 clock enable, ARR/PSC/CCR register setup for basic, PWM, and
+one-pulse modes; NVIC enable/disable paths. Timer Tier 2 via `timer_calc.h`:
+`timer_compute_pwm_psc` across frequency/step combinations; `timer_compute_duty_ccr` boundary
+cases (0%, 50%, 100%). Total host tests: 252.
+
+---
+
 ## [2026-04-17] milestone | Add driver host tests for GPIO and EXTI (#99)
 
 Added `tests/gpio/` (44 tests) and `tests/exti/` (56 tests) using the fake peripheral stub
@@ -18,7 +67,7 @@ for all 6 GPIO ports across all 4 EXTICR registers, RTSR/FTSR trigger types, IMR
 NVIC enable via `NVIC_EnableIRQ`), `exti_enable_line`/`exti_disable_line` (NVIC ISER/ICER),
 `exti_set_interrupt_mask`/`exti_set_event_mask` (EXTI IMR/EMR), `exti_is_pending`/
 `exti_clear_pending` (EXTI PR), and `exti_software_trigger` (EXTI SWIER). Updated
-`tests/Makefile` to include the `exti` suite. Total host tests: 247.
+`tests/Makefile` to include the `exti` suite. Total host tests: 164 (CLI + string_utils + GPIO + EXTI).
 
 ---
 

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -2,14 +2,6 @@
 
 ## Open Issues by Priority
 
-### Testing & Quality (highest priority)
-
-| Issue | Title | Notes |
-|---|---|---|
-| ~~#99~~ | ~~Driver host tests: GPIO and EXTI~~ | ✅ Done — 44 GPIO tests + 56 EXTI tests. |
-| #100 | Driver host tests: UART | Tier 1 + Tier 2. Circular buffer wrap logic, baud divisor, init register setup. |
-| #101 | Driver host tests: RCC and Timer | Tier 1 + Tier 2. PLL solver — most complex logic in codebase. |
-
 ### Architecture / Quality
 
 | Issue | Title | Notes |
@@ -43,15 +35,12 @@
 
 ## Suggested Priority Order
 
-1. **#99** — GPIO/EXTI driver tests (simplest drivers; validate the fake stub infrastructure)
-2. **#100** — UART driver tests (circular buffer has non-obvious wrap edge cases)
-3. **#101** — RCC/Timer driver tests (PLL solver is the most complex logic in the codebase)
-4. **#62** — non-blocking SysTick tick counter
-5. **#26** — unified error codes
-6. **#69** — multi-instance UART
-7. **#73** — NVIC priority scheme
-8. Remaining drivers (#66, #67, #68, #70, #71, #72) after #26 and #73
-9. Examples (#14, #16, #22, #45) driven by driver availability
+1. **#62** — non-blocking SysTick tick counter
+2. **#26** — unified error codes
+3. **#69** — multi-instance UART
+4. **#73** — NVIC priority scheme
+5. Remaining drivers (#66, #67, #68, #70, #71, #72) after #26 and #73
+6. Examples (#14, #16, #22, #45) driven by driver availability
 
 ---
 
@@ -74,5 +63,9 @@ See [log.md](log.md) for the full history. Key milestones:
 - ✅ lcov code coverage report uploaded as CI artifact
 - ✅ Unity as direct root-level submodule (`3rd_party/unity/`)
 - ✅ All GitHub Actions upgraded to Node.js 24
-- ✅ HIL test infrastructure: Unity on target (60 tests), machine-parseable output, Python automation, performance baselines
+- ✅ HIL test infrastructure: Unity on target (77 tests), machine-parseable output, Python automation, performance baselines
 - ✅ Self-hosted Raspberry Pi HIL runner (`pi-hil` label), `hil-tests` CI job with `needs: host-tests`
+- ✅ HIL Tier 5: UART loopback (USART1 + USART6), GPIO output/input loopback, EXTI edge + software-trigger tests
+- ✅ HIL SPI throughput: 5-sample median with warm-up transfer, majority-vote integrity check, recalibrated baselines (#112)
+- ✅ Parallel agent worktree workflow: `worktree_new.sh` / `worktree_clean.sh`, CLAUDE.md instructions, agents wiki page (#114)
+- ✅ Tailscale remote access + MCP HIL server (`scripts/mcp_hil_server.py`) for Claude Code integration (#109)

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -31,7 +31,11 @@ make test        # Build and run all host test suites
 | `string_utils` | `tests/string_utils/` | 23 | Custom string functions in `utils/src/string_utils.c` |
 | `cli` | `tests/cli/` | 41 | CLI engine in `utils/src/cli.c` |
 | `gpio` | `tests/gpio/` | 44 | GPIO driver in `drivers/src/gpio_handler.c` |
-| **Total** | | **108** | |
+| `exti` | `tests/exti/` | 56 | EXTI driver in `drivers/src/exti_handler.c` |
+| `uart` | `tests/uart/` | 46 | UART driver in `drivers/src/uart.c` |
+| `rcc` | `tests/rcc/` | 36 | RCC driver in `drivers/src/rcc.c` |
+| `timer` | `tests/timer/` | 52 | Timer driver in `drivers/src/timer.c` |
+| **Total** | | **298** | |
 
 ### Architecture
 
@@ -125,7 +129,7 @@ Complex computation buried in register-writing functions is extracted into stand
 
 **Convention:** Pure functions live in the existing driver `.c` file but are declared in a companion `<driver>_calc.h` header (not the main public header) to signal they are implementation-level utilities exposed for testing.
 
-**High-value extractions planned:**
+**Implemented extractions:**
 
 | Driver | Pure function | What it tests |
 |---|---|---|
@@ -187,7 +191,7 @@ The Unity ARM library is built by `3rd_party/Makefile` and linked as `libunity_a
 
 `examples/cli/test_harness.c` contains all HIL test cases. It uses a parameterized macro `RUN_SPI_TEST(instance, prescaler, buffer_size, use_dma)` to run SPI tests across parameter combinations without code duplication.
 
-**Test tiers (60 tests total):**
+**Test tiers (77 tests total):**
 
 | Tier | Tests | What it covers |
 |---|---|---|
@@ -195,6 +199,10 @@ The Unity ARM library is built by `3rd_party/Makefile` and linked as `libunity_a
 | Tier 2a: SPI2 deep sweep | 24 | APB1 bus (50 MHz): all prescalers at 256B + buffer sizes 1/4/16/64B at psc=2 |
 | Tier 2b: SPI1 deep sweep | 24 | APB2 bus (100 MHz): same matrix as SPI2 |
 | Tier 3: FPU | 2 | Hardware FPU multiplication and division |
+| Tier 4: RCC + Timer | 5 | Clock frequencies via `rcc_get_*` API; `timer_delay_us` accuracy (±20 µs @ 100 MHz) |
+| Tier 5: UART loopback | 8 | USART1 (PA9/PB7) + USART6 (PC6/PC7) at 115200 baud, polled, multiple byte patterns |
+| Tier 5: GPIO loopback | 2 | Output HIGH/LOW/toggle driving input pin through loopback cable |
+| Tier 5: EXTI loopback | 2 | Rising+falling edge ISR via loopback; software trigger via EXTI SWIER |
 
 ### Machine-parseable output
 
@@ -202,9 +210,11 @@ The Unity ARM library is built by `3rd_party/Makefile` and linked as `libunity_a
 
 ```
 START_TESTS                                               ← sequence start marker
-TEST:spi1_dma_psc2_256B:PASS:cycles=4811:throughput_kbps=5333  ← per-test result
+TEST:spi1_dma_psc2_256B:PASS:cycles=4413:throughput_kbps=5801:samples=5:integrity_passes=5
 END_TESTS                                                 ← sequence end marker
 ```
+
+The extended `samples=N:integrity_passes=M` fields are emitted by `spi_perf.c` for multi-sample tests. `run_hil_tests.py` accepts both the legacy single-value format and the extended format.
 
 Test names follow the pattern `spi<N>_<mode>_psc<P>_<S>B` (e.g., `spi2_dma_psc4_256B`).
 


### PR DESCRIPTION
## Summary

- **roadmap.md**: removes the completed Testing & Quality section (#99/#100/#101 all closed); trims priority order; bumps HIL test count 60→77; adds completed milestones for #112, #114, #109
- **architecture.md**: expands `tests/` directory listing with all 7 driver suites and `driver_stubs/`; adds `scripts/` entries for MCP server and worktree helpers; updates three-layer pyramid counts (Layer 2: 298, Layer 3: 77); removes stale "New" labels from driver test layout
- **testing.md**: expands host test suite table 3→7 rows (total 108→298); relabels Tier 2 extractions as implemented; adds HIL Tier 4 + Tier 5 rows to test tier table; updates machine-parseable output example with `samples=`/`integrity_passes=` fields
- **log.md**: adds four missing entries (#101 RCC/Timer, #100 UART, HIL GPIO/EXTI loopback, #112 SPI robustness); fixes stale test count in #99 entry

## Test plan
- [x] Docs-only change — CI host-tests and firmware-build must pass
- [x] Verify no broken wiki links

🤖 Generated with [Claude Code](https://claude.com/claude-code)