### PR TITLE
Centralise NVIC interrupt priority scheme (#73)

### DIFF
--- a/drivers/inc/critical_section.h
+++ b/drivers/inc/critical_section.h
@@ -1,0 +1,31 @@
+#ifndef CRITICAL_SECTION_H
+#define CRITICAL_SECTION_H
+
+#include "stm32f4xx.h"
+#include "irq_priorities.h"
+
+/*
+ * Nestable priority-based critical section using BASEPRI.
+ *
+ * Masks all interrupts at IRQ_PRIO_UART (2) and below while leaving
+ * DMA ISRs (priority 0, 1) free to fire -- avoiding buffer overruns
+ * when protecting shared data accessed from both task and ISR contexts.
+ *
+ * Usage:
+ *   uint32_t saved = critical_section_enter();
+ *   // protected code
+ *   critical_section_exit(saved);
+ */
+static inline uint32_t critical_section_enter(void)
+{
+    uint32_t prev = __get_BASEPRI();
+    __set_BASEPRI(IRQ_BASEPRI_MASK << (8U - __NVIC_PRIO_BITS));
+    return prev;
+}
+
+static inline void critical_section_exit(uint32_t saved)
+{
+    __set_BASEPRI(saved);
+}
+
+#endif /* CRITICAL_SECTION_H */

--- a/drivers/inc/irq_priorities.h
+++ b/drivers/inc/irq_priorities.h
@@ -1,0 +1,41 @@
+#ifndef IRQ_PRIORITIES_H
+#define IRQ_PRIORITIES_H
+
+#include "stm32f4xx.h"   /* __NVIC_PRIO_BITS = 4 on STM32F411 */
+
+/*
+ * Priority grouping: PRIGROUP=0 -> all 4 bits are preemption priority,
+ * 0 sub-priority bits.  Levels 0 (highest) ... 15 (lowest).
+ * Called once in Reset_Handler before any peripheral init.
+ */
+#define NVIC_PRIORITY_GROUP     0U
+
+/*
+ * Peripheral priority levels (lower value = fires first).
+ *
+ * Hierarchy rationale:
+ *   DMA streams must be able to preempt the UART ISR so that a DMA
+ *   transfer-complete interrupt can fire even while the UART error ISR
+ *   is already running -- preventing buffer overruns under sustained load.
+ *   EXTI and timer ISRs are application-level and can tolerate more latency.
+ *
+ *   0  IRQ_PRIO_DMA_HIGH -- DMA TX streams (UART TX, SPI)
+ *   1  IRQ_PRIO_DMA_LOW  -- DMA RX streams (UART RX, SPI)
+ *   2  IRQ_PRIO_UART     -- USART ISR (error flags / idle / RXNE)
+ *   3  IRQ_PRIO_EXTI     -- GPIO edge interrupts
+ *   3  IRQ_PRIO_TIMER    -- General-purpose timer update ISR
+ */
+#define IRQ_PRIO_DMA_HIGH    0U
+#define IRQ_PRIO_DMA_LOW     1U
+#define IRQ_PRIO_UART        2U
+#define IRQ_PRIO_EXTI        3U
+#define IRQ_PRIO_TIMER       3U
+
+/*
+ * BASEPRI threshold for critical sections.
+ * Masking at IRQ_PRIO_UART (2) leaves DMA ISRs (0,1) able to fire
+ * during critical sections protecting shared UART/SPI buffers.
+ */
+#define IRQ_BASEPRI_MASK     IRQ_PRIO_UART
+
+#endif /* IRQ_PRIORITIES_H */

--- a/drivers/src/exti_handler.c
+++ b/drivers/src/exti_handler.c
@@ -2,7 +2,8 @@
 
 #include "error.h"
 #include "exti_handler.h"
-#include "gpio_handler.h" 
+#include "gpio_handler.h"
+#include "irq_priorities.h"
 #include "stm32f4xx.h"
 
 /* Private helper functions */
@@ -71,6 +72,7 @@ err_t exti_configure_gpio_interrupt(gpio_port_t port, uint8_t pin_num,
     /* Enable NVIC interrupt */
     IRQn_Type irq_num = get_exti_irq_number(pin_num);
     if (irq_num != (IRQn_Type)-1) {
+        NVIC_SetPriority(irq_num, IRQ_PRIO_EXTI);
         NVIC_EnableIRQ(irq_num);
     }
 

--- a/drivers/src/spi.c
+++ b/drivers/src/spi.c
@@ -5,6 +5,7 @@
 /* Only include hardware headers when compiling for target */
 #ifndef SPI_HOST_TEST
 #include "dma.h"
+#include "irq_priorities.h"
 #include "stm32f4xx.h"
 #endif
 
@@ -284,7 +285,7 @@ static err_t spi_dma_init_streams(spi_handle_t *handle) {
         .tc_callback   = spi_dma_rx_complete_cb,
         .error_callback = (void *)0,
         .cb_ctx        = handle,
-        .nvic_priority = 1,
+        .nvic_priority = IRQ_PRIO_DMA_LOW,
     };
     if (dma_stream_init(&rx_cfg) != ERR_OK) return ERR_INVALID_ARG;
 
@@ -301,7 +302,7 @@ static err_t spi_dma_init_streams(spi_handle_t *handle) {
         .tc_callback   = (void *)0,   /* Only need RX TC */
         .error_callback = (void *)0,
         .cb_ctx        = (void *)0,
-        .nvic_priority = 1,
+        .nvic_priority = IRQ_PRIO_DMA_LOW,
     };
     if (dma_stream_init(&tx_cfg) != ERR_OK) {
         dma_stream_release(map->rx_stream);

--- a/drivers/src/timer.c
+++ b/drivers/src/timer.c
@@ -1,5 +1,6 @@
 #include "timer.h"
 #include "timer_calc.h"
+#include "irq_priorities.h"
 #include "rcc.h"
 #include "stm32f4xx.h"
 
@@ -96,6 +97,7 @@ void timer_register_callback(timer_instance_t tim, timer_callback_t cb)
 
     if (cb) {
         r->DIER |= DIER_UIE;
+        NVIC_SetPriority(hw[tim].irqn, IRQ_PRIO_TIMER);
         NVIC_EnableIRQ(hw[tim].irqn);
     } else {
         r->DIER &= ~DIER_UIE;

--- a/drivers/src/uart.c
+++ b/drivers/src/uart.c
@@ -3,6 +3,7 @@
 
 #include "dma.h"
 #include "gpio_handler.h"
+#include "irq_priorities.h"
 #include "rcc.h"
 #include "stm32f4xx.h"
 #include "uart.h"
@@ -212,7 +213,7 @@ void uart_start_rx_dma(uint8_t *buf, uint16_t size) {
         .tc_callback   = uart_rx_dma_tc_callback,
         .error_callback = NULL,
         .cb_ctx        = NULL,
-        .nvic_priority = 1,
+        .nvic_priority = IRQ_PRIO_DMA_LOW,
     };
     dma_stream_init(&rx_cfg);
 
@@ -357,16 +358,16 @@ static void uart_tx_dma_init(void) {
         .tc_callback   = uart_tx_dma_tc_callback,
         .error_callback = NULL,
         .cb_ctx        = NULL,
-        .nvic_priority = 0,  /* DMA higher priority than UART (2) */
+        .nvic_priority = IRQ_PRIO_DMA_HIGH,
     };
     dma_stream_init(&tx_cfg);
 }
 
 static void uart_nvic_init(void) {
     /* Enable USART2 interrupt in NVIC */
+    NVIC_SetPriority(USART2_IRQn, IRQ_PRIO_UART);
     NVIC_EnableIRQ(USART2_IRQn);
-    NVIC_SetPriority(USART2_IRQn, 2);  // Lower priority (higher number)
-    // DMA NVIC is configured by dma_stream_init() with priority 0
-    // DMA must have higher priority than UART to allow DMA completion 
-    // interrupts to fire even when called from UART interrupt context
+    /* DMA NVIC is configured by dma_stream_init() using IRQ_PRIO_DMA_HIGH/LOW.
+     * DMA must have higher priority than UART to allow DMA completion
+     * interrupts to fire even when called from UART interrupt context. */
 }

--- a/startup/stm32f411_startup.c
+++ b/startup/stm32f411_startup.c
@@ -1,4 +1,6 @@
 #include <stdint.h>
+#include "stm32f4xx.h"
+#include "irq_priorities.h"
 
 /*Symbols defined in the linker script */
 extern uint32_t _estack;
@@ -200,6 +202,9 @@ void Default_Handler(void)
 /* Reset Handler */
 void Reset_Handler(void)
 {
+    /* Set NVIC priority grouping: all 4 bits = preemption, 0 sub-priority bits */
+    NVIC_SetPriorityGrouping(NVIC_PRIORITY_GROUP);
+
 #ifdef ENABLE_HW_FPU
 	/* Enable FPU: set CP10 and CP11 to full access (bits 20-23 in CPACR).
 	 * This must happen before any C code that may use floating-point,

--- a/tests/driver_stubs/core_cm4.h
+++ b/tests/driver_stubs/core_cm4.h
@@ -181,6 +181,19 @@ static inline void     __ISB(void)         {}
 static inline void     __NOP(void)         {}
 static inline void     __WFI(void)         {}
 
+/* ---- BASEPRI stubs (for critical_section.h) ----------------------------- */
+
+extern uint32_t fake_BASEPRI;
+static inline uint32_t __get_BASEPRI(void)            { return fake_BASEPRI; }
+static inline void     __set_BASEPRI(uint32_t val)    { fake_BASEPRI = val; }
+
+/* ---- NVIC_SetPriorityGrouping stub --------------------------------------- */
+
+static inline void NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+    (void)PriorityGroup;  /* no-op in host tests */
+}
+
 /* ---- DWT / CoreDebug bit constants (used by spi_perf.c) ----------------- */
 
 #define DWT_CTRL_CYCCNTENA_Msk        (1UL << 0)

--- a/tests/driver_stubs/test_periph.c
+++ b/tests/driver_stubs/test_periph.c
@@ -69,6 +69,9 @@ SysTick_Type     fake_SysTick;
 DWT_Type         fake_DWT;
 CoreDebug_Type   fake_CoreDebug;
 
+/* ---- BASEPRI fake (declared in core_cm4.h stub) ------------------------- */
+uint32_t fake_BASEPRI = 0;
+
 /* ---- System clock (declared in system_stm32f4xx.h) --------------------- */
 
 uint32_t SystemCoreClock = 100000000U;  /* 100 MHz */
@@ -130,4 +133,6 @@ void test_periph_reset(void)
     memset(&fake_SysTick,    0, sizeof(fake_SysTick));
     memset(&fake_DWT,        0, sizeof(fake_DWT));
     memset(&fake_CoreDebug,  0, sizeof(fake_CoreDebug));
+
+    fake_BASEPRI = 0;
 }

--- a/tests/driver_stubs/test_periph.h
+++ b/tests/driver_stubs/test_periph.h
@@ -70,6 +70,9 @@ extern DMA_Stream_TypeDef fake_DMA2_S7;
 /* ---- Cortex-M4 core peripheral fakes (declared in core_cm4.h stub) ------ */
 /* fake_NVIC, fake_SCB, fake_SysTick, fake_DWT, fake_CoreDebug             */
 
+/* ---- BASEPRI fake (declared in core_cm4.h stub) ------------------------- */
+extern uint32_t fake_BASEPRI;
+
 /* ---- Override STM32 peripheral instance macros -------------------------- */
 
 #undef GPIOA

--- a/tests/exti/test_exti.c
+++ b/tests/exti/test_exti.c
@@ -26,6 +26,7 @@
 #include "error.h"
 #include "exti_handler.h" /* EXTI driver API */
 #include "gpio_handler.h" /* For gpio_port_t */
+#include "irq_priorities.h"
 
 /* ---- Test lifecycle ----------------------------------------------------- */
 
@@ -517,6 +518,37 @@ void test_software_trigger_invalid_line_returns_error(void)
 }
 
 /* ======================================================================== */
+/* exti_configure_gpio_interrupt — NVIC priority                             */
+/* ======================================================================== */
+
+void test_configure_pin0_nvic_priority_is_exti(void)
+{
+    exti_configure_gpio_interrupt(GPIO_PORT_A, 0, EXTI_TRIGGER_RISING,
+                                  EXTI_MODE_INTERRUPT);
+    /* EXTI0_IRQn = 6 */
+    TEST_ASSERT_EQUAL(IRQ_PRIO_EXTI << (8U - __NVIC_PRIO_BITS),
+                      fake_NVIC.IP[(uint32_t)EXTI0_IRQn]);
+}
+
+void test_configure_pin7_nvic_priority_is_exti(void)
+{
+    exti_configure_gpio_interrupt(GPIO_PORT_A, 7, EXTI_TRIGGER_RISING,
+                                  EXTI_MODE_INTERRUPT);
+    /* EXTI9_5_IRQn = 23 */
+    TEST_ASSERT_EQUAL(IRQ_PRIO_EXTI << (8U - __NVIC_PRIO_BITS),
+                      fake_NVIC.IP[(uint32_t)EXTI9_5_IRQn]);
+}
+
+void test_configure_pin10_nvic_priority_is_exti(void)
+{
+    exti_configure_gpio_interrupt(GPIO_PORT_A, 10, EXTI_TRIGGER_RISING,
+                                  EXTI_MODE_INTERRUPT);
+    /* EXTI15_10_IRQn = 40 */
+    TEST_ASSERT_EQUAL(IRQ_PRIO_EXTI << (8U - __NVIC_PRIO_BITS),
+                      fake_NVIC.IP[(uint32_t)EXTI15_10_IRQn]);
+}
+
+/* ======================================================================== */
 /* main                                                                      */
 /* ======================================================================== */
 
@@ -605,6 +637,11 @@ int main(void)
     RUN_TEST(test_software_trigger_line0_sets_swier_bit0);
     RUN_TEST(test_software_trigger_does_not_affect_other_lines);
     RUN_TEST(test_software_trigger_invalid_line_returns_error);
+
+    /* NVIC priority */
+    RUN_TEST(test_configure_pin0_nvic_priority_is_exti);
+    RUN_TEST(test_configure_pin7_nvic_priority_is_exti);
+    RUN_TEST(test_configure_pin10_nvic_priority_is_exti);
 
     return UNITY_END();
 }

--- a/tests/timer/test_timer.c
+++ b/tests/timer/test_timer.c
@@ -22,6 +22,7 @@
 
 #include "unity.h"
 #include "stm32f4xx.h"  /* stub: TypeDefs + fake peripheral declarations */
+#include "irq_priorities.h"
 #include "rcc.h"
 #include "timer.h"
 #include "timer_calc.h"
@@ -281,6 +282,14 @@ void test_register_callback_does_not_affect_other_timer_dier(void)
     TEST_ASSERT_BITS_LOW(DIER_UIE, fake_TIM3.DIER);
 }
 
+void test_register_callback_sets_nvic_priority(void)
+{
+    timer_init(TIMER_2, 0U, 999U);
+    timer_register_callback(TIMER_2, test_cb);
+    TEST_ASSERT_EQUAL(IRQ_PRIO_TIMER << (8U - __NVIC_PRIO_BITS),
+                      fake_NVIC.IP[(uint32_t)TIM2_IRQn]);
+}
+
 /* ======================================================================== */
 /* timer_pwm_init                                                             */
 /* ======================================================================== */
@@ -492,6 +501,7 @@ int main(void)
     RUN_TEST(test_register_null_callback_disables_nvic_irq);
     RUN_TEST(test_register_callback_tim5_enables_nvic_irq);
     RUN_TEST(test_register_callback_does_not_affect_other_timer_dier);
+    RUN_TEST(test_register_callback_sets_nvic_priority);
 
     /* timer_pwm_init */
     RUN_TEST(test_pwm_init_ch1_enables_apb1_clock);

--- a/tests/uart/test_uart.c
+++ b/tests/uart/test_uart.c
@@ -29,6 +29,8 @@
 
 #include "unity.h"
 #include "stm32f4xx.h"  /* stub: TypeDefs + fake peripheral declarations */
+#include "irq_priorities.h"
+#include "critical_section.h"
 #include "rcc.h"
 #include "uart.h"
 #include "uart_calc.h"
@@ -257,11 +259,31 @@ void test_uart_init_nvic_usart2_irq_enabled(void)
     TEST_ASSERT_BITS_HIGH(1U << (irqn & 0x1FU), fake_NVIC.ISER[irqn >> 5U]);
 }
 
-void test_uart_init_nvic_usart2_priority_is_2(void)
+void test_uart_init_nvic_usart2_priority(void)
 {
     uart_init();
-    /* NVIC_SetPriority stores (priority << (8 - __NVIC_PRIO_BITS)) = 2 << 4 = 32 */
-    TEST_ASSERT_EQUAL(2U << (8U - 4U), fake_NVIC.IP[(uint32_t)USART2_IRQn]);
+    /* NVIC_SetPriority stores (priority << (8 - __NVIC_PRIO_BITS)) */
+    TEST_ASSERT_EQUAL(IRQ_PRIO_UART << (8U - __NVIC_PRIO_BITS),
+                      fake_NVIC.IP[(uint32_t)USART2_IRQn]);
+}
+
+void test_uart_init_nvic_dma_tx_priority(void)
+{
+    uart_init();
+    /* UART TX uses DMA1 Stream6 (DMA_STREAM_1_6) */
+    TEST_ASSERT_EQUAL(IRQ_PRIO_DMA_HIGH << (8U - __NVIC_PRIO_BITS),
+                      fake_NVIC.IP[(uint32_t)DMA1_Stream6_IRQn]);
+}
+
+void test_uart_init_nvic_dma_rx_priority(void)
+{
+    uart_init();
+    static uint8_t buf[32];
+    uart_start_rx_dma(buf, sizeof(buf));
+    /* UART RX uses DMA1 Stream5 (DMA_STREAM_1_5) */
+    TEST_ASSERT_EQUAL(IRQ_PRIO_DMA_LOW << (8U - __NVIC_PRIO_BITS),
+                      fake_NVIC.IP[(uint32_t)DMA1_Stream5_IRQn]);
+    uart_stop_rx_dma();
 }
 
 /* ======================================================================== */
@@ -485,6 +507,39 @@ void test_null_rx_callback_does_not_crash(void)
 }
 
 /* ======================================================================== */
+/* Critical section                                                           */
+/* ======================================================================== */
+
+void test_critical_section_enter_sets_basepri(void)
+{
+    fake_BASEPRI = 0;
+    uint32_t saved = critical_section_enter();
+    TEST_ASSERT_EQUAL(0U, saved);  /* previous value was 0 */
+    TEST_ASSERT_EQUAL(IRQ_BASEPRI_MASK << (8U - __NVIC_PRIO_BITS), fake_BASEPRI);
+    critical_section_exit(saved);
+}
+
+void test_critical_section_exit_restores_basepri(void)
+{
+    fake_BASEPRI = 0;
+    uint32_t saved = critical_section_enter();
+    critical_section_exit(saved);
+    TEST_ASSERT_EQUAL(0U, fake_BASEPRI);
+}
+
+void test_critical_section_nesting(void)
+{
+    fake_BASEPRI = 0;
+    uint32_t s1 = critical_section_enter();
+    uint32_t s2 = critical_section_enter();
+    /* second enter is a no-op in terms of saved value since BASEPRI is already set */
+    critical_section_exit(s2);
+    /* BASEPRI still set after inner exit because s2 == already-masked value */
+    critical_section_exit(s1);
+    TEST_ASSERT_EQUAL(0U, fake_BASEPRI);
+}
+
+/* ======================================================================== */
 /* main                                                                       */
 /* ======================================================================== */
 
@@ -526,7 +581,9 @@ int main(void)
 
     /* uart_init — NVIC */
     RUN_TEST(test_uart_init_nvic_usart2_irq_enabled);
-    RUN_TEST(test_uart_init_nvic_usart2_priority_is_2);
+    RUN_TEST(test_uart_init_nvic_usart2_priority);
+    RUN_TEST(test_uart_init_nvic_dma_tx_priority);
+    RUN_TEST(test_uart_init_nvic_dma_rx_priority);
 
     /* uart_write */
     RUN_TEST(test_uart_write_puts_char_in_dr);
@@ -561,6 +618,11 @@ int main(void)
     RUN_TEST(test_rx_callback_not_called_when_dma_rx_active);
     RUN_TEST(test_rx_callback_receives_correct_character);
     RUN_TEST(test_null_rx_callback_does_not_crash);
+
+    /* Critical section */
+    RUN_TEST(test_critical_section_enter_sets_basepri);
+    RUN_TEST(test_critical_section_exit_restores_basepri);
+    RUN_TEST(test_critical_section_nesting);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- **`drivers/inc/irq_priorities.h`** — named constants for all peripheral IRQ priorities with documented hierarchy (DMA_HIGH=0 > DMA_LOW=1 > UART=2 > EXTI/TIMER=3) and BASEPRI mask constant
- **`drivers/inc/critical_section.h`** — nestable BASEPRI-based critical sections; masks UART and below, leaves DMA free
- **`startup/stm32f411_startup.c`** — explicit `NVIC_SetPriorityGrouping(0)` at reset
- **`uart.c`**, **`spi.c`** — magic numbers replaced with named constants
- **`exti_handler.c`**, **`timer.c`** — now explicitly call `NVIC_SetPriority` before `NVIC_EnableIRQ` (previously silent default of 0)
- **Test stubs** — `fake_BASEPRI` + `__get/set_BASEPRI()` for host testing
- **8 new host tests** — DMA priority levels, EXTI priority (3 IRQ groups), timer priority, critical section enter/exit/nesting

## Test plan
- [x] `make test` — all existing + 8 new tests pass
- [x] `make all` — clean firmware build
- [x] No magic number priority calls remain in `drivers/src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)