### PR TITLE
Add long-term project plans for refactor, bootloader, and comms+DSP tracks

### DIFF
--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -27,6 +27,17 @@ Claude reads this file at session start via `CLAUDE.md`. Update it whenever a pa
 | [drivers/exti.md](drivers/exti.md) | External interrupt configuration on GPIO pins |
 | [drivers/iwdg.md](drivers/iwdg.md) | Independent Watchdog — configurable timeout, feed, reset cause detection |
 
+## Plans
+
+Multi-phase project plans. Each plan's phases are sized as individual GitHub issues.
+
+| Page | Summary |
+|---|---|
+| [plans/index.md](plans/index.md) | Plans index — convention and active plans |
+| [plans/000-repo-refactor.md](plans/000-repo-refactor.md) | Refactor `examples/` → `apps/`, add `lib/` and `tools/` |
+| [plans/001-bootloader-and-security.md](plans/001-bootloader-and-security.md) | Bootloader, image signing, OTA, A/B slots, anti-rollback, RDP |
+| [plans/002-comms-and-dsp-baseband.md](plans/002-comms-and-dsp-baseband.md) | Two-board comms (UART/SPI/I²C) + software BPSK modem with FEC |
+
 ## Decisions
 
 | Page | Summary |

--- a/docs/wiki/plans/000-repo-refactor.md
+++ b/docs/wiki/plans/000-repo-refactor.md
@@ -1,0 +1,135 @@
+# Plan 000 — Repository Refactor for Multi-Track Work
+
+**Status:** proposed
+**Tracking issue:** _(to be filed)_
+**Prerequisite for:** [Plan 001 — Bootloader & Security](001-bootloader-and-security.md), [Plan 002 — Inter-Board Comms + DSP Baseband](002-comms-and-dsp-baseband.md)
+
+## Why
+
+Both planned tracks ship multiple firmware images and need reusable, non-driver code (crypto, framing, modem core). Without a refactor, `examples/` becomes a 30-target dumping ground and there's no clean home for middleware that isn't a driver and isn't a leaf utility.
+
+## Goals
+
+1. Make it easy to extend the project with new tracks without restructuring.
+2. Keep building, flashing, and testing any old or new app a single command.
+3. Give middleware (crypto, framing, modem) a clear home that mirrors how `drivers/` and `utils/` are organised.
+4. Allow per-app linker scripts (bootloader needs its own).
+
+## Non-goals
+
+- Changing the driver, utils, or test infrastructure.
+- Touching CI workflow logic beyond path updates.
+- Replacing Make with CMake or any other build system.
+
+## Target layout
+
+```
+stm32-bare-metal/
+├── chip_headers/        unchanged
+├── linker/              + per-app scripts (bootloader_ls.ld, app_ls.ld) alongside stm32_ls.ld
+├── startup/             unchanged
+├── 3rd_party/           unchanged
+├── drivers/             unchanged
+├── utils/               unchanged
+│
+├── lib/                 NEW — middleware libraries, no main(), no hardware ownership
+│   └── (populated by later plans)
+│
+├── apps/                RENAMED from examples/
+│   ├── basic/           current examples/basic/*
+│   └── cli/             current examples/cli/
+│
+├── tests/               unchanged structure; future tests/lib/* added by later plans
+├── tools/               NEW — host-side tools (sign_image.py, ota_send.py, ber_plot.py)
+├── scripts/             unchanged
+└── docs/wiki/plans/     NEW — multi-phase project plans (this doc)
+```
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | `examples/` → `apps/` | Matches what they actually are; the term "example" undersells the CLI app. |
+| 2 | `lib/` at top level (not nested per-app) | Crypto and framing will be reused across bootloader OTA *and* comms. |
+| 3 | App selects linker script via Makefile var | Bootloader needs its own flash region; default stays `stm32_ls.ld`. |
+| 4 | Keep flat `EXAMPLE=<name>` lookup | Existing recursive find in `examples/Makefile` already supports nested dirs; no command-line breaking change. |
+
+## Phases
+
+Each phase is one PR.
+
+### Phase 0.1 — Rename `examples/` → `apps/`
+
+**Scope:**
+- `git mv examples apps`
+- Update `Makefile` (SUBDIRS, $(MAKE) -C examples → apps, find paths under `$(BUILD_DIR)/examples` → `$(BUILD_DIR)/apps`)
+- Update `Makefile.common` (`EXAMPLES_DIR` → `APPS_DIR`)
+- Update `apps/Makefile` (was `examples/Makefile`) — rename comments
+- Update CI workflows that reference `examples/` paths
+- Update `CLAUDE.md` and `docs/wiki/architecture.md` directory listings
+- Update HIL scripts (`run_hil_tests.py` build path, `mcp_hil_server.py` if any path references)
+- Keep variable name `EXAMPLE=` for backward compatibility — internal var only
+
+**Validation:**
+- `make test` passes
+- `make all` builds all apps
+- `make flash EXAMPLE=cli_simple` works
+- `python3 scripts/run_hil_tests.py` passes
+- CI green on all three jobs (host-tests, firmware-build, hil-tests)
+
+### Phase 0.2 — Introduce `lib/` infrastructure
+
+**Scope:**
+- Create empty `lib/` with a `Makefile` that mirrors `drivers/Makefile`
+- Each `lib/<name>/` builds to `libname.a` under `$(BUILD_DIR)/lib/<name>/`
+- Add `LIB_DIR` to `Makefile.common`, export `<NAME>_LIB` vars as needed
+- Add `lib` to root `SUBDIRS`; make it depend on `3rd_party` and `drivers` if later libs need them
+- Add a placeholder `lib/.gitkeep` and `lib/README.md` documenting the convention
+- Add `tests/lib/` directory with a placeholder for host tests of future libs
+
+**Validation:**
+- `make test` and `make all` still pass (no new code, just plumbing)
+- Building with empty `lib/` is a no-op
+
+### Phase 0.3 — Per-app linker script selection
+
+**Scope:**
+- Add `LDSCRIPT ?= $(LINKER_DIR)/stm32_ls.ld` default (already in `Makefile.common`)
+- Allow apps to override `LDSCRIPT` from their own Makefile before linking
+- Document the convention in `apps/<app>/Makefile` template
+- No new linker scripts yet — those land with bootloader work in Plan 001
+
+**Validation:**
+- All existing apps still link with the default script
+- A test override (e.g. point `cli_simple` at a copy of the script via a stub var) confirms the mechanism — revert the stub before merge
+
+### Phase 0.4 — Add `tools/` directory
+
+**Scope:**
+- Create `tools/` with a `README.md` describing convention (host-side scripts, not built by Make)
+- No code yet — populated by Plan 001 (`sign_image.py`, `ota_send.py`) and Plan 002 (`ber_plot.py`)
+
+**Validation:**
+- Directory exists, README explains purpose
+
+### Phase 0.5 — Documentation update
+
+**Scope:**
+- Refresh `docs/wiki/architecture.md` directory tree
+- Refresh `CLAUDE.md` directory tree
+- Add `docs/wiki/plans/` to wiki index
+- Add a `log.md` entry summarising the refactor
+
+**Validation:**
+- Links resolve, tree matches reality
+
+## Risk & rollback
+
+- The rename touches many files but is mechanical. Each phase is its own PR; if Phase 0.1 breaks something subtle in CI, revert is one PR.
+- HIL scripts have hardcoded `examples/` paths — sweep with `grep -r examples scripts/ .github/` before merging.
+- Documentation drift: phases 0.1 and 0.5 must land together or in adjacent PRs.
+
+## Out of scope
+
+- Replacing Unity, switching test runners, CMake migration — separate proposals if desired.
+- Reorganising `drivers/` or `utils/` internally.

--- a/docs/wiki/plans/001-bootloader-and-security.md
+++ b/docs/wiki/plans/001-bootloader-and-security.md
@@ -1,0 +1,170 @@
+# Plan 001 — Bootloader & Embedded Security Track
+
+**Status:** proposed
+**Tracking issue:** _(to be filed)_
+**Depends on:** [Plan 000 — Repository Refactor](000-repo-refactor.md)
+
+## Why
+
+This track builds the security primitives every embedded platform ships: a custom bootloader, signed firmware images, OTA update, A/B partitioning, anti-rollback, and option-byte protection. It exercises bootloader/runtime separation, reset-vector control, flash partitioning, ECDSA verification on a Cortex-M4, and host-side tooling — all directly transferable industry skills.
+
+Limitations of the F411 platform are part of the learning: no crypto accelerator, no secure-element, no HUK. The project documents what's possible in software, what isn't, and where production designs would require silicon support.
+
+## End-state vision
+
+- Bootloader at `0x08000000` (16 KB, sector 0).
+- Two app slots A and B, with metadata sectors describing version/hash/signature.
+- Bootloader verifies the signature of the active slot before jumping. Failed verify falls back to the other slot.
+- A host tool signs app images with an ECDSA P-256 private key. The corresponding public key is baked into the bootloader.
+- A second host tool delivers OTA updates over UART using a framed protocol with CRC and ACK/NACK.
+- Anti-rollback: monotonic counter in flash prevents downgrade.
+- RDP Level 1 (and a documented experiment with Level 2) demonstrates readout protection.
+- Documentation captures threat model, key management, and what would have to change for production.
+
+## Reusable middleware (`lib/`)
+
+| Library | Purpose |
+|---|---|
+| `lib/crypto/` | SHA-256, ECDSA-P256 verify (micro-ecc), constant-time compare |
+| `lib/img/` | Image header struct, slot metadata, integrity + signature checks |
+| `lib/framing/` | HDLC-style framing with CRC-16, ACK/NACK, sequence numbers (also reused by Plan 002) |
+| `lib/flash/` | Higher-level wrappers over the flash driver: erase-then-write a slot, atomic metadata commit |
+
+## Apps (`apps/bootloader/`)
+
+| App | Purpose |
+|---|---|
+| `loader` | The bootloader binary. Linker script targets sector 0 only. |
+| `app_blinky_signed` | Trivial signed app proving the verify-and-jump path. |
+| `app_cli_signed` | Production CLI app, repackaged as signed image. |
+
+## Host tools (`tools/`)
+
+| Tool | Purpose |
+|---|---|
+| `sign_image.py` | Take a `.bin`, append metadata + signature, produce a flashable image. |
+| `keygen.py` | Generate ECDSA P-256 keypair; emit C array for bootloader public key. |
+| `ota_send.py` | Stream a signed image to the running device over UART. |
+| `partition_dump.py` | Read flash via OpenOCD/`st-info` and pretty-print slot metadata for debugging. |
+
+## Phases
+
+Each phase is one issue / one PR. Phases assume Plan 000 has landed.
+
+### Phase 1.1 — Internal flash driver (Issue #71)
+
+Already on the roadmap; required prerequisite. Adds `drivers/src/flash.c` with sector erase, word/halfword/byte program, lock/unlock, BSY polling. Host tests use the existing fake-stub pattern.
+
+### Phase 1.2 — Image header & metadata format
+
+**Scope:**
+- Define `lib/img/img_header.h`: magic, version, size, SHA-256, ECDSA signature, image type
+- Define slot metadata format (active flag, fail count, monotonic counter)
+- Pure host-testable parser: validate magic, sanity-check size, parse fields
+- Document the format in `docs/wiki/plans/001-bootloader/image-format.md`
+
+**Validation:** Host tests cover header round-trip, malformed inputs, boundary values.
+
+### Phase 1.3 — Crypto primitives in `lib/crypto/`
+
+**Scope:**
+- Vendor micro-ecc (single C file, MIT license)
+- Add SHA-256 (existing public-domain implementation, single C file)
+- Wrap them in a minimal API: `crypto_sha256(buf, len, out)`, `crypto_ecdsa_verify(pubkey, hash, sig)`
+- Host unit tests with NIST FIPS 186-4 test vectors
+- Constant-time `crypto_memcmp` for signature comparison
+
+**Validation:** Host tests pass FIPS vectors; ECDSA verify completes in <500 ms on a 100 MHz F411 (measured later in HIL).
+
+### Phase 1.4 — Host tooling: `keygen.py`, `sign_image.py`
+
+**Scope:**
+- `keygen.py`: generate P-256 keypair, emit `bootloader_pubkey.c` with `const uint8_t pubkey[64]`
+- `sign_image.py`: read `.bin`, compute SHA-256, sign with private key, prepend header, write `.signed.bin`
+- Both use Python's `cryptography` library
+- Document workflow in `docs/wiki/plans/001-bootloader/signing.md`
+
+**Validation:** Sign a known input, verify with `openssl` CLI as a cross-check.
+
+### Phase 1.5 — Bootloader skeleton (no crypto yet)
+
+**Scope:**
+- New `apps/bootloader/loader/` with `linker/bootloader_ls.ld` (16 KB at 0x08000000)
+- App linker script `linker/app_ls.ld` (slot A at 0x08010000, configurable)
+- Bootloader: minimal init (clock, UART for logs), read header from slot A, sanity check magic, jump to app reset vector
+- App template: relocatable to slot offset, vector table at app base via `SCB->VTOR`
+- Trivial `app_blinky_signed` that blinks (signature ignored at this stage)
+
+**Validation:** HIL test that bootloader → app jump works end-to-end. App's blink LED toggles. Reset re-enters bootloader cleanly.
+
+### Phase 1.6 — Signature verification + verify-and-jump
+
+**Scope:**
+- Bootloader includes embedded public key
+- Computes SHA-256 over app payload, verifies ECDSA against header signature
+- On verify success: jump. On failure: log and stop (no fallback yet).
+- Time the verify with the cycle counter; log the result.
+
+**Validation:** Signed image boots; tampered byte fails verify and bootloader halts. HIL test asserts both cases via UART output. Verify time recorded as a baseline.
+
+### Phase 1.7 — A/B slots and fallback
+
+**Scope:**
+- Slot metadata in dedicated sector with active flag, fail counter
+- Bootloader picks active slot, increments fail counter before jump, app must clear it after init (rollback-on-crash)
+- If active slot verify fails, try the other slot; if both fail, halt with diagnostics
+- `partition_dump.py` host tool to read and pretty-print
+
+**Validation:** HIL tests for: clean A→A boot, clean B→B boot, A bad → fallback to B, both bad → halt.
+
+### Phase 1.8 — OTA over UART (`framing` lib + `ota_send.py`)
+
+**Scope:**
+- `lib/framing/`: HDLC-style framing with byte-stuffing, CRC-16, ACK/NACK, sequence numbers
+- Bootloader OTA mode entered via magic command from app (writes flag in backup register or RAM, resets)
+- Bootloader receives image into inactive slot, verifies, swaps active slot atomically
+- `tools/ota_send.py` host driver
+
+**Validation:** End-to-end OTA from PC → device → reboot into new image. HIL automation in CI.
+
+### Phase 1.9 — Anti-rollback
+
+**Scope:**
+- Monotonic version counter in slot metadata
+- Bootloader refuses to boot a slot whose version < highest-ever-seen (stored in dedicated sector)
+- Counter incremented atomically after successful boot
+
+**Validation:** HIL: flash older image → bootloader rejects. Flash newer → boots and counter advances. Re-flash old → still rejected.
+
+### Phase 1.10 — Option byte protection (RDP)
+
+**Scope:**
+- Document RDP Level 0/1/2 semantics for STM32F4
+- Script to set RDP Level 1 (mass-erase on regression to L0; debug locked)
+- HIL test that confirms RDP-1 blocks debug attach
+- **Do NOT enable RDP Level 2 on the dev board** — it is permanent. Document the procedure only, leave it as a manual experiment with a separate "burn" board if the user chooses.
+
+**Validation:** HIL confirms debug-attach fails when RDP-1 is set; reverting to L0 mass-erases as expected.
+
+### Phase 1.11 — Threat model & docs
+
+**Scope:**
+- `docs/wiki/plans/001-bootloader/threat-model.md`: attacker capabilities, what's protected, what isn't (no anti-glitch, no secure element, software-only key storage)
+- `docs/wiki/plans/001-bootloader/production-gap.md`: what would change for production (HSM-backed signing keys, secure-boot ROM, TrustZone-M on M33 parts, anti-tamper, fault injection countermeasures)
+- ADR for the chosen image format and partition layout
+
+**Validation:** Doc review; cross-reference from architecture wiki page.
+
+## Risk & rollback
+
+- Bootloader bricking the dev board is the main hazard. Mitigations: keep a known-good bootloader binary; OpenOCD recovery procedure documented in Phase 1.5; never auto-flash bootloader in CI (only the slot images).
+- Microeccnees vendoring choice — confirm license + size before committing.
+- ECDSA verify time on 100 MHz Cortex-M4 without crypto accelerator is the wildcard. If it exceeds budget, fall back to RSA-PSS-2048 (fixed-time verify with public exponent) or Ed25519. Decision in Phase 1.3.
+- RDP Level 2 is irreversible — explicitly out of scope for the dev board.
+
+## Out of scope
+
+- Encrypted firmware images (signed only).
+- Anti-tamper, anti-glitch, side-channel-resistant signature verify.
+- Secure boot ROM (impossible — F411 has no immutable boot ROM with crypto).
+- Wireless OTA (UART only).

--- a/docs/wiki/plans/002-comms-and-dsp-baseband.md
+++ b/docs/wiki/plans/002-comms-and-dsp-baseband.md
@@ -1,0 +1,239 @@
+# Plan 002 — Inter-Board Comms + DSP Baseband Track
+
+**Status:** proposed
+**Tracking issue:** _(to be filed)_
+**Depends on:** [Plan 000 — Repository Refactor](000-repo-refactor.md)
+**Optional dependency:** [Plan 001](001-bootloader-and-security.md) — `lib/framing/` is shared; whichever track lands first defines it.
+
+## Why
+
+This track turns the pair of NUCLEO-F411RE boards into a wired comms+DSP testbed. It exercises three competencies:
+
+1. **Inter-board protocol engineering** — implementing UART, SPI, and I²C as fully bidirectional links with framing, retransmit, flow control, and benchmarking.
+2. **Real-time DSP on Cortex-M4F** — using CMSIS-DSP, FIR/IIR filters, FFT, and writing a software modem (BPSK or M-FSK) end-to-end.
+3. **Measurement methodology** — throughput, latency, jitter, and BER curves vs SNR, with reproducible HIL measurements.
+
+The two boards talk over physical wires — no RF — so all impairments are injected in software. This makes results reproducible and lets us study channel coding (FEC) without an anechoic chamber.
+
+## End-state vision
+
+- Two boards, wired together via headers, each runnable as **node A** or **node B** based on a build-time flag or a strapping pin.
+- A reliable framed link layer (`lib/framing/`) reused across UART / SPI / I²C transports.
+- Throughput, latency, and jitter benchmarks for each transport, automated and plotted from CSV.
+- A software modem (BPSK first, optional M-FSK extension) running over a wired analog link: PWM-DAC out one board → ADC in on the other.
+- Forward error correction (Hamming(7,4) baseline, optional convolutional + Viterbi).
+- BER vs SNR curves produced by injecting Gaussian noise in software at the receiver.
+- Written-up measurement report comparing protocols and modem configurations.
+
+## Hardware requirements
+
+- 2× NUCLEO-F411RE (already on hand).
+- Jumper wires + a small breadboard.
+- For DSP analog link: 1× RC low-pass filter (10kΩ + 10nF) per board, optionally 1× MCP4921 SPI DAC for higher fidelity (~$2).
+- For I²C: 2× 4.7 kΩ pull-up resistors to 3.3 V.
+- Logic analyser (optional but useful — Saleae or similar).
+
+## Reusable middleware (`lib/`)
+
+| Library | Purpose |
+|---|---|
+| `lib/framing/` | HDLC-style framing, CRC-16, ACK/NACK, sequence numbers (shared with Plan 001) |
+| `lib/link/` | Transport-agnostic link layer — submit/receive frames, callbacks, stats |
+| `lib/dsp/` | FIR, IIR, FFT wrappers around CMSIS-DSP; raised-cosine filter; matched filter |
+| `lib/modem/` | Symbol mapper/demapper, frame sync, timing recovery, AGC |
+| `lib/fec/` | Hamming(7,4); optional Viterbi for K=7 convolutional code |
+| `lib/channel/` | AWGN noise injector (host + on-target) for BER experiments |
+
+## Apps (`apps/comms/`, `apps/dsp/`)
+
+| App | Role | Purpose |
+|---|---|---|
+| `comms/uart_pingpong` | A & B | Latency / throughput baseline over UART |
+| `comms/spi_pingpong` | A=master, B=slave | Same, over SPI; requires SPI slave driver |
+| `comms/i2c_pingpong` | A=master, B=slave | Same, over I²C; requires I²C master + slave drivers |
+| `comms/bench_runner` | A | Runs a sweep across protocols and rates, emits CSV over UART |
+| `dsp/modem_tx` | A | Generate symbols, pulse-shape, output via PWM-DAC |
+| `dsp/modem_rx` | B | Sample via ADC+DMA, AGC, matched filter, sync, demap |
+| `dsp/loopback_test` | single board | Self-test with internal connection (sanity check before wiring boards) |
+
+## Host tools (`tools/`)
+
+| Tool | Purpose |
+|---|---|
+| `bench_plot.py` | Read CSV from `bench_runner`, plot throughput/latency/jitter |
+| `ber_plot.py` | Sweep SNR, collect BER samples, plot curves |
+| `iq_dump.py` | Receive on-target IQ snapshots over UART, plot constellation |
+
+## Phases
+
+Each phase is one issue / one PR. Phases assume Plan 000 has landed.
+
+---
+
+### Sub-track A — Inter-board comms
+
+#### Phase 2.1 — Two-board test fixture
+
+**Scope:**
+- Document wiring on the wiki: which pins, which jumpers, ground-loop avoidance
+- Build-time macro `BOARD_NODE=A|B` plumbed through `Makefile.common`
+- Both boards run the same firmware image with role chosen at boot from a strapping pin (USER button held at reset = node B)
+- Update HIL infrastructure: `run_hil_tests.py` learns to flash either board; `mcp_hil_server.py` gains a `board` parameter
+- A trivial app that prints its role to UART, used to verify the fixture
+
+**Validation:** Both boards report correct role from independent serial captures.
+
+#### Phase 2.2 — `lib/framing/` reliable frame layer
+
+**Scope:**
+- HDLC-style byte-stuffing (0x7E flag, 0x7D escape)
+- CRC-16-CCITT (reuse hardware CRC driver where available)
+- ACK/NACK with sequence numbers, sliding window of 1
+- Timeout + retransmit, configurable per transport
+- Pure-host unit tests for the encoder/decoder
+
+**Validation:** Host tests cover frame round-trip, corruption, lost ACK, duplicate detection. ≥95% line coverage.
+
+#### Phase 2.3 — UART ping-pong app + benchmark
+
+**Scope:**
+- `apps/comms/uart_pingpong`: sends N-byte frame, awaits echo, measures RTT
+- Sweep frame size and baud rate
+- Emit CSV: `transport,baud,frame_size,throughput_kbps,rtt_us_p50,rtt_us_p99,error_count`
+- HIL test asserts throughput and error rate are within tolerance
+
+**Validation:** RTT < 5 ms at 115200 baud / 64-byte frames. Zero CRC errors over 1M frames.
+
+#### Phase 2.4 — SPI slave driver + ping-pong
+
+**Scope:**
+- Extend the SPI driver: slave mode with NSS hardware control + RX/TX DMA
+- New driver host tests for slave configuration paths
+- `apps/comms/spi_pingpong`: A=master clocks the link; B=slave responds
+- Compare achievable throughput at 1, 5, 10 MHz SPI clock
+
+**Validation:** SPI clock up to 10 MHz with no CRC errors at the framing layer. CSV output matches UART format.
+
+#### Phase 2.5 — I²C master + slave driver (closes Issue #66)
+
+**Scope:**
+- Implement I²C master: 7-bit addressing, repeated-start, polled and DMA flavours
+- Implement I²C slave: address-match interrupt, RX/TX DMA, clock-stretching
+- Full host tests for both
+- `apps/comms/i2c_pingpong` at 100 kHz, 400 kHz, 1 MHz (Fast Mode Plus if pads support it)
+
+**Validation:** 1 MHz I²C with pull-ups; CRC errors zero over 1M frames. CSV emitted.
+
+#### Phase 2.6 — Bench runner + plotting
+
+**Scope:**
+- `apps/comms/bench_runner`: sweeps all three transports automatically, dumps CSV
+- `tools/bench_plot.py`: matplotlib plots — throughput vs payload size, latency CDFs
+- Wiki page summarising findings
+
+**Validation:** Benchmark report committed under `docs/wiki/plans/002-comms/results-comms.md`.
+
+---
+
+### Sub-track B — DSP baseband
+
+#### Phase 2.7 — Vendor CMSIS-DSP, basic filters
+
+**Scope:**
+- Add CMSIS-DSP as a 3rd-party submodule
+- `lib/dsp/`: thin wrappers for `arm_fir_f32`, `arm_biquad_cascade_df1_f32`, `arm_rfft_fast_f32`
+- Host tests with reference signals (impulse, sinewave, chirp) and Python-generated golden outputs
+- A loopback app that runs an FIR and reports cycles/sample using the cycle counter
+
+**Validation:** Filter outputs match reference within 1e-5 relative error. Cycle counts logged as baseline.
+
+#### Phase 2.8 — Analog link fixture
+
+**Scope:**
+- Wire PWM output of board A through an RC low-pass filter into the ADC input of board B (and vice versa for full-duplex)
+- Document the filter cutoff vs PWM carrier choice
+- Self-test app: board A outputs a sinewave via PWM-DAC, board B captures via ADC+DMA, sends samples back over UART
+- `tools/iq_dump.py` plots the captured waveform vs the original
+
+**Validation:** Captured sine matches generated sine in frequency and amplitude (with documented attenuation).
+
+Optional upgrade later: replace PWM+RC with an MCP4921 SPI DAC for cleaner output.
+
+#### Phase 2.9 — `lib/modem/` BPSK transmit
+
+**Scope:**
+- Bit → symbol mapper (BPSK: 0→-1, 1→+1)
+- Root-raised-cosine pulse shaping (β=0.35), upsample
+- Buffer + DMA out via PWM (or SPI DAC if installed)
+- `apps/dsp/modem_tx`: transmit a known PRBS sequence at chosen symbol rate
+- Pure host tests for the symbol mapper and pulse-shaping kernel against Python references
+
+**Validation:** Transmit waveform matches Python-generated reference (captured by `iq_dump.py`).
+
+#### Phase 2.10 — `lib/modem/` BPSK receive
+
+**Scope:**
+- ADC+DMA capture
+- AGC (slow-loop scalar gain)
+- Matched filter (root-raised-cosine, mirrored)
+- Mueller-and-Müller timing recovery
+- Frame sync via known preamble (Barker-13 or m-sequence)
+- Symbol slicer; demap to bits
+- `apps/dsp/modem_rx`: locks to TX, reports BER over a known PRBS
+
+**Validation:** BER < 1e-4 with no injected noise on the wired link.
+
+#### Phase 2.11 — FEC: Hamming(7,4)
+
+**Scope:**
+- `lib/fec/hamming74.{c,h}` — pure functions, encode + decode-with-correct
+- Host tests with exhaustive 4-bit input space + single-bit error injection
+- Modem TX/RX wired to use FEC; toggle on/off via command-line flag
+
+**Validation:** With FEC on, single-bit errors corrected. BER drops as expected.
+
+#### Phase 2.12 — Channel model + BER curves
+
+**Scope:**
+- `lib/channel/awgn.c` — add Gaussian noise to received samples in software, controlled SNR
+- `dsp/modem_rx` gains a noise-injection mode (post-ADC, pre-AGC)
+- `tools/ber_plot.py` sweeps SNR, runs N frames per point, emits BER vs SNR plot
+- Compare measured curve to theoretical BPSK + Hamming(7,4) curve
+
+**Validation:** Measured BER curve within ~1 dB of theory at BER=1e-3.
+
+#### Phase 2.13 — (Optional) Convolutional + Viterbi
+
+**Scope:**
+- K=7, rate-1/2 convolutional encoder
+- Soft-decision Viterbi decoder (CMSIS-DSP fixed point)
+- BER curve comparison: uncoded vs Hamming vs Viterbi
+- Document on-target decode throughput (samples/sec)
+
+**Validation:** Viterbi recovers ~5 dB coding gain at BER=1e-4 vs uncoded.
+
+#### Phase 2.14 — Measurement report
+
+**Scope:**
+- `docs/wiki/plans/002-dsp/results-dsp.md` — final write-up
+- Plots: TX waveform, RX constellation (1-D for BPSK), BER curves uncoded vs FEC variants
+- Honest tradeoff discussion: PWM-DAC vs SPI-DAC, where the implementation hits Cortex-M4 limits
+
+**Validation:** Doc review; cross-link from architecture page.
+
+---
+
+## Risk & rollback
+
+- **SPI/I²C slave drivers** are new territory — slave mode is materially more complex than master (clock stretching, NSS edge cases). Allocate buffer for surprises in Phases 2.4 and 2.5.
+- **PWM-DAC quality** may limit modem performance. The plan accepts this; if it bottlenecks the BER experiments, swap to MCP4921 — covered as an optional upgrade in Phase 2.8.
+- **CMSIS-DSP size** is significant. Confirm flash budget early; LTO + dead-code elimination should keep only used kernels.
+- **Two-board HIL** complicates the runner. Plan 2.1 must fully resolve flash-and-test for both boards before any later phase relies on it.
+- **Wiring stability** — bad connections will look like protocol bugs. Document a "wiring sanity check" first-thing-to-do for any debug session.
+
+## Out of scope
+
+- Wireless RF — wired only. No SDR, no RF frontend, no antenna.
+- QAM beyond QPSK — BPSK first, M-FSK or QPSK as optional extensions.
+- LDPC, Turbo codes — Hamming and Viterbi are sufficient to teach the methodology.
+- Bluetooth / WiFi / LoRa via external modules — that's a different project.

--- a/docs/wiki/plans/index.md
+++ b/docs/wiki/plans/index.md
@@ -1,0 +1,18 @@
+# Project Plans
+
+Multi-phase project plans. Each plan is a track of related work that spans many issues / PRs. Each plan's phases are sized as individual GitHub issues; the plan doc itself is the durable design + scope record.
+
+## Active plans
+
+| # | Title | Status | Tracking issue |
+|---|---|---|---|
+| 000 | [Repository refactor for multi-track work](000-repo-refactor.md) | proposed | _(to file)_ |
+| 001 | [Bootloader & embedded security](001-bootloader-and-security.md) | proposed | _(to file)_ |
+| 002 | [Inter-board comms + DSP baseband](002-comms-and-dsp-baseband.md) | proposed | _(to file)_ |
+
+## Convention
+
+- One markdown file per plan, prefixed with a 3-digit number. Numbers are stable; do not renumber.
+- Each plan has: **Why**, **End-state vision**, **Phases** (each one issue), **Risk & rollback**, **Out of scope**.
+- A plan stays here for life; once finished, status becomes `done` and the doc remains as historical reference.
+- Each plan gets a single **tracking issue** in GitHub with a checklist of phase issues. Phase issues are filed as needed, not all up front.

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -1,5 +1,15 @@
 # Roadmap
 
+## Long-Term Tracks
+
+Detailed multi-phase plans live in [plans/](plans/index.md).
+
+| # | Track | Status |
+|---|---|---|
+| 000 | [Repository refactor](plans/000-repo-refactor.md) — `examples/` → `apps/`, add `lib/` and `tools/` | proposed (prerequisite for 001 and 002) |
+| 001 | [Bootloader & embedded security](plans/001-bootloader-and-security.md) — custom bootloader, ECDSA-signed images, OTA, A/B slots, anti-rollback, RDP | proposed |
+| 002 | [Inter-board comms + DSP baseband](plans/002-comms-and-dsp-baseband.md) — UART/SPI/I²C link benchmarks + BPSK modem over wired analog link | proposed |
+
 ## Open Issues by Priority
 
 ### Driver Development
@@ -26,8 +36,10 @@
 
 ## Suggested Priority Order
 
-1. Remaining drivers (#66, #67, #68, #70, #71, #72)
-2. Examples (#14, #16, #22, #45) driven by driver availability
+1. **Plan 000** — Repository refactor (unblocks both new tracks)
+2. Remaining drivers (#66, #67, #68, #70, #71, #72) — `#71` and `#66` are also prerequisites for Plans 001 and 002 respectively
+3. Plans 001 and 002 — pursued in parallel where they don't share files
+4. Examples (#14, #16, #22, #45) driven by driver availability
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `docs/wiki/plans/` with three multi-phase project plans (000 refactor, 001 bootloader/security, 002 comms+DSP baseband).
- Wires the plans into `docs/wiki/index.md` and `docs/wiki/roadmap.md`.
- Establishes the convention: plan doc = durable design record; one tracking issue per plan = live checklist of phase issues filed lazily.

## Plans

| # | Topic | Phases |
|---|---|---|
| 000 | Repository refactor — `examples/` → `apps/`, `lib/`, `tools/`, per-app linker | 5 |
| 001 | Bootloader + ECDSA-signed images + OTA + A/B slots + anti-rollback + RDP | 11 |
| 002 | Two-board comms (UART/SPI/I²C) + BPSK modem with FEC over a wired analog link | 14 |

## Tracking issues

- Closes #135
- Tracking issues filed: #136 (Plan 000), #137 (Plan 001), #138 (Plan 002)

## Test plan

- [x] `make test` — all 19 host suites pass
- [x] `make all` — all firmware examples build clean
- [x] CI: host-tests passes
- [x] CI: firmware-build passes
- [x] CI: hil-tests passes (no code changes, expected pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)