### PR TITLE
Implement Stop and Standby low-power modes (#70)

### DIFF
--- a/drivers/inc/sleep_mode.h
+++ b/drivers/inc/sleep_mode.h
@@ -1,7 +1,16 @@
 #ifndef SLEEP_MODE_H_
 #define SLEEP_MODE_H_
 
+#include <stdint.h>
+
 void sleep_mode_init(void);
 void enter_sleep_mode(void);
+
+void enter_stop_mode(void);
+void enter_standby_mode(uint8_t enable_wkup_pin);
+
+int sleep_was_standby_wakeup(void);
+void sleep_clear_standby_flag(void);
+void sleep_clear_wakeup_flag(void);
 
 #endif // SLEEP_MODE_H_

--- a/drivers/src/sleep_mode.c
+++ b/drivers/src/sleep_mode.c
@@ -1,42 +1,45 @@
-/*
- * sleep_mode.c
- *
- * Created on: 24 de jun de 2024
- * 
- * By default, the microcontroller is in Run mode after a system or a power-on reset.
- * In Run mode the CPU is clocked by HCLK and the program code is executed.
- * The microcontroller can enter Sleep mode by executing the WFI (Wait For Interrupt)
- * instruction. In Sleep mode the CPU clock is stopped while the HCLK, PCLK1,
- * PCLK2, and the peripheral clocks are running.
- * The microcontroller returns to Run mode when an interrupt or a reset occurs.
- * In Sleep mode, the consumption is reduced down to 15 µA (typical value at 3 V
- * and 25 °C) in Sleep mode with the regulator in main mode.
- * 
- */
 #include "sleep_mode.h"
 #include "stm32f4xx.h"
 
-/* Initialize sleep mode settings
- *
- * The SLEEPDEEP bit in the Cortex System Control Register (SCR) must be set
- */
 void sleep_mode_init(void) {
-    // Enable Power Control clock
     RCC->APB1ENR |= RCC_APB1ENR_PWREN;
-    // Clear SLEEPDEEP bit of Cortex System Control Register
-    SCB->SCR &= ~(SCB_SCR_SLEEPDEEP_Msk);
+    SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
 }
 
-/* Low-power modes are entered by the MCU by executing the WFI (Wait For Interrupt),
- * or WFE (Wait for Event) instructions, or when the SLEEPONEXIT bit in the Cortex-M4
- * System Control register is set on Return from ISR.
- * Entering Low-power mode through WFI or WFE is executed only if no interrupt is
- * pending or no event is pending.
- * In this example, we use WFI to enter sleep mode.
- */
 void enter_sleep_mode(void) {
-    // Clear SLEEPONEXIT bit of Cortex System Control Register
     SCB->SCR &= ~SCB_SCR_SLEEPONEXIT_Msk;
-    // Enter Sleep mode, wake up on any interrupt
     __WFI();
+}
+
+void enter_stop_mode(void) {
+    PWR->CR |= PWR_CR_CWUF;
+    PWR->CR |= PWR_CR_LPDS | PWR_CR_FPDS;
+    PWR->CR &= ~PWR_CR_PDDS;
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+    __DSB();
+    __WFI();
+    SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
+}
+
+void enter_standby_mode(uint8_t enable_wkup_pin) {
+    PWR->CR |= PWR_CR_CWUF | PWR_CR_CSBF;
+    PWR->CR |= PWR_CR_PDDS;
+    if (enable_wkup_pin) {
+        PWR->CSR |= PWR_CSR_EWUP;
+    }
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+    __DSB();
+    __WFI();
+}
+
+int sleep_was_standby_wakeup(void) {
+    return (PWR->CSR & PWR_CSR_SBF) ? 1 : 0;
+}
+
+void sleep_clear_standby_flag(void) {
+    PWR->CR |= PWR_CR_CSBF;
+}
+
+void sleep_clear_wakeup_flag(void) {
+    PWR->CR |= PWR_CR_CWUF;
 }

--- a/examples/cli/cli_commands.c
+++ b/examples/cli/cli_commands.c
@@ -4,14 +4,16 @@
 #include "flash.h"
 #include "led2.h"
 #include "printf.h"
+#include "printf_dma.h"
 #include "rcc.h"
+#include "sleep_mode.h"
 #include "spi_perf.h"
 #include "systick.h"
 #include "timer.h"
+#include "uart.h"
 
 #ifdef HIL_TEST_MODE
 #include "test_output.h"
-#include "printf_dma.h"
 #endif
 
 // Command implementations
@@ -450,6 +452,37 @@ static int cmd_crc_test(const char *args)
     return 0;
 }
 
+static int cmd_stop_mode(const char *args)
+{
+    (void)args;
+    printf("Entering Stop mode (low-power regulator, flash off)...\n");
+    printf_dma_flush();
+
+    enter_stop_mode();
+
+    /* Woke up — HSI is now the clock source. Restore PLL to 100 MHz. */
+    rcc_init(RCC_CLK_SRC_HSI, 100000000U);
+    uart_init();
+    systick_init();
+    printf_dma_init();
+
+    printf("Woke from Stop mode — clock restored to 100 MHz\n");
+    return 0;
+}
+
+static int cmd_standby_mode(const char *args)
+{
+    (void)args;
+    printf("Entering Standby mode (WKUP pin enabled)...\n");
+    printf("System will reset on wakeup.\n");
+    printf_dma_flush();
+
+    enter_standby_mode(1);
+
+    /* Should never reach here on real hardware */
+    return 0;
+}
+
 // Command table (help command is automatically added by CLI library)
 static const cli_command_t commands[] = {
     {"uptime",        "Print uptime (hh:mm:ss.mmm)", cmd_uptime},
@@ -462,6 +495,8 @@ static const cli_command_t commands[] = {
     {"flash_write",   "Write flash <addr> <value>",       cmd_flash_write},
     {"flash_erase",   "Erase flash <sector> (4-7)",       cmd_flash_erase},
     {"crc_test",      "CRC32 of flash <addr> [words]",    cmd_crc_test},
+    {"stop_mode",     "Enter Stop mode (wake on interrupt)",      cmd_stop_mode},
+    {"standby_mode",  "Enter Standby mode (full reset on wake)",  cmd_standby_mode},
     {"fault_test",    "Trigger a fault (nullptr|divzero|illegal)", cmd_fault_test},
 #ifdef ENABLE_HW_FPU
     {"fpu_test",      "Validate HW FPU is working", cmd_fpu_test},

--- a/examples/cli/cli_simple.c
+++ b/examples/cli/cli_simple.c
@@ -61,6 +61,12 @@ int main(void) {
     uart_init();
     systick_init();
     sleep_mode_init();
+
+    // Detect standby wakeup (before printf_dma_init so UART is ready)
+    if (sleep_was_standby_wakeup()) {
+        sleep_clear_standby_flag();
+        sleep_clear_wakeup_flag();
+    }
     
     // Enable DIV_0 trapping and individual fault handlers
     fault_handler_init();

--- a/examples/cli/test_harness.c
+++ b/examples/cli/test_harness.c
@@ -43,6 +43,7 @@
 #include "exti_handler.h"
 #include "flash.h"
 #include "crc.h"
+#include "sleep_mode.h"
 #include "stm32f4xx.h"  /* DWT / CoreDebug for cycle counting */
 
 /* ====================================================================
@@ -873,6 +874,47 @@ void test_crc_hw_performance(void)
 }
 
 /* ====================================================================
+ * Stop mode test — Tier 8
+ *
+ * Uses EXTI software trigger on line 7 (PB7) to wake immediately from
+ * Stop mode without external wiring or hang risk. After wake, the PLL
+ * is restored to 100 MHz and systick re-initialised.
+ * ==================================================================== */
+
+void test_stop_mode_enter_and_wake(void)
+{
+    /* Configure PB7 as input, enable EXTI line 7 rising edge */
+    gpio_clock_enable(GPIO_PORT_B);
+    gpio_configure_pin(GPIO_PORT_B, 7, GPIO_MODE_INPUT);
+    RCC->APB2ENR |= RCC_APB2ENR_SYSCFGEN;
+
+    int ret = exti_configure_gpio_interrupt(GPIO_PORT_B, 7,
+                                            EXTI_TRIGGER_RISING,
+                                            EXTI_MODE_INTERRUPT);
+    TEST_ASSERT_EQUAL_MESSAGE(0, ret, "EXTI config for stop wake failed");
+
+    /* Set EXTI pending via software trigger so WFI wakes immediately */
+    exti_software_trigger(7);
+
+    /* Enter Stop mode — wakes immediately due to pending EXTI */
+    enter_stop_mode();
+
+    /* Restore PLL to 100 MHz (Stop mode reverts to HSI) */
+    rcc_init(RCC_CLK_SRC_HSI, 100000000U);
+    systick_init();
+
+    /* Verify clock restored */
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(100000000U, rcc_get_sysclk(),
+        "SYSCLK not restored to 100 MHz after Stop mode wake");
+
+    /* Cleanup EXTI */
+    exti_clear_pending(7);
+    exti_disable_line(7);
+    exti_set_interrupt_mask(7, 0);
+    gpio_configure_pin(GPIO_PORT_B, 7, GPIO_MODE_ANALOG);
+}
+
+/* ====================================================================
  * Main test runner
  * ==================================================================== */
 
@@ -1089,6 +1131,16 @@ int run_unity_tests(void) {
     RUN_TEST(test_crc_hw_accumulate_matches_sequential);
     RUN_TEST(test_crc_hw_flash_region);
     RUN_TEST(test_crc_hw_performance);
+
+    /* ----------------------------------------------------------
+     * Tier 8: Low-power Stop mode test
+     *   Uses EXTI software trigger to wake immediately.
+     *   No external wiring required.
+     * ---------------------------------------------------------- */
+    printf("\n--- Tier 8: Stop mode enter/wake ---\n");
+    printf_dma_flush();
+
+    RUN_TEST(test_stop_mode_enter_and_wake);
 
     printf_dma_flush();
     return UNITY_END();

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS = string_utils cli gpio exti rcc timer uart systick flash iwdg crc
+SUBDIRS = string_utils cli gpio exti rcc timer uart systick flash iwdg crc lowpower
 
 COVERAGE_INFO = coverage.info
 COVERAGE_FILT = coverage-filtered.info
@@ -56,6 +56,10 @@ run: all
 	@echo "Running crc tests"
 	@echo "========================================"
 	@$(MAKE) -C crc run
+	@echo "========================================"
+	@echo "Running lowpower tests"
+	@echo "========================================"
+	@$(MAKE) -C lowpower run
 	@echo "========================================"
 	@echo "All test suites passed"
 	@echo "========================================"

--- a/tests/driver_stubs/test_periph.c
+++ b/tests/driver_stubs/test_periph.c
@@ -65,6 +65,7 @@ DMA_Stream_TypeDef fake_DMA2_S7;
 
 IWDG_TypeDef    fake_IWDG;
 CRC_TypeDef     fake_CRC;
+PWR_TypeDef     fake_PWR;
 
 /* ---- Cortex-M4 core peripheral fake instances (declared in core_cm4.h) - */
 
@@ -137,6 +138,7 @@ void test_periph_reset(void)
 
     memset(&fake_IWDG,       0, sizeof(fake_IWDG));
     memset(&fake_CRC,        0, sizeof(fake_CRC));
+    memset(&fake_PWR,        0, sizeof(fake_PWR));
 
     memset(&fake_NVIC,       0, sizeof(fake_NVIC));
     memset(&fake_SCB,        0, sizeof(fake_SCB));

--- a/tests/driver_stubs/test_periph.h
+++ b/tests/driver_stubs/test_periph.h
@@ -71,6 +71,7 @@ extern DMA_Stream_TypeDef fake_DMA2_S7;
 
 extern IWDG_TypeDef    fake_IWDG;
 extern CRC_TypeDef     fake_CRC;
+extern PWR_TypeDef     fake_PWR;
 
 /* ---- Cortex-M4 core peripheral fakes (declared in core_cm4.h stub) ------ */
 /* fake_NVIC, fake_SCB, fake_SysTick, fake_DWT, fake_CoreDebug             */
@@ -174,6 +175,9 @@ extern uint32_t fake_BASEPRI;
 
 #undef CRC
 #define CRC      (&fake_CRC)
+
+#undef PWR
+#define PWR      (&fake_PWR)
 
 /* ---- Reset helper ------------------------------------------------------- */
 

--- a/tests/lowpower/Makefile
+++ b/tests/lowpower/Makefile
@@ -1,0 +1,25 @@
+CC     = gcc
+CFLAGS = -Wall -Wextra -Wno-unknown-pragmas -Wno-unknown-warning-option \
+         -I../../tests/driver_stubs \
+         -I../../drivers/inc \
+         -I../../chip_headers/CMSIS/Include \
+         -I../../chip_headers/CMSIS/Device/ST/STM32F4xx/Include \
+         -I../../3rd_party/unity/src \
+         $(EXTRA_CFLAGS)
+
+UNITY_SRC       = ../../3rd_party/unity/src/unity.c
+DRIVER_SRC      = ../../drivers/src/sleep_mode.c
+TEST_PERIPH_SRC = ../../tests/driver_stubs/test_periph.c
+
+.PHONY: all run clean
+
+all: test_lowpower.out
+
+run: all
+	./test_lowpower.out
+
+test_lowpower.out: test_lowpower.c $(DRIVER_SRC) $(TEST_PERIPH_SRC) $(UNITY_SRC)
+	$(CC) $(CFLAGS) $^ -o $@
+
+clean:
+	rm -f *.out *.o *.gcda *.gcno

--- a/tests/lowpower/test_lowpower.c
+++ b/tests/lowpower/test_lowpower.c
@@ -1,0 +1,155 @@
+#include "unity.h"
+#include "stm32f4xx.h"
+#include "test_periph.h"
+#include "sleep_mode.h"
+
+void setUp(void) {
+    test_periph_reset();
+}
+
+void tearDown(void) {}
+
+/* --- sleep_mode_init tests --- */
+
+void test_init_enables_pwr_clock(void) {
+    sleep_mode_init();
+    TEST_ASSERT_BITS_HIGH(RCC_APB1ENR_PWREN, fake_RCC.APB1ENR);
+}
+
+void test_init_clears_sleepdeep(void) {
+    fake_SCB.SCR = SCB_SCR_SLEEPDEEP_Msk;
+    sleep_mode_init();
+    TEST_ASSERT_BITS_LOW(SCB_SCR_SLEEPDEEP_Msk, fake_SCB.SCR);
+}
+
+/* --- enter_sleep_mode tests --- */
+
+void test_sleep_clears_sleeponexit(void) {
+    fake_SCB.SCR = SCB_SCR_SLEEPONEXIT_Msk;
+    enter_sleep_mode();
+    TEST_ASSERT_BITS_LOW(SCB_SCR_SLEEPONEXIT_Msk, fake_SCB.SCR);
+}
+
+/* --- enter_stop_mode tests --- */
+
+void test_stop_sets_cwuf(void) {
+    enter_stop_mode();
+    TEST_ASSERT_BITS_HIGH(PWR_CR_CWUF, fake_PWR.CR);
+}
+
+void test_stop_sets_lpds(void) {
+    enter_stop_mode();
+    TEST_ASSERT_BITS_HIGH(PWR_CR_LPDS, fake_PWR.CR);
+}
+
+void test_stop_sets_fpds(void) {
+    enter_stop_mode();
+    TEST_ASSERT_BITS_HIGH(PWR_CR_FPDS, fake_PWR.CR);
+}
+
+void test_stop_clears_pdds(void) {
+    fake_PWR.CR = PWR_CR_PDDS;
+    enter_stop_mode();
+    TEST_ASSERT_BITS_LOW(PWR_CR_PDDS, fake_PWR.CR);
+}
+
+void test_stop_clears_sleepdeep_on_return(void) {
+    enter_stop_mode();
+    TEST_ASSERT_BITS_LOW(SCB_SCR_SLEEPDEEP_Msk, fake_SCB.SCR);
+}
+
+void test_stop_does_not_set_pdds(void) {
+    enter_stop_mode();
+    TEST_ASSERT_BITS_LOW(PWR_CR_PDDS, fake_PWR.CR);
+}
+
+/* --- enter_standby_mode tests --- */
+
+void test_standby_sets_pdds(void) {
+    enter_standby_mode(0);
+    TEST_ASSERT_BITS_HIGH(PWR_CR_PDDS, fake_PWR.CR);
+}
+
+void test_standby_sets_cwuf(void) {
+    enter_standby_mode(0);
+    TEST_ASSERT_BITS_HIGH(PWR_CR_CWUF, fake_PWR.CR);
+}
+
+void test_standby_sets_csbf(void) {
+    enter_standby_mode(0);
+    TEST_ASSERT_BITS_HIGH(PWR_CR_CSBF, fake_PWR.CR);
+}
+
+void test_standby_sets_sleepdeep(void) {
+    enter_standby_mode(0);
+    TEST_ASSERT_BITS_HIGH(SCB_SCR_SLEEPDEEP_Msk, fake_SCB.SCR);
+}
+
+void test_standby_enables_wkup_pin(void) {
+    enter_standby_mode(1);
+    TEST_ASSERT_BITS_HIGH(PWR_CSR_EWUP, fake_PWR.CSR);
+}
+
+void test_standby_does_not_enable_wkup_pin_when_zero(void) {
+    enter_standby_mode(0);
+    TEST_ASSERT_BITS_LOW(PWR_CSR_EWUP, fake_PWR.CSR);
+}
+
+/* --- sleep_was_standby_wakeup tests --- */
+
+void test_was_standby_returns_1_when_sbf_set(void) {
+    fake_PWR.CSR = PWR_CSR_SBF;
+    TEST_ASSERT_EQUAL(1, sleep_was_standby_wakeup());
+}
+
+void test_was_standby_returns_0_when_sbf_clear(void) {
+    fake_PWR.CSR = 0;
+    TEST_ASSERT_EQUAL(0, sleep_was_standby_wakeup());
+}
+
+/* --- sleep_clear_standby_flag tests --- */
+
+void test_clear_standby_flag_sets_csbf(void) {
+    fake_PWR.CR = 0;
+    sleep_clear_standby_flag();
+    TEST_ASSERT_BITS_HIGH(PWR_CR_CSBF, fake_PWR.CR);
+}
+
+/* --- sleep_clear_wakeup_flag tests --- */
+
+void test_clear_wakeup_flag_sets_cwuf(void) {
+    fake_PWR.CR = 0;
+    sleep_clear_wakeup_flag();
+    TEST_ASSERT_BITS_HIGH(PWR_CR_CWUF, fake_PWR.CR);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_init_enables_pwr_clock);
+    RUN_TEST(test_init_clears_sleepdeep);
+
+    RUN_TEST(test_sleep_clears_sleeponexit);
+
+    RUN_TEST(test_stop_sets_cwuf);
+    RUN_TEST(test_stop_sets_lpds);
+    RUN_TEST(test_stop_sets_fpds);
+    RUN_TEST(test_stop_clears_pdds);
+    RUN_TEST(test_stop_clears_sleepdeep_on_return);
+    RUN_TEST(test_stop_does_not_set_pdds);
+
+    RUN_TEST(test_standby_sets_pdds);
+    RUN_TEST(test_standby_sets_cwuf);
+    RUN_TEST(test_standby_sets_csbf);
+    RUN_TEST(test_standby_sets_sleepdeep);
+    RUN_TEST(test_standby_enables_wkup_pin);
+    RUN_TEST(test_standby_does_not_enable_wkup_pin_when_zero);
+
+    RUN_TEST(test_was_standby_returns_1_when_sbf_set);
+    RUN_TEST(test_was_standby_returns_0_when_sbf_clear);
+
+    RUN_TEST(test_clear_standby_flag_sets_csbf);
+    RUN_TEST(test_clear_wakeup_flag_sets_cwuf);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- Extends the existing `sleep_mode` driver with **Stop mode** (~20 µA, SRAM preserved, wakes on interrupt) and **Standby mode** (~2.5 µA, full reset on wakeup via WKUP pin)
- Adds `fake_PWR` to driver test stubs and **19 host unit tests** verifying all register writes
- Adds CLI commands (`stop_mode`, `standby_mode`) for manual testing
- Adds **HIL Tier 8 test**: uses EXTI software trigger to wake from Stop mode immediately, then verifies PLL restoration to 100 MHz
- Detects standby wakeup in `main()` and clears flags on boot

## Test plan
- [x] `make test` — all host tests pass (existing + 19 new lowpower tests)
- [x] `make all` — all firmware examples build cleanly
- [x] CI `host-tests` job passes
- [x] CI `firmware-build` job passes
- [x] CI `hil-tests` job passes (Tier 8 stop mode test wakes and restores clock)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)