### PR TITLE
Plan 001: track phases as individual issues (#137)

### DIFF
--- a/docs/wiki/plans/001-bootloader-and-security.md
+++ b/docs/wiki/plans/001-bootloader-and-security.md
@@ -1,7 +1,7 @@
 # Plan 001 — Bootloader & Embedded Security Track
 
-**Status:** proposed
-**Tracking issue:** _(to be filed)_
+**Status:** in progress
+**Tracking issue:** [#137](https://github.com/ViniBR01/stm32-bare-metal/issues/137)
 **Depends on:** [Plan 000 — Repository Refactor](000-repo-refactor.md)
 
 ## Why
@@ -53,9 +53,13 @@ Each phase is one issue / one PR. Phases assume Plan 000 has landed.
 
 ### Phase 1.1 — Internal flash driver (Issue #71)
 
-Already on the roadmap; required prerequisite. Adds `drivers/src/flash.c` with sector erase, word/halfword/byte program, lock/unlock, BSY polling. Host tests use the existing fake-stub pattern.
+**Status:** done — landed in PR #132 as part of #71. The planned `lib/flash/` middleware (slot erase wrapper, atomic metadata commit, sector-range validator) has been folded into Phase 1.7, where the abstractions are first actually exercised.
+
+Adds `drivers/src/flash.c` with sector erase, word/halfword/byte program, lock/unlock, BSY polling. Host tests use the existing fake-stub pattern.
 
 ### Phase 1.2 — Image header & metadata format
+
+**Status:** filed — [#143](https://github.com/ViniBR01/stm32-bare-metal/issues/143)
 
 **Scope:**
 - Define `lib/img/img_header.h`: magic, version, size, SHA-256, ECDSA signature, image type
@@ -66,6 +70,8 @@ Already on the roadmap; required prerequisite. Adds `drivers/src/flash.c` with s
 **Validation:** Host tests cover header round-trip, malformed inputs, boundary values.
 
 ### Phase 1.3 — Crypto primitives in `lib/crypto/`
+
+**Status:** filed — [#144](https://github.com/ViniBR01/stm32-bare-metal/issues/144)
 
 **Scope:**
 - Vendor micro-ecc (single C file, MIT license)
@@ -110,6 +116,7 @@ Already on the roadmap; required prerequisite. Adds `drivers/src/flash.c` with s
 ### Phase 1.7 — A/B slots and fallback
 
 **Scope:**
+- `lib/flash/` middleware (absorbed from former Phase 1.1 scope): slot-erase wrapper, atomic metadata commit primitive, sector-range validator
 - Slot metadata in dedicated sector with active flag, fail counter
 - Bootloader picks active slot, increments fail counter before jump, app must clear it after init (rollback-on-crash)
 - If active slot verify fails, try the other slot; if both fail, halt with diagnostics

--- a/docs/wiki/plans/index.md
+++ b/docs/wiki/plans/index.md
@@ -6,9 +6,9 @@ Multi-phase project plans. Each plan is a track of related work that spans many 
 
 | # | Title | Status | Tracking issue |
 |---|---|---|---|
-| 000 | [Repository refactor for multi-track work](000-repo-refactor.md) | proposed | _(to file)_ |
-| 001 | [Bootloader & embedded security](001-bootloader-and-security.md) | proposed | _(to file)_ |
-| 002 | [Inter-board comms + DSP baseband](002-comms-and-dsp-baseband.md) | proposed | _(to file)_ |
+| 000 | [Repository refactor for multi-track work](000-repo-refactor.md) | landed | [#136](https://github.com/ViniBR01/stm32-bare-metal/issues/136) |
+| 001 | [Bootloader & embedded security](001-bootloader-and-security.md) | in progress | [#137](https://github.com/ViniBR01/stm32-bare-metal/issues/137) |
+| 002 | [Inter-board comms + DSP baseband](002-comms-and-dsp-baseband.md) | proposed | [#138](https://github.com/ViniBR01/stm32-bare-metal/issues/138) |
 
 ## Convention
 


### PR DESCRIPTION
## Summary

- Files the first wave of Plan 001 phase issues: #143 (Phase 1.2 — image header & metadata format) and #144 (Phase 1.3 — crypto primitives in `lib/crypto/`). Both are host-only and can proceed in parallel.
- Marks Phase 1.1 done (covered by #71 / PR #132). The originally planned `lib/flash/` middleware (slot erase, atomic metadata commit, sector-range validator) is folded into Phase 1.7, where it's first exercised by A/B slot management.
- Updates the master tracking issue #137 checklist with status and per-phase issue links, and refreshes `docs/wiki/plans/index.md` to reflect that Plan 000 has landed and Plan 001 is in progress.
- Subsequent phases (1.4+) will be filed lazily as work begins, matching the convention in `docs/wiki/plans/index.md`.

## Test plan

- [x] `make test` passes (host unit tests)
- [x] `make all` passes (all firmware apps build)
- [x] CI host-tests, firmware-build, hil-tests jobs green
- [x] #137 body shows Phase 1.1 ticked and #143/#144 referenced
- [x] #143 and #144 each link back to #137 and to the matching plan-doc section