### PR TITLE
Fix blink_simple: missing systick_init() (#140)

### DIFF
--- a/examples/basic/blink_simple.c
+++ b/examples/basic/blink_simple.c
@@ -4,6 +4,7 @@
 int main(void)
 {
     led2_init();
+    systick_init();
 
     while(1)
     {


### PR DESCRIPTION
## Summary
- `delay_ms()` requires the SysTick counter to be running; `blink_simple` never called `systick_init()`, so the LED did not blink at the documented interval.
- Add `systick_init()` immediately after `led2_init()` in `main()`.

Closes #140.

## Test plan
- [x] `make EXAMPLE=blink_simple` builds clean.
- [x] Flash to NUCLEO and confirm LED2 toggles at the expected interval.
- [x] No HIL test changes — the existing SysTick HIL coverage already validates the underlying API.