### PR TITLE
Add unified error code scheme (err_t) across all drivers (#26)

### DIFF
--- a/drivers/inc/dma.h
+++ b/drivers/inc/dma.h
@@ -2,6 +2,7 @@
 #define DMA_H
 
 #include <stdint.h>
+#include "error.h"
 
 /**
  * @brief DMA stream identifiers
@@ -88,9 +89,10 @@ typedef struct {
  * priority, error interrupts, TC interrupt), and sets the peripheral address.
  *
  * @param cfg  Pointer to the stream configuration
- * @return 0 on success, -1 if the stream is invalid or already allocated
+ * @return ERR_OK on success, ERR_INVALID_ARG if the stream is invalid,
+ *         ERR_BUSY if the stream is already allocated
  */
-int dma_stream_init(const dma_stream_config_t *cfg);
+err_t dma_stream_init(const dma_stream_config_t *cfg);
 
 /**
  * @brief Start a DMA transfer on a previously initialized stream
@@ -101,9 +103,9 @@ int dma_stream_init(const dma_stream_config_t *cfg);
  * @param id        Stream identifier (must have been initialized)
  * @param mem_addr  Memory address (M0AR)
  * @param count     Number of data items to transfer (NDTR, 1-65535)
- * @return 0 on success, -1 if the stream is not allocated
+ * @return ERR_OK on success, ERR_INVALID_ARG if the stream is not allocated
  */
-int dma_stream_start(dma_stream_id_t id, uint32_t mem_addr, uint16_t count);
+err_t dma_stream_start(dma_stream_id_t id, uint32_t mem_addr, uint16_t count);
 
 /**
  * @brief Stop (disable) a DMA stream
@@ -149,10 +151,10 @@ void dma_stream_set_mem_inc(dma_stream_id_t id, uint8_t enable);
  * @param mem_addr  Memory address (M0AR)
  * @param count     Number of data items (NDTR, 1-65535)
  * @param mem_inc   1 = enable MINC, 0 = disable MINC
- * @return 0 on success, -1 if the stream is not allocated
+ * @return ERR_OK on success, ERR_INVALID_ARG if the stream is not allocated
  */
-int dma_stream_start_config(dma_stream_id_t id, uint32_t mem_addr,
-                            uint16_t count, uint8_t mem_inc);
+err_t dma_stream_start_config(dma_stream_id_t id, uint32_t mem_addr,
+                              uint16_t count, uint8_t mem_inc);
 
 /**
  * @brief Check whether a DMA stream is currently transferring

--- a/drivers/inc/error.h
+++ b/drivers/inc/error.h
@@ -1,0 +1,21 @@
+#ifndef ERROR_H
+#define ERROR_H
+
+/**
+ * @file error.h
+ * @brief Unified error codes for all drivers.
+ *
+ * All driver functions that return a status use err_t.
+ * Functions with non-error semantic returns (boolean state, field values)
+ * keep their original return type (int, uint8_t) but may use ERR_INVALID_ARG
+ * for their error path.
+ */
+
+typedef enum {
+    ERR_OK          =  0,   /**< Success */
+    ERR_INVALID_ARG = -1,   /**< Bad parameter (NULL, out of range, etc.) */
+    ERR_TIMEOUT     = -2,   /**< Hardware did not become ready in time */
+    ERR_BUSY        = -3,   /**< Resource already in use / already allocated */
+} err_t;
+
+#endif /* ERROR_H */

--- a/drivers/inc/exti_handler.h
+++ b/drivers/inc/exti_handler.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include "error.h"
 #include "gpio_handler.h"  // For gpio_port_t enum
 
 /**
@@ -32,67 +33,60 @@ typedef enum {
  * EXTI line is automatically selected (should match pin_num for GPIO)
  * @param trigger Trigger type (rising, falling, both)
  * @param mode EXTI mode (interrupt, event, both)
- * @return 0 on success, -1 on error
+ * @return ERR_OK on success, ERR_INVALID_ARG on error
  */
-int exti_configure_gpio_interrupt(gpio_port_t port, uint8_t pin_num, 
-                                  exti_trigger_t trigger, exti_mode_t mode);
+err_t exti_configure_gpio_interrupt(gpio_port_t port, uint8_t pin_num,
+                                    exti_trigger_t trigger, exti_mode_t mode);
 
 /**
  * @brief Enable EXTI line in NVIC
  * @param line EXTI line to enable
- * @return 0 on success, -1 on error
+ * @return ERR_OK on success, ERR_INVALID_ARG on error
  */
-int exti_enable_line(uint8_t line);
+err_t exti_enable_line(uint8_t line);
 
 /**
  * @brief Disable EXTI line in NVIC
  * @param line EXTI line to disable
- * @return 0 on success, -1 on error
+ * @return ERR_OK on success, ERR_INVALID_ARG on error
  */
-int exti_disable_line(uint8_t line);
+err_t exti_disable_line(uint8_t line);
 
 /**
  * @brief Enable/disable EXTI line interrupt mask
  * @param line EXTI line
  * @param enable true to enable, false to disable
- * @return 0 on success, -1 on error
+ * @return ERR_OK on success, ERR_INVALID_ARG on error
  */
-int exti_set_interrupt_mask(uint8_t line, uint8_t enable);
+err_t exti_set_interrupt_mask(uint8_t line, uint8_t enable);
 
 /**
  * @brief Enable/disable EXTI line event mask
  * @param line EXTI line
  * @param enable true to enable, false to disable
- * @return 0 on success, -1 on error
+ * @return ERR_OK on success, ERR_INVALID_ARG on error
  */
-int exti_set_event_mask(uint8_t line, uint8_t enable);
+err_t exti_set_event_mask(uint8_t line, uint8_t enable);
 
 /**
  * @brief Check if EXTI line interrupt is pending
  * @param line EXTI line to check
- * @return 1 if pending, 0 if not pending, -1 on error
+ * @return 1 if pending, 0 if not pending, ERR_INVALID_ARG (-1) on error
  */
 int exti_is_pending(uint8_t line);
 
 /**
  * @brief Clear EXTI line pending flag
  * @param line EXTI line to clear
- * @return 0 on success, -1 on error
+ * @return ERR_OK on success, ERR_INVALID_ARG on error
  */
-int exti_clear_pending(uint8_t line);
-
-/**
- * @brief Disable EXTI line completely
- * @param line EXTI line to disable
- * @return 0 on success, -1 on error
- */
-int exti_disable_line(uint8_t line);
+err_t exti_clear_pending(uint8_t line);
 
 /**
  * @brief Generate software interrupt on EXTI line
  * @param line EXTI line
- * @return 0 on success, -1 on error
+ * @return ERR_OK on success, ERR_INVALID_ARG on error
  */
-int exti_software_trigger(uint8_t line);
+err_t exti_software_trigger(uint8_t line);
 
 #endif /* EXTI_HANDLER_H_ */

--- a/drivers/inc/rcc.h
+++ b/drivers/inc/rcc.h
@@ -2,6 +2,7 @@
 #define RCC_H
 
 #include <stdint.h>
+#include "error.h"
 
 /**
  * @brief Clock source selection for rcc_init
@@ -28,9 +29,10 @@ typedef enum {
  *
  * @param source          Clock source (HSI or HSE bypass)
  * @param target_sysclk_hz  Desired SYSCLK frequency in Hz (e.g. 100000000)
- * @return 0 on success, -1 on invalid parameters or PLL lock timeout
+ * @return ERR_OK on success, ERR_INVALID_ARG on invalid parameters,
+ *         ERR_TIMEOUT on PLL/HSE lock timeout
  */
-int rcc_init(rcc_clk_src_t source, uint32_t target_sysclk_hz);
+err_t rcc_init(rcc_clk_src_t source, uint32_t target_sysclk_hz);
 
 /** @return Current SYSCLK frequency in Hz */
 uint32_t rcc_get_sysclk(void);

--- a/drivers/inc/rcc_calc.h
+++ b/drivers/inc/rcc_calc.h
@@ -11,6 +11,7 @@
 #define RCC_CALC_H
 
 #include <stdint.h>
+#include "error.h"
 
 /**
  * PLL factors computed by rcc_compute_pll_config().
@@ -38,10 +39,10 @@ typedef struct {
  * @param src_hz    Source oscillator frequency in Hz (e.g. 16 000 000 for HSI)
  * @param target_hz Desired SYSCLK frequency in Hz
  * @param out       Filled on success; undefined on failure
- * @return 0 on success, -1 if no valid configuration exists
+ * @return ERR_OK on success, ERR_INVALID_ARG if no valid configuration exists
  */
-int rcc_compute_pll_config(uint32_t src_hz, uint32_t target_hz,
-                           rcc_pll_factors_t *out);
+err_t rcc_compute_pll_config(uint32_t src_hz, uint32_t target_hz,
+                             rcc_pll_factors_t *out);
 
 /**
  * @brief Return the number of flash wait states needed for hclk_hz.

--- a/drivers/inc/spi.h
+++ b/drivers/inc/spi.h
@@ -2,6 +2,7 @@
 #define SPI_H
 
 #include <stdint.h>
+#include "error.h"
 #include "gpio_handler.h"
 
 /**
@@ -59,9 +60,9 @@ typedef struct {
  *
  * @param handle  Caller-allocated handle to populate
  * @param config  Configuration parameters
- * @return 0 on success, -1 on invalid parameters
+ * @return ERR_OK on success, ERR_INVALID_ARG on invalid parameters
  */
-int spi_init(spi_handle_t *handle, const spi_config_t *config);
+err_t spi_init(spi_handle_t *handle, const spi_config_t *config);
 
 /**
  * @brief Deinitialize an SPI peripheral
@@ -99,9 +100,9 @@ void spi_disable(spi_handle_t *handle);
  * @param tx      Transmit buffer (may be NULL)
  * @param rx      Receive buffer (may be NULL)
  * @param len     Number of bytes to transfer
- * @return 0 on success, -1 on error
+ * @return ERR_OK on success, ERR_INVALID_ARG on error
  */
-int spi_transfer(spi_handle_t *handle, const uint8_t *tx, uint8_t *rx, uint16_t len);
+err_t spi_transfer(spi_handle_t *handle, const uint8_t *tx, uint8_t *rx, uint16_t len);
 
 /**
  * @brief Start a full-duplex SPI transfer using DMA (non-blocking)
@@ -118,9 +119,9 @@ int spi_transfer(spi_handle_t *handle, const uint8_t *tx, uint8_t *rx, uint16_t 
  * @param tx      Transmit buffer (may be NULL)
  * @param rx      Receive buffer (may be NULL)
  * @param len     Number of bytes to transfer (1-65535)
- * @return 0 on success, -1 on error
+ * @return ERR_OK on success, ERR_INVALID_ARG on error
  */
-int spi_transfer_dma(spi_handle_t *handle, const uint8_t *tx, uint8_t *rx, uint16_t len);
+err_t spi_transfer_dma(spi_handle_t *handle, const uint8_t *tx, uint8_t *rx, uint16_t len);
 
 /**
  * @brief Perform a full-duplex SPI transfer using DMA (blocking)
@@ -131,15 +132,15 @@ int spi_transfer_dma(spi_handle_t *handle, const uint8_t *tx, uint8_t *rx, uint1
  * @param tx      Transmit buffer (may be NULL)
  * @param rx      Receive buffer (may be NULL)
  * @param len     Number of bytes to transfer (1-65535)
- * @return 0 on success, -1 on error
+ * @return ERR_OK on success, ERR_INVALID_ARG on error
  */
-int spi_transfer_dma_blocking(spi_handle_t *handle, const uint8_t *tx, uint8_t *rx, uint16_t len);
+err_t spi_transfer_dma_blocking(spi_handle_t *handle, const uint8_t *tx, uint8_t *rx, uint16_t len);
 
 /**
  * @brief Convert a human-readable prescaler value to the BR[2:0] bit field
  *
  * @param prescaler  Prescaler divider (must be power of 2: 2, 4, 8, ..., 256)
- * @return BR field value (0-7) on success, -1 if prescaler is invalid
+ * @return BR field value (0-7) on success, ERR_INVALID_ARG (-1) if prescaler is invalid
  */
 int spi_prescaler_to_br(uint16_t prescaler);
 

--- a/drivers/src/dma.c
+++ b/drivers/src/dma.c
@@ -1,4 +1,5 @@
 #include "dma.h"
+#include "error.h"
 #include "stm32f4xx.h"
 
 /*===========================================================================
@@ -175,16 +176,16 @@ static dma_stream_state_t stream_state[DMA_STREAM_COUNT];
  * Public API
  *===========================================================================*/
 
-int dma_stream_init(const dma_stream_config_t *cfg) {
+err_t dma_stream_init(const dma_stream_config_t *cfg) {
     if (!cfg || cfg->stream >= DMA_STREAM_COUNT || cfg->channel > 7) {
-        return -1;
+        return ERR_INVALID_ARG;
     }
 
     dma_stream_id_t id = cfg->stream;
 
     /* Conflict detection: reject if already allocated */
     if (stream_state[id].allocated) {
-        return -1;
+        return ERR_BUSY;
     }
 
     const dma_hw_info_t *hw = &hw_table[id];
@@ -229,12 +230,12 @@ int dma_stream_init(const dma_stream_config_t *cfg) {
     NVIC_SetPriority(hw->irqn, cfg->nvic_priority);
     NVIC_EnableIRQ(hw->irqn);
 
-    return 0;
+    return ERR_OK;
 }
 
-int dma_stream_start(dma_stream_id_t id, uint32_t mem_addr, uint16_t count) {
+err_t dma_stream_start(dma_stream_id_t id, uint32_t mem_addr, uint16_t count) {
     if (id >= DMA_STREAM_COUNT || !stream_state[id].allocated) {
-        return -1;
+        return ERR_INVALID_ARG;
     }
 
     const dma_hw_info_t *hw = &hw_table[id];
@@ -254,7 +255,7 @@ int dma_stream_start(dma_stream_id_t id, uint32_t mem_addr, uint16_t count) {
     /* Enable stream */
     s->CR |= DMA_SxCR_EN;
 
-    return 0;
+    return ERR_OK;
 }
 
 void dma_stream_stop(dma_stream_id_t id) {
@@ -301,10 +302,10 @@ void dma_stream_set_mem_inc(dma_stream_id_t id, uint8_t enable) {
     s->CR = stream_state[id].cr_base;
 }
 
-int dma_stream_start_config(dma_stream_id_t id, uint32_t mem_addr,
-                            uint16_t count, uint8_t mem_inc) {
+err_t dma_stream_start_config(dma_stream_id_t id, uint32_t mem_addr,
+                              uint16_t count, uint8_t mem_inc) {
     if (id >= DMA_STREAM_COUNT || !stream_state[id].allocated) {
-        return -1;
+        return ERR_INVALID_ARG;
     }
 
     const dma_hw_info_t *hw = &hw_table[id];
@@ -330,7 +331,7 @@ int dma_stream_start_config(dma_stream_id_t id, uint32_t mem_addr,
     /* Enable stream -- single write, no read-modify-write */
     s->CR = cr | DMA_SxCR_EN;
 
-    return 0;
+    return ERR_OK;
 }
 
 int dma_stream_busy(dma_stream_id_t id) {

--- a/drivers/src/exti_handler.c
+++ b/drivers/src/exti_handler.c
@@ -1,26 +1,27 @@
 #include <stdint.h>
 
+#include "error.h"
 #include "exti_handler.h"
 #include "gpio_handler.h" 
 #include "stm32f4xx.h"
 
 /* Private helper functions */
-static int is_valid_pin(uint8_t pin_num);
-static int is_valid_exti_line(uint8_t line);
-static int is_valid_gpio_port(gpio_port_t port);
+static int  is_valid_pin(uint8_t pin_num);
+static int  is_valid_exti_line(uint8_t line);
+static int  is_valid_gpio_port(gpio_port_t port);
 static uint8_t get_port_value(gpio_port_t port);
 static IRQn_Type get_exti_irq_number(uint8_t line);
 static void configure_syscfg_exti_port(uint8_t line, gpio_port_t port);
 
 /* Implementation of public functions */
 
-int exti_configure_gpio_interrupt(gpio_port_t port, uint8_t pin_num, 
-                                  exti_trigger_t trigger, exti_mode_t mode)
+err_t exti_configure_gpio_interrupt(gpio_port_t port, uint8_t pin_num,
+                                    exti_trigger_t trigger, exti_mode_t mode)
 {
     /* Parameter validation */
-    if (!is_valid_gpio_port(port) || !is_valid_pin(pin_num) || 
+    if (!is_valid_gpio_port(port) || !is_valid_pin(pin_num) ||
         trigger >= EXTI_TRIGGER_INVALID || mode >= EXTI_MODE_INVALID) {
-        return -1;
+        return ERR_INVALID_ARG;
     }
 
     /* __get_PRIMASK() returns 0 if interrupts are enabled, non-zero if disabled */
@@ -78,41 +79,41 @@ int exti_configure_gpio_interrupt(gpio_port_t port, uint8_t pin_num,
         __enable_irq();
     }
 
-    return 0;
+    return ERR_OK;
 }
 
-int exti_enable_line(uint8_t line)
+err_t exti_enable_line(uint8_t line)
 {
     if (!is_valid_exti_line(line)) {
-        return -1;
+        return ERR_INVALID_ARG;
     }
 
     IRQn_Type irq_num = get_exti_irq_number(line);
     if (irq_num != (IRQn_Type)-1) {
         NVIC_EnableIRQ(irq_num);
-        return 0;
+        return ERR_OK;
     }
-    return -1;
+    return ERR_INVALID_ARG;
 }
 
-int exti_disable_line(uint8_t line)
+err_t exti_disable_line(uint8_t line)
 {
     if (!is_valid_exti_line(line)) {
-        return -1;
+        return ERR_INVALID_ARG;
     }
 
     IRQn_Type irq_num = get_exti_irq_number(line);
     if (irq_num != (IRQn_Type)-1) {
         NVIC_DisableIRQ(irq_num);
-        return 0;
+        return ERR_OK;
     }
-    return -1;
+    return ERR_INVALID_ARG;
 }
 
-int exti_set_interrupt_mask(uint8_t line, uint8_t enable)
+err_t exti_set_interrupt_mask(uint8_t line, uint8_t enable)
 {
     if (!is_valid_exti_line(line)) {
-        return -1;
+        return ERR_INVALID_ARG;
     }
 
     if (enable) {
@@ -120,13 +121,13 @@ int exti_set_interrupt_mask(uint8_t line, uint8_t enable)
     } else {
         EXTI->IMR &= ~(1U << line);
     }
-    return 0;
+    return ERR_OK;
 }
 
-int exti_set_event_mask(uint8_t line, uint8_t enable)
+err_t exti_set_event_mask(uint8_t line, uint8_t enable)
 {
     if (!is_valid_exti_line(line)) {
-        return -1;
+        return ERR_INVALID_ARG;
     }
 
     if (enable) {
@@ -134,38 +135,38 @@ int exti_set_event_mask(uint8_t line, uint8_t enable)
     } else {
         EXTI->EMR &= ~(1U << line);
     }
-    return 0;
+    return ERR_OK;
 }
 
 int exti_is_pending(uint8_t line)
 {
     if (!is_valid_exti_line(line)) {
-        return -1;
+        return ERR_INVALID_ARG;
     }
 
     return (EXTI->PR & (1U << line)) ? 1 : 0;
 }
 
-int exti_clear_pending(uint8_t line)
+err_t exti_clear_pending(uint8_t line)
 {
     if (!is_valid_exti_line(line)) {
-        return -1;
+        return ERR_INVALID_ARG;
     }
 
     /* Clear pending bit by writing 1 to it */
     EXTI->PR = (1U << line);
-    return 0;
+    return ERR_OK;
 }
 
-int exti_software_trigger(uint8_t line)
+err_t exti_software_trigger(uint8_t line)
 {
     if (!is_valid_exti_line(line)) {
-        return -1;
+        return ERR_INVALID_ARG;
     }
 
     /* Generate software interrupt by writing to SWIER */
     EXTI->SWIER |= (1U << line);
-    return 0;
+    return ERR_OK;
 }
 
 /* Private helper function implementations */

--- a/drivers/src/rcc.c
+++ b/drivers/src/rcc.c
@@ -74,8 +74,8 @@ uint32_t rcc_compute_apb_divider(uint32_t hclk_hz, uint32_t max_hz)
     return div;
 }
 
-int rcc_compute_pll_config(uint32_t src_hz, uint32_t target_hz,
-                           rcc_pll_factors_t *out)
+err_t rcc_compute_pll_config(uint32_t src_hz, uint32_t target_hz,
+                             rcc_pll_factors_t *out)
 {
     uint32_t pllm   = src_hz / VCO_INPUT_TARGET;
     uint32_t vco_in = src_hz / pllm;
@@ -95,7 +95,7 @@ int rcc_compute_pll_config(uint32_t src_hz, uint32_t target_hz,
         break;
     }
     if (plln == 0)
-        return -1;
+        return ERR_INVALID_ARG;
 
     uint32_t vco_out = vco_in * plln;
     uint32_t pllq    = vco_out / 48000000U;
@@ -106,7 +106,7 @@ int rcc_compute_pll_config(uint32_t src_hz, uint32_t target_hz,
     out->plln = plln;
     out->pllp = pllp;
     out->pllq = pllq;
-    return 0;
+    return ERR_OK;
 }
 
 static void cache_default_clocks(uint32_t source_freq) {
@@ -117,23 +117,23 @@ static void cache_default_clocks(uint32_t source_freq) {
     s_apb1_timer_clk = source_freq;
 }
 
-int rcc_init(rcc_clk_src_t source, uint32_t target_sysclk_hz) {
+err_t rcc_init(rcc_clk_src_t source, uint32_t target_sysclk_hz) {
     uint32_t source_freq = (source == RCC_CLK_SRC_HSE_BYPASS)
                            ? HSE_FREQ_HZ : HSI_FREQ_HZ;
 
     /* No PLL needed — run directly from the oscillator */
     if (target_sysclk_hz == source_freq) {
         cache_default_clocks(source_freq);
-        return 0;
+        return ERR_OK;
     }
 
     if (target_sysclk_hz > SYSCLK_MAX)
-        return -1;
+        return ERR_INVALID_ARG;
 
     /* --- Compute PLL factors --- */
     rcc_pll_factors_t pll;
-    if (rcc_compute_pll_config(source_freq, target_sysclk_hz, &pll) != 0)
-        return -1;
+    if (rcc_compute_pll_config(source_freq, target_sysclk_hz, &pll) != ERR_OK)
+        return ERR_INVALID_ARG;
 
     uint32_t pllm = pll.pllm;
     uint32_t plln = pll.plln;
@@ -161,7 +161,7 @@ int rcc_init(rcc_clk_src_t source, uint32_t target_sysclk_hz) {
         for (uint32_t t = HSE_READY_TIMEOUT; t; t--) {
             if (RCC->CR & RCC_CR_HSERDY)
                 break;
-            if (t == 1) return -1;
+            if (t == 1) return ERR_TIMEOUT;
         }
     }
     /* HSI is on by default after reset — nothing to do for HSI */
@@ -189,7 +189,7 @@ int rcc_init(rcc_clk_src_t source, uint32_t target_sysclk_hz) {
     for (uint32_t t = PLL_LOCK_TIMEOUT; t; t--) {
         if (RCC->CR & RCC_CR_PLLRDY)
             break;
-        if (t == 1) return -1;
+        if (t == 1) return ERR_TIMEOUT;
     }
 
     /* --- Set bus prescalers --- */
@@ -215,7 +215,7 @@ int rcc_init(rcc_clk_src_t source, uint32_t target_sysclk_hz) {
     s_apb2_clk      = target_sysclk_hz / ppre2_div;
     s_apb1_timer_clk = (ppre1_div == 1) ? s_apb1_clk : s_apb1_clk * 2;
 
-    return 0;
+    return ERR_OK;
 }
 
 /*

--- a/drivers/src/spi.c
+++ b/drivers/src/spi.c
@@ -1,4 +1,5 @@
 #include "spi.h"
+#include "error.h"
 #include "gpio_handler.h"
 
 /* Only include hardware headers when compiling for target */
@@ -21,7 +22,7 @@ int spi_prescaler_to_br(uint16_t prescaler) {
         case 64:  return 5;
         case 128: return 6;
         case 256: return 7;
-        default:  return -1;
+        default:  return ERR_INVALID_ARG;
     }
 }
 
@@ -73,10 +74,10 @@ static void spi_gpio_init(const spi_config_t *cfg) {
     gpio_set_af(cfg->mosi_port, cfg->mosi_pin, cfg->mosi_af);
 }
 
-int spi_init(spi_handle_t *handle, const spi_config_t *config) {
-    if (!handle || !config) return -1;
-    if (config->instance >= SPI_INSTANCE_COUNT) return -1;
-    if (config->prescaler_br > 7) return -1;
+err_t spi_init(spi_handle_t *handle, const spi_config_t *config) {
+    if (!handle || !config) return ERR_INVALID_ARG;
+    if (config->instance >= SPI_INSTANCE_COUNT) return ERR_INVALID_ARG;
+    if (config->prescaler_br > 7) return ERR_INVALID_ARG;
 
     const spi_hw_info_t *hw = &spi_hw_table[config->instance];
 
@@ -99,7 +100,7 @@ int spi_init(spi_handle_t *handle, const spi_config_t *config) {
              | (config->cpol ? SPI_CR1_CPOL : 0)
              | (config->cpha ? SPI_CR1_CPHA : 0);
 
-    return 0;
+    return ERR_OK;
 }
 
 /* Forward declaration -- defined in the DMA section below */
@@ -140,8 +141,8 @@ void spi_disable(spi_handle_t *handle) {
     spi->CR1 &= ~SPI_CR1_SPE;
 }
 
-int spi_transfer(spi_handle_t *handle, const uint8_t *tx, uint8_t *rx, uint16_t len) {
-    if (!handle || !handle->regs || len == 0) return -1;
+err_t spi_transfer(spi_handle_t *handle, const uint8_t *tx, uint8_t *rx, uint16_t len) {
+    if (!handle || !handle->regs || len == 0) return ERR_INVALID_ARG;
 
     SPI_TypeDef *spi = (SPI_TypeDef *)handle->regs;
 
@@ -165,7 +166,7 @@ int spi_transfer(spi_handle_t *handle, const uint8_t *tx, uint8_t *rx, uint16_t 
     /* Disable SPI */
     spi->CR1 &= ~SPI_CR1_SPE;
 
-    return 0;
+    return ERR_OK;
 }
 
 /*===========================================================================
@@ -265,7 +266,7 @@ static void spi_dma_rx_complete_cb(dma_stream_id_t stream, void *ctx) {
  * Called on the first spi_transfer_dma() invocation.  Subsequent transfers
  * skip this and go straight to dma_stream_set_mem_inc() + dma_stream_start().
  */
-static int spi_dma_init_streams(spi_handle_t *handle) {
+static err_t spi_dma_init_streams(spi_handle_t *handle) {
     spi_instance_t inst = handle->config.instance;
     SPI_TypeDef *spi = (SPI_TypeDef *)handle->regs;
     const spi_dma_map_t *map = &spi_dma_map[inst];
@@ -285,7 +286,7 @@ static int spi_dma_init_streams(spi_handle_t *handle) {
         .cb_ctx        = handle,
         .nvic_priority = 1,
     };
-    if (dma_stream_init(&rx_cfg) != 0) return -1;
+    if (dma_stream_init(&rx_cfg) != ERR_OK) return ERR_INVALID_ARG;
 
     /* TX stream (memory-to-peripheral) */
     dma_stream_config_t tx_cfg = {
@@ -302,18 +303,18 @@ static int spi_dma_init_streams(spi_handle_t *handle) {
         .cb_ctx        = (void *)0,
         .nvic_priority = 1,
     };
-    if (dma_stream_init(&tx_cfg) != 0) {
+    if (dma_stream_init(&tx_cfg) != ERR_OK) {
         dma_stream_release(map->rx_stream);
-        return -1;
+        return ERR_INVALID_ARG;
     }
 
     spi_dma_initialized[inst] = 1;
-    return 0;
+    return ERR_OK;
 }
 
-int spi_transfer_dma(spi_handle_t *handle, const uint8_t *tx, uint8_t *rx, uint16_t len) {
-    if (!handle || !handle->regs || len == 0) return -1;
-    if (handle->config.instance >= SPI_INSTANCE_COUNT) return -1;
+err_t spi_transfer_dma(spi_handle_t *handle, const uint8_t *tx, uint8_t *rx, uint16_t len) {
+    if (!handle || !handle->regs || len == 0) return ERR_INVALID_ARG;
+    if (handle->config.instance >= SPI_INSTANCE_COUNT) return ERR_INVALID_ARG;
 
     spi_instance_t inst = handle->config.instance;
     SPI_TypeDef *spi = (SPI_TypeDef *)handle->regs;
@@ -321,7 +322,7 @@ int spi_transfer_dma(spi_handle_t *handle, const uint8_t *tx, uint8_t *rx, uint1
 
     /* One-time stream allocation (first transfer only) */
     if (!spi_dma_initialized[inst]) {
-        if (spi_dma_init_streams(handle) != 0) return -1;
+        if (spi_dma_init_streams(handle) != ERR_OK) return ERR_INVALID_ARG;
     }
 
     /* Store handle so the callback can find it */
@@ -342,17 +343,17 @@ int spi_transfer_dma(spi_handle_t *handle, const uint8_t *tx, uint8_t *rx, uint1
     dma_stream_start_config(map->rx_stream, rx_addr, len, rx != (void *)0);
     dma_stream_start_config(map->tx_stream, tx_addr, len, tx != (void *)0);
 
-    return 0;
+    return ERR_OK;
 }
 
-int spi_transfer_dma_blocking(spi_handle_t *handle, const uint8_t *tx,
-                              uint8_t *rx, uint16_t len) {
-    int rc = spi_transfer_dma(handle, tx, rx, len);
-    if (rc != 0) return rc;
+err_t spi_transfer_dma_blocking(spi_handle_t *handle, const uint8_t *tx,
+                                uint8_t *rx, uint16_t len) {
+    err_t rc = spi_transfer_dma(handle, tx, rx, len);
+    if (rc != ERR_OK) return rc;
 
     while (handle->dma_busy);
 
-    return 0;
+    return ERR_OK;
 }
 
 #endif /* SPI_HOST_TEST */

--- a/tests/exti/test_exti.c
+++ b/tests/exti/test_exti.c
@@ -23,6 +23,7 @@
 
 #include "unity.h"
 #include "stm32f4xx.h"    /* stub: TypeDefs + fake peripheral declarations */
+#include "error.h"
 #include "exti_handler.h" /* EXTI driver API */
 #include "gpio_handler.h" /* For gpio_port_t */
 
@@ -263,7 +264,7 @@ void test_configure_invalid_pin_returns_error(void)
     int ret = exti_configure_gpio_interrupt(GPIO_PORT_A, 16,
                                             EXTI_TRIGGER_RISING,
                                             EXTI_MODE_INTERRUPT);
-    TEST_ASSERT_EQUAL(-1, ret);
+    TEST_ASSERT_EQUAL(ERR_INVALID_ARG, ret);
 }
 
 void test_configure_invalid_trigger_returns_error(void)
@@ -271,7 +272,7 @@ void test_configure_invalid_trigger_returns_error(void)
     int ret = exti_configure_gpio_interrupt(GPIO_PORT_A, 5,
                                             EXTI_TRIGGER_INVALID,
                                             EXTI_MODE_INTERRUPT);
-    TEST_ASSERT_EQUAL(-1, ret);
+    TEST_ASSERT_EQUAL(ERR_INVALID_ARG, ret);
 }
 
 void test_configure_invalid_mode_returns_error(void)
@@ -279,7 +280,7 @@ void test_configure_invalid_mode_returns_error(void)
     int ret = exti_configure_gpio_interrupt(GPIO_PORT_A, 5,
                                             EXTI_TRIGGER_RISING,
                                             EXTI_MODE_INVALID);
-    TEST_ASSERT_EQUAL(-1, ret);
+    TEST_ASSERT_EQUAL(ERR_INVALID_ARG, ret);
 }
 
 /* ======================================================================== */
@@ -289,7 +290,7 @@ void test_configure_invalid_mode_returns_error(void)
 void test_enable_line0_sets_nvic_iser(void)
 {
     int ret = exti_enable_line(0);
-    TEST_ASSERT_EQUAL(0, ret);
+    TEST_ASSERT_EQUAL(ERR_OK, ret);
     /* EXTI0_IRQn = 6 → ISER[0] bit 6 */
     TEST_ASSERT_BITS_HIGH(1U << 6, fake_NVIC.ISER[0]);
 }
@@ -297,7 +298,7 @@ void test_enable_line0_sets_nvic_iser(void)
 void test_enable_line1_sets_nvic_iser(void)
 {
     int ret = exti_enable_line(1);
-    TEST_ASSERT_EQUAL(0, ret);
+    TEST_ASSERT_EQUAL(ERR_OK, ret);
     /* EXTI1_IRQn = 7 → ISER[0] bit 7 */
     TEST_ASSERT_BITS_HIGH(1U << 7, fake_NVIC.ISER[0]);
 }
@@ -305,7 +306,7 @@ void test_enable_line1_sets_nvic_iser(void)
 void test_enable_line5_sets_nvic_iser_exti9_5(void)
 {
     int ret = exti_enable_line(5);
-    TEST_ASSERT_EQUAL(0, ret);
+    TEST_ASSERT_EQUAL(ERR_OK, ret);
     /* EXTI9_5_IRQn = 23 → ISER[0] bit 23 */
     TEST_ASSERT_BITS_HIGH(1U << 23, fake_NVIC.ISER[0]);
 }
@@ -313,7 +314,7 @@ void test_enable_line5_sets_nvic_iser_exti9_5(void)
 void test_enable_line10_sets_nvic_iser_exti15_10(void)
 {
     int ret = exti_enable_line(10);
-    TEST_ASSERT_EQUAL(0, ret);
+    TEST_ASSERT_EQUAL(ERR_OK, ret);
     /* EXTI15_10_IRQn = 40 → ISER[1] bit 8 */
     TEST_ASSERT_BITS_HIGH(1U << 8, fake_NVIC.ISER[1]);
 }
@@ -321,7 +322,7 @@ void test_enable_line10_sets_nvic_iser_exti15_10(void)
 void test_enable_line15_sets_nvic_iser_exti15_10(void)
 {
     int ret = exti_enable_line(15);
-    TEST_ASSERT_EQUAL(0, ret);
+    TEST_ASSERT_EQUAL(ERR_OK, ret);
     /* EXTI15_10_IRQn = 40 → ISER[1] bit 8 */
     TEST_ASSERT_BITS_HIGH(1U << 8, fake_NVIC.ISER[1]);
 }
@@ -329,20 +330,20 @@ void test_enable_line15_sets_nvic_iser_exti15_10(void)
 void test_enable_invalid_line_returns_error(void)
 {
     int ret = exti_enable_line(23);  /* Valid EXTI line but no GPIO IRQ */
-    /* Lines 16-22 map to (IRQn_Type)-1, should return -1 */
-    TEST_ASSERT_EQUAL(-1, ret);
+    /* Lines 16-22 map to (IRQn_Type)-1, should return ERR_INVALID_ARG */
+    TEST_ASSERT_EQUAL(ERR_INVALID_ARG, ret);
 }
 
 void test_enable_out_of_range_line_returns_error(void)
 {
     int ret = exti_enable_line(25);
-    TEST_ASSERT_EQUAL(-1, ret);
+    TEST_ASSERT_EQUAL(ERR_INVALID_ARG, ret);
 }
 
 void test_disable_line0_sets_nvic_icer(void)
 {
     int ret = exti_disable_line(0);
-    TEST_ASSERT_EQUAL(0, ret);
+    TEST_ASSERT_EQUAL(ERR_OK, ret);
     /* EXTI0_IRQn = 6 → ICER[0] bit 6 */
     TEST_ASSERT_BITS_HIGH(1U << 6, fake_NVIC.ICER[0]);
 }
@@ -350,7 +351,7 @@ void test_disable_line0_sets_nvic_icer(void)
 void test_disable_line4_sets_nvic_icer(void)
 {
     int ret = exti_disable_line(4);
-    TEST_ASSERT_EQUAL(0, ret);
+    TEST_ASSERT_EQUAL(ERR_OK, ret);
     /* EXTI4_IRQn = 10 → ICER[0] bit 10 */
     TEST_ASSERT_BITS_HIGH(1U << 10, fake_NVIC.ICER[0]);
 }
@@ -358,7 +359,7 @@ void test_disable_line4_sets_nvic_icer(void)
 void test_disable_line12_sets_nvic_icer_exti15_10(void)
 {
     int ret = exti_disable_line(12);
-    TEST_ASSERT_EQUAL(0, ret);
+    TEST_ASSERT_EQUAL(ERR_OK, ret);
     /* EXTI15_10_IRQn = 40 → ICER[1] bit 8 */
     TEST_ASSERT_BITS_HIGH(1U << 8, fake_NVIC.ICER[1]);
 }
@@ -366,7 +367,7 @@ void test_disable_line12_sets_nvic_icer_exti15_10(void)
 void test_disable_invalid_line_returns_error(void)
 {
     int ret = exti_disable_line(25);
-    TEST_ASSERT_EQUAL(-1, ret);
+    TEST_ASSERT_EQUAL(ERR_INVALID_ARG, ret);
 }
 
 /* ======================================================================== */
@@ -376,7 +377,7 @@ void test_disable_invalid_line_returns_error(void)
 void test_set_interrupt_mask_enable_sets_imr_bit(void)
 {
     int ret = exti_set_interrupt_mask(5, 1);
-    TEST_ASSERT_EQUAL(0, ret);
+    TEST_ASSERT_EQUAL(ERR_OK, ret);
     TEST_ASSERT_BITS_HIGH(1U << 5, fake_EXTI.IMR);
 }
 
@@ -384,7 +385,7 @@ void test_set_interrupt_mask_disable_clears_imr_bit(void)
 {
     fake_EXTI.IMR = (1U << 5);
     int ret = exti_set_interrupt_mask(5, 0);
-    TEST_ASSERT_EQUAL(0, ret);
+    TEST_ASSERT_EQUAL(ERR_OK, ret);
     TEST_ASSERT_BITS_LOW(1U << 5, fake_EXTI.IMR);
 }
 
@@ -399,7 +400,7 @@ void test_set_interrupt_mask_does_not_affect_other_lines(void)
 void test_set_interrupt_mask_invalid_line_returns_error(void)
 {
     int ret = exti_set_interrupt_mask(25, 1);
-    TEST_ASSERT_EQUAL(-1, ret);
+    TEST_ASSERT_EQUAL(ERR_INVALID_ARG, ret);
 }
 
 /* ======================================================================== */
@@ -409,7 +410,7 @@ void test_set_interrupt_mask_invalid_line_returns_error(void)
 void test_set_event_mask_enable_sets_emr_bit(void)
 {
     int ret = exti_set_event_mask(5, 1);
-    TEST_ASSERT_EQUAL(0, ret);
+    TEST_ASSERT_EQUAL(ERR_OK, ret);
     TEST_ASSERT_BITS_HIGH(1U << 5, fake_EXTI.EMR);
 }
 
@@ -417,7 +418,7 @@ void test_set_event_mask_disable_clears_emr_bit(void)
 {
     fake_EXTI.EMR = (1U << 5);
     int ret = exti_set_event_mask(5, 0);
-    TEST_ASSERT_EQUAL(0, ret);
+    TEST_ASSERT_EQUAL(ERR_OK, ret);
     TEST_ASSERT_BITS_LOW(1U << 5, fake_EXTI.EMR);
 }
 
@@ -432,7 +433,7 @@ void test_set_event_mask_does_not_affect_other_lines(void)
 void test_set_event_mask_invalid_line_returns_error(void)
 {
     int ret = exti_set_event_mask(25, 1);
-    TEST_ASSERT_EQUAL(-1, ret);
+    TEST_ASSERT_EQUAL(ERR_INVALID_ARG, ret);
 }
 
 /* ======================================================================== */
@@ -463,7 +464,7 @@ void test_is_pending_only_checks_requested_line(void)
 void test_is_pending_invalid_line_returns_error(void)
 {
     int ret = exti_is_pending(25);
-    TEST_ASSERT_EQUAL(-1, ret);
+    TEST_ASSERT_EQUAL(ERR_INVALID_ARG, ret);
 }
 
 /* ======================================================================== */
@@ -473,7 +474,7 @@ void test_is_pending_invalid_line_returns_error(void)
 void test_clear_pending_writes_1_to_pr_bit(void)
 {
     int ret = exti_clear_pending(5);
-    TEST_ASSERT_EQUAL(0, ret);
+    TEST_ASSERT_EQUAL(ERR_OK, ret);
     /* PR is write-1-to-clear on hardware; in the fake struct, the driver
      * writes 1 to the bit. We verify the write happened. */
     TEST_ASSERT_BITS_HIGH(1U << 5, fake_EXTI.PR);
@@ -482,7 +483,7 @@ void test_clear_pending_writes_1_to_pr_bit(void)
 void test_clear_pending_invalid_line_returns_error(void)
 {
     int ret = exti_clear_pending(25);
-    TEST_ASSERT_EQUAL(-1, ret);
+    TEST_ASSERT_EQUAL(ERR_INVALID_ARG, ret);
 }
 
 /* ======================================================================== */
@@ -492,7 +493,7 @@ void test_clear_pending_invalid_line_returns_error(void)
 void test_software_trigger_sets_swier_bit(void)
 {
     int ret = exti_software_trigger(5);
-    TEST_ASSERT_EQUAL(0, ret);
+    TEST_ASSERT_EQUAL(ERR_OK, ret);
     TEST_ASSERT_BITS_HIGH(1U << 5, fake_EXTI.SWIER);
 }
 
@@ -512,7 +513,7 @@ void test_software_trigger_does_not_affect_other_lines(void)
 void test_software_trigger_invalid_line_returns_error(void)
 {
     int ret = exti_software_trigger(25);
-    TEST_ASSERT_EQUAL(-1, ret);
+    TEST_ASSERT_EQUAL(ERR_INVALID_ARG, ret);
 }
 
 /* ======================================================================== */

--- a/tests/rcc/test_rcc.c
+++ b/tests/rcc/test_rcc.c
@@ -20,6 +20,7 @@
 
 #include "unity.h"
 #include "stm32f4xx.h"   /* stub: TypeDefs + fake peripheral declarations */
+#include "error.h"
 #include "rcc.h"
 #include "rcc_calc.h"
 
@@ -119,7 +120,7 @@ void test_apb_divider_exact_boundary_passes_without_extra_divide(void)
 void test_pll_config_hsi_to_100mhz_pllm(void)
 {
     rcc_pll_factors_t f;
-    TEST_ASSERT_EQUAL(0, rcc_compute_pll_config(16000000U, 100000000U, &f));
+    TEST_ASSERT_EQUAL(ERR_OK, rcc_compute_pll_config(16000000U, 100000000U, &f));
     TEST_ASSERT_EQUAL(8, f.pllm);
 }
 
@@ -154,7 +155,7 @@ void test_pll_config_hsi_to_100mhz_pllq(void)
 void test_pll_config_hse_to_100mhz_pllm_is_4(void)
 {
     rcc_pll_factors_t f;
-    TEST_ASSERT_EQUAL(0, rcc_compute_pll_config(8000000U, 100000000U, &f));
+    TEST_ASSERT_EQUAL(ERR_OK, rcc_compute_pll_config(8000000U, 100000000U, &f));
     TEST_ASSERT_EQUAL(4, f.pllm);
 }
 
@@ -179,7 +180,7 @@ void test_pll_config_hse_to_100mhz_pllp_is_2(void)
 void test_pll_config_hsi_to_96mhz_plln_is_96(void)
 {
     rcc_pll_factors_t f;
-    TEST_ASSERT_EQUAL(0, rcc_compute_pll_config(16000000U, 96000000U, &f));
+    TEST_ASSERT_EQUAL(ERR_OK, rcc_compute_pll_config(16000000U, 96000000U, &f));
     TEST_ASSERT_EQUAL(96, f.plln);
 }
 
@@ -197,13 +198,13 @@ void test_pll_config_target_3mhz_returns_error(void)
 {
     rcc_pll_factors_t f;
     /* All PLLP values give VCO out < 100 MHz minimum */
-    TEST_ASSERT_EQUAL(-1, rcc_compute_pll_config(16000000U, 3000000U, &f));
+    TEST_ASSERT_EQUAL(ERR_INVALID_ARG, rcc_compute_pll_config(16000000U, 3000000U, &f));
 }
 
 void test_pll_config_target_zero_returns_error(void)
 {
     rcc_pll_factors_t f;
-    TEST_ASSERT_EQUAL(-1, rcc_compute_pll_config(16000000U, 0U, &f));
+    TEST_ASSERT_EQUAL(ERR_INVALID_ARG, rcc_compute_pll_config(16000000U, 0U, &f));
 }
 
 /*
@@ -213,7 +214,7 @@ void test_pll_config_target_zero_returns_error(void)
 void test_pll_config_hsi_to_50mhz_pllq_clamped_to_2(void)
 {
     rcc_pll_factors_t f;
-    TEST_ASSERT_EQUAL(0, rcc_compute_pll_config(16000000U, 50000000U, &f));
+    TEST_ASSERT_EQUAL(ERR_OK, rcc_compute_pll_config(16000000U, 50000000U, &f));
     TEST_ASSERT_GREATER_OR_EQUAL(2, f.pllq);
 }
 
@@ -228,7 +229,7 @@ void test_pll_config_hsi_to_50mhz_pllq_clamped_to_2(void)
  */
 void test_rcc_init_hsi_direct_returns_0(void)
 {
-    TEST_ASSERT_EQUAL(0, rcc_init(RCC_CLK_SRC_HSI, 16000000U));
+    TEST_ASSERT_EQUAL(ERR_OK, rcc_init(RCC_CLK_SRC_HSI, 16000000U));
 }
 
 void test_rcc_init_hsi_direct_caches_sysclk(void)
@@ -264,7 +265,7 @@ void test_rcc_init_hsi_direct_caches_apb1_timer_clk(void)
 
 void test_rcc_init_hse_direct_returns_0(void)
 {
-    TEST_ASSERT_EQUAL(0, rcc_init(RCC_CLK_SRC_HSE_BYPASS, 8000000U));
+    TEST_ASSERT_EQUAL(ERR_OK, rcc_init(RCC_CLK_SRC_HSE_BYPASS, 8000000U));
 }
 
 void test_rcc_init_hse_direct_caches_sysclk(void)
@@ -276,16 +277,17 @@ void test_rcc_init_hse_direct_caches_sysclk(void)
 void test_rcc_init_target_exceeds_max_returns_error(void)
 {
     /* 101 MHz > SYSCLK_MAX (100 MHz) — rejected immediately, no busy-waits */
-    TEST_ASSERT_EQUAL(-1, rcc_init(RCC_CLK_SRC_HSI, 101000000U));
+    TEST_ASSERT_EQUAL(ERR_INVALID_ARG, rcc_init(RCC_CLK_SRC_HSI, 101000000U));
 }
 
 void test_rcc_init_unreachable_pll_target_returns_error(void)
 {
     /*
-     * 3 MHz: rcc_compute_pll_config returns -1 immediately (VCO output
-     * would be < 100 MHz min for every valid PLLP value). No busy-waits.
+     * 3 MHz: rcc_compute_pll_config returns ERR_INVALID_ARG immediately
+     * (VCO output would be < 100 MHz min for every valid PLLP value).
+     * No busy-waits.
      */
-    TEST_ASSERT_EQUAL(-1, rcc_init(RCC_CLK_SRC_HSI, 3000000U));
+    TEST_ASSERT_EQUAL(ERR_INVALID_ARG, rcc_init(RCC_CLK_SRC_HSI, 3000000U));
 }
 
 /* ======================================================================== */


### PR DESCRIPTION
## Summary

- Adds `drivers/inc/error.h` with a new `err_t` enum: `ERR_OK=0`, `ERR_INVALID_ARG=-1`, `ERR_TIMEOUT=-2`, `ERR_BUSY=-3`
- Updates all pure error-return functions in `rcc`, `exti`, `spi`, and `dma` drivers to use `err_t` return type and named constants
- Updates host test assertions from literal integers (`-1`, `0`) to named constants (`ERR_INVALID_ARG`, `ERR_OK`) for self-documenting tests
- `ERR_BUSY` is used specifically for the DMA stream-already-allocated case, distinguishing it from bad-parameter errors
- `ERR_TIMEOUT` is used for RCC PLL/HSE lock timeouts, distinguishing hardware wait failures from bad-parameter errors
- Functions with non-error semantic returns (boolean state like `dma_stream_busy`, field values like `spi_prescaler_to_br`) keep their `int` return type but use `ERR_INVALID_ARG` for their error path
- 298 host unit tests pass with 0 failures; all firmware examples build cleanly

## Test plan

- [x] `make test` — 298 tests, 0 failures
- [x] `make all` — all firmware examples build cleanly after `make clean`
- [x] `grep -rn "return -1" drivers/src/` — only `spi_perf.c` (non-driver test-runner, intentional)
- [x] `grep -rn "return -2" drivers/src/` — empty
- [x] `grep -rn "return -3" drivers/src/` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)