### PR TITLE
Plan 001 Phase 1.2: Image header & metadata format (#143)

### DIFF
--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -36,6 +36,7 @@ Multi-phase project plans. Each plan's phases are sized as individual GitHub iss
 | [plans/index.md](plans/index.md) | Plans index — convention and active plans |
 | [plans/000-repo-refactor.md](plans/000-repo-refactor.md) | Repository refactor — renamed `examples/` → `apps/`, added `lib/` and `tools/`, per-app linker scripts (landed) |
 | [plans/001-bootloader-and-security.md](plans/001-bootloader-and-security.md) | Bootloader, image signing, OTA, A/B slots, anti-rollback, RDP |
+| [plans/001-bootloader/image-format.md](plans/001-bootloader/image-format.md) | Plan 001 Phase 1.2 — image header & slot metadata on-flash format, CRC-32 spec, parser API |
 | [plans/002-comms-and-dsp-baseband.md](plans/002-comms-and-dsp-baseband.md) | Two-board comms (UART/SPI/I²C) + software BPSK modem with FEC |
 
 ## Decisions

--- a/docs/wiki/plans/001-bootloader-and-security.md
+++ b/docs/wiki/plans/001-bootloader-and-security.md
@@ -69,6 +69,8 @@ Adds `drivers/src/flash.c` with sector erase, word/halfword/byte program, lock/u
 
 **Validation:** Host tests cover header round-trip, malformed inputs, boundary values.
 
+See [image-format.md](001-bootloader/image-format.md).
+
 ### Phase 1.3 — Crypto primitives in `lib/crypto/`
 
 **Status:** filed — [#144](https://github.com/ViniBR01/stm32-bare-metal/issues/144)

--- a/docs/wiki/plans/001-bootloader/image-format.md
+++ b/docs/wiki/plans/001-bootloader/image-format.md
@@ -1,0 +1,149 @@
+# Plan 001 — Image Header & Slot Metadata Format
+
+**Phase:** 1.2
+**Status:** landed (via Issue [#143](https://github.com/ViniBR01/stm32-bare-metal/issues/143))
+**Implementation:** `lib/img/`
+**Tests:** `tests/lib/img/`
+
+## Purpose
+
+Defines the on-flash binary layout that the host signing tool writes and the
+bootloader reads, and the slot-metadata layout the A/B fallback logic uses.
+Phase 1.2 lands the format and a host-validated parser only — the SHA-256 and
+ECDSA signature fields are populated with placeholder bytes here and become
+authoritative in Phase 1.3 (`#144`, crypto primitives).
+
+The format is deliberately minimal:
+
+- Pure C (`<stdint.h>`, `<stddef.h>`, `<string.h>`) so the same parser
+  compiles for host gcc and `arm-none-eabi-gcc`.
+- Software-only CRC-32 (no STM32 hardware CRC engine), so the host signer
+  matches without special hardware.
+- `__attribute__((packed))` on the structs and `_Static_assert` on their
+  `sizeof` — any silent layout change breaks the build on both host and
+  target.
+
+## Image header — `img_header_t`
+
+Total size: **140 bytes**. Lives at the start of every signed image.
+
+| Offset | Size | Field             | Description                                                       |
+|--------|------|-------------------|-------------------------------------------------------------------|
+| 0      | 4    | `magic`           | `0x494D4748` — ASCII `"IMGH"` (little-endian).                    |
+| 4      | 4    | `header_version`  | Header format version. Currently `1`.                             |
+| 8      | 4    | `image_version`   | Monotonic firmware version. Used by Phase 1.9 anti-rollback.      |
+| 12     | 4    | `image_type`      | `1 = IMG_TYPE_BOOTLOADER`, `2 = IMG_TYPE_APP`.                    |
+| 16     | 4    | `payload_size`    | Bytes of payload after the header.                                |
+| 20     | 4    | `payload_offset`  | Bytes from header start to payload start. Must be ≥ 140.          |
+| 24     | 32   | `sha256`          | SHA-256 of payload. Placeholder until Phase 1.3.                  |
+| 56     | 64   | `signature`       | ECDSA P-256 signature, raw `R \|\| S`. Placeholder until Phase 1.3. |
+| 120    | 16   | `reserved[4]`     | Reserved for future use. Parser accepts any value.                |
+| 136    | 4    | `header_crc`      | CRC-32 over bytes `[0, 136)`.                                     |
+
+## Slot metadata — `img_slot_metadata_t`
+
+Total size: **36 bytes**. Lives in a dedicated metadata sector per slot, **not**
+embedded in the image. Phase 1.7 uses it for A/B fallback; Phase 1.9 uses
+`monotonic_counter` for anti-rollback.
+
+| Offset | Size | Field                | Description                                                    |
+|--------|------|----------------------|----------------------------------------------------------------|
+| 0      | 4    | `magic`              | `0x534C4F54` — ASCII `"SLOT"` (little-endian).                 |
+| 4      | 4    | `metadata_version`   | Currently `1`.                                                 |
+| 8      | 4    | `active`             | Non-zero = active slot.                                        |
+| 12     | 4    | `fail_count`         | Bootloader increments before jump; app clears after init.      |
+| 16     | 4    | `monotonic_counter`  | Anti-rollback floor (Phase 1.9).                               |
+| 20     | 12   | `reserved[3]`        | Reserved for future use. Parser accepts any value.             |
+| 32     | 4    | `metadata_crc`       | CRC-32 over bytes `[0, 32)`.                                   |
+
+## CRC-32 algorithm
+
+Standard IEEE 802.3 / zlib CRC-32, software-only. Spec sufficient for an
+independent (e.g. Python) signer to match byte-for-byte:
+
+| Property      | Value                |
+|---------------|----------------------|
+| Polynomial    | `0xEDB88320` (reflected of `0x04C11DB7`) |
+| Initial value | `0xFFFFFFFF`         |
+| Reflect input | yes (LSB-first)      |
+| Reflect output| yes                  |
+| Final XOR     | `0xFFFFFFFF`         |
+
+Reference vector: `CRC32("123456789") == 0xCBF43926`. Implementation in
+`lib/img/src/img_header.c` is bytewise (no precomputed table) — header and
+metadata CRCs cover ≤ 140 bytes, so the table cost would not pay back the
+bootloader-sector flash budget.
+
+The `header_crc` / `metadata_crc` fields cover every preceding byte in the
+struct, in raw flash order.
+
+## Magic values
+
+| Constant                   | Hex value     | ASCII   |
+|----------------------------|---------------|---------|
+| `IMG_HEADER_MAGIC`         | `0x494D4748`  | `IMGH`  |
+| `IMG_SLOT_METADATA_MAGIC`  | `0x534C4F54`  | `SLOT`  |
+
+Both are stored little-endian, so the byte sequence on flash is `48 47 4D 49`
+("HGMI" if you read raw bytes left-to-right) for `IMGH`, etc.
+
+## Parser API
+
+```c
+img_err_t img_header_parse(const uint8_t *buf, size_t buf_len, img_header_t *out);
+img_err_t img_slot_metadata_parse(const uint8_t *buf, size_t buf_len,
+                                  img_slot_metadata_t *out);
+uint32_t  img_crc32(const uint8_t *buf, size_t len);
+```
+
+### Validation order (first failure wins)
+
+For `img_header_parse`:
+
+1. NULL `buf` or `out` → `IMG_ERR_NULL_ARG`.
+2. `buf_len < sizeof(img_header_t)` → `IMG_ERR_BAD_SIZE`.
+3. Trailing CRC does not match recomputed CRC over preceding bytes → `IMG_ERR_BAD_CRC`.
+4. `magic != IMG_HEADER_MAGIC` → `IMG_ERR_BAD_MAGIC`.
+5. `header_version != 1` → `IMG_ERR_BAD_VERSION`.
+6. `image_type` not in `{1, 2}` → `IMG_ERR_BAD_TYPE`.
+7. `payload_offset < sizeof(img_header_t)` → `IMG_ERR_BAD_OFFSET`.
+8. `payload_size == 0` → `IMG_ERR_BAD_SIZE`.
+
+For `img_slot_metadata_parse`:
+
+1. NULL args → `IMG_ERR_NULL_ARG`.
+2. Buffer too small → `IMG_ERR_BAD_SIZE`.
+3. CRC mismatch → `IMG_ERR_BAD_CRC`.
+4. Bad magic → `IMG_ERR_BAD_MAGIC`.
+5. `metadata_version != 1` → `IMG_ERR_BAD_VERSION`.
+
+CRC is checked before magic because a corrupted-flash header that *happens* to
+look like a valid magic must not be parsed; the integrity check has to gate
+field interpretation. Tests `test_header_bad_magic` /
+`test_metadata_bad_magic` recompute the CRC after tampering specifically to
+exercise the magic check.
+
+### Error codes
+
+| Code                  | Value | Meaning                                                  |
+|-----------------------|-------|----------------------------------------------------------|
+| `IMG_OK`              |  0    | Parsed and validated.                                    |
+| `IMG_ERR_BAD_MAGIC`   | -1    | Magic field does not match expected value.               |
+| `IMG_ERR_BAD_VERSION` | -2    | Header / metadata version is not the supported value.    |
+| `IMG_ERR_BAD_TYPE`    | -3    | `image_type` is not a known enum.                        |
+| `IMG_ERR_BAD_SIZE`    | -4    | Buffer too small or payload size invalid.                |
+| `IMG_ERR_BAD_OFFSET`  | -5    | Payload offset overlaps the header.                      |
+| `IMG_ERR_BAD_CRC`     | -6    | CRC over preceding bytes does not match trailing field.  |
+| `IMG_ERR_NULL_ARG`    | -7    | A required pointer is NULL.                              |
+
+## Future work
+
+- Phase 1.3 (#144): replace placeholder SHA-256 / signature bytes with real
+  values produced by `lib/crypto/`.
+- Phase 1.4: host signer (`tools/sign_image.py`) writes this exact format,
+  cross-validated against the CRC-32 reference vector and against the parser
+  here.
+- Phase 1.7: slot metadata becomes load-bearing for A/B fallback. The
+  `reserved[3]` words are an intentional cushion for that phase.
+- Phase 1.9: anti-rollback uses `image_version` (image header) and
+  `monotonic_counter` (slot metadata).

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -15,7 +15,7 @@ include ../Makefile.common
 # Subdirectories — each is a single middleware library.
 # Add a new lib by creating lib/<name>/{Makefile,inc,src} and listing it here.
 #==============================================================================
-SUBDIRS := skeleton
+SUBDIRS := skeleton img
 
 #==============================================================================
 # Build rules

--- a/lib/img/Makefile
+++ b/lib/img/Makefile
@@ -1,0 +1,58 @@
+#==============================================================================
+# Image Header / Slot Metadata Library Makefile
+#
+# Defines on-flash image header and slot metadata structures plus a pure-C
+# parser. Host-validated, target-usable. Mirrors lib/skeleton/Makefile.
+#==============================================================================
+
+# Module name for identification
+MODULE_NAME := lib_img
+
+# Default target
+.DEFAULT_GOAL := all
+
+# Include common definitions
+include ../../Makefile.common
+
+#==============================================================================
+# Local directories
+#==============================================================================
+LOCAL_SRC_DIR := src
+LOCAL_INC_DIR := inc
+LOCAL_BUILD_DIR := $(BUILD_DIR)/lib/img
+
+#==============================================================================
+# Source files
+#==============================================================================
+LOCAL_SRCS := $(wildcard $(LOCAL_SRC_DIR)/*.c)
+LOCAL_OBJS := $(patsubst $(LOCAL_SRC_DIR)/%.c,$(LOCAL_BUILD_DIR)/%.o,$(LOCAL_SRCS))
+
+#==============================================================================
+# Target library
+#==============================================================================
+TARGET_LIB := $(LOCAL_BUILD_DIR)/libimg.a
+
+#==============================================================================
+# Build rules
+#==============================================================================
+.PHONY: all clean
+
+all: $(TARGET_LIB)
+
+# Build the img library.
+$(TARGET_LIB): $(LOCAL_OBJS)
+	$(make-build-dir)
+	@echo "Creating img library..."
+	$(AR) rcs $@ $^
+	@echo "Img library created: $@"
+
+# Compile sources.
+$(LOCAL_BUILD_DIR)/%.o: $(LOCAL_SRC_DIR)/%.c
+	$(make-build-dir)
+	@echo "Compiling img: $<"
+	$(CC) $(CFLAGS) -I$(LOCAL_INC_DIR) -o $@ $<
+
+# Clean local build artifacts.
+clean:
+	@echo "Cleaning img..."
+	@rm -rf $(LOCAL_BUILD_DIR)

--- a/lib/img/inc/img_header.h
+++ b/lib/img/inc/img_header.h
@@ -1,0 +1,128 @@
+#ifndef LIB_IMG_HEADER_H
+#define LIB_IMG_HEADER_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * On-flash image header and slot metadata format. These structs are written
+ * verbatim by the host signing tool and parsed verbatim by the bootloader, so
+ * their layout must be deterministic across host gcc and arm-none-eabi-gcc.
+ *
+ * `__attribute__((packed))` is used so no implicit padding is ever inserted,
+ * even if a future field is added with a non-aligned size. All current fields
+ * are naturally 4-byte aligned, so there is no unaligned-access penalty on
+ * Cortex-M4. Sizes are also pinned with _Static_assert below.
+ */
+
+/* "IMGH" in ASCII, little-endian. */
+#define IMG_HEADER_MAGIC          0x494D4748u
+
+/* "SLOT" in ASCII, little-endian. */
+#define IMG_SLOT_METADATA_MAGIC   0x534C4F54u
+
+/* Header format version. Bump on incompatible changes. */
+#define IMG_HEADER_VERSION        1u
+#define IMG_SLOT_METADATA_VERSION 1u
+
+/* Image type enum values. Stored as a uint32_t in the header. */
+#define IMG_TYPE_BOOTLOADER       1u
+#define IMG_TYPE_APP              2u
+
+#define IMG_SHA256_SIZE           32
+#define IMG_SIGNATURE_SIZE        64  /* ECDSA P-256 raw R||S, 32 + 32 bytes. */
+
+typedef struct __attribute__((packed)) {
+    uint32_t magic;            /* IMG_HEADER_MAGIC */
+    uint32_t header_version;   /* IMG_HEADER_VERSION */
+    uint32_t image_version;    /* monotonic firmware version (anti-rollback) */
+    uint32_t image_type;       /* IMG_TYPE_BOOTLOADER | IMG_TYPE_APP */
+    uint32_t payload_size;     /* bytes of payload following the header */
+    uint32_t payload_offset;   /* bytes from header start to payload start */
+    uint8_t  sha256[IMG_SHA256_SIZE];
+    uint8_t  signature[IMG_SIGNATURE_SIZE];
+    uint32_t reserved[4];
+    uint32_t header_crc;       /* CRC-32 over all preceding header bytes */
+} img_header_t;
+
+typedef struct __attribute__((packed)) {
+    uint32_t magic;             /* IMG_SLOT_METADATA_MAGIC */
+    uint32_t metadata_version;  /* IMG_SLOT_METADATA_VERSION */
+    uint32_t active;            /* non-zero = active slot */
+    uint32_t fail_count;        /* bootloader increments before jump */
+    uint32_t monotonic_counter; /* anti-rollback floor */
+    uint32_t reserved[3];
+    uint32_t metadata_crc;      /* CRC-32 over all preceding bytes */
+} img_slot_metadata_t;
+
+/*
+ * Pin the on-flash sizes. If any future change to the structs perturbs the
+ * layout, these asserts fail at compile time on both host and target.
+ *   header  : 6*4 + 32 + 64 + 4*4 + 4 = 140 bytes
+ *   metadata: 5*4 + 3*4 + 4         =  36 bytes
+ */
+_Static_assert(sizeof(img_header_t) == 140,
+               "img_header_t must be exactly 140 bytes on flash");
+_Static_assert(sizeof(img_slot_metadata_t) == 36,
+               "img_slot_metadata_t must be exactly 36 bytes on flash");
+
+typedef enum {
+    IMG_OK              = 0,
+    IMG_ERR_BAD_MAGIC   = -1,
+    IMG_ERR_BAD_VERSION = -2,
+    IMG_ERR_BAD_TYPE    = -3,
+    IMG_ERR_BAD_SIZE    = -4,
+    IMG_ERR_BAD_OFFSET  = -5,
+    IMG_ERR_BAD_CRC     = -6,
+    IMG_ERR_NULL_ARG    = -7,
+} img_err_t;
+
+/*
+ * Parse and validate an image header from a raw byte buffer.
+ *
+ * Validation order (first failure wins):
+ *   1. NULL args            -> IMG_ERR_NULL_ARG
+ *   2. buf_len too small    -> IMG_ERR_BAD_SIZE
+ *   3. CRC mismatch         -> IMG_ERR_BAD_CRC
+ *   4. Magic mismatch       -> IMG_ERR_BAD_MAGIC
+ *   5. header_version != 1  -> IMG_ERR_BAD_VERSION
+ *   6. unknown image_type   -> IMG_ERR_BAD_TYPE
+ *   7. payload_offset < sizeof(header)  -> IMG_ERR_BAD_OFFSET
+ *      payload_size == 0                -> IMG_ERR_BAD_SIZE
+ *
+ * On success the validated struct is copied into *out.
+ */
+img_err_t img_header_parse(const uint8_t *buf, size_t buf_len, img_header_t *out);
+
+/*
+ * Parse and validate a slot metadata blob from a raw byte buffer.
+ *
+ * Validation order (first failure wins):
+ *   1. NULL args              -> IMG_ERR_NULL_ARG
+ *   2. buf_len too small      -> IMG_ERR_BAD_SIZE
+ *   3. CRC mismatch           -> IMG_ERR_BAD_CRC
+ *   4. Magic mismatch         -> IMG_ERR_BAD_MAGIC
+ *   5. metadata_version != 1  -> IMG_ERR_BAD_VERSION
+ *
+ * On success the validated struct is copied into *out.
+ */
+img_err_t img_slot_metadata_parse(const uint8_t *buf, size_t buf_len,
+                                  img_slot_metadata_t *out);
+
+/*
+ * Standard IEEE 802.3 / zlib CRC-32. Polynomial 0xEDB88320 (reflected),
+ * initial value 0xFFFFFFFF, reflected input/output, final XOR 0xFFFFFFFF.
+ * Software-only — does not use the STM32 hardware CRC engine, so the host
+ * signer can match without special hardware.
+ */
+uint32_t img_crc32(const uint8_t *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIB_IMG_HEADER_H */

--- a/lib/img/src/img_header.c
+++ b/lib/img/src/img_header.c
@@ -1,0 +1,115 @@
+#include "img_header.h"
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+/*
+ * Bytewise CRC-32, no precomputed table. Per-byte cost is 8 shift-and-XOR
+ * iterations: trivial for the host signer and acceptable for the bootloader,
+ * which only ever CRCs a 140-byte header and a 36-byte metadata blob. Keeping
+ * the implementation table-free saves ~1 KB of flash that the bootloader
+ * sector cannot afford.
+ */
+uint32_t img_crc32(const uint8_t *buf, size_t len)
+{
+    uint32_t crc = 0xFFFFFFFFu;
+
+    if (buf == NULL) {
+        return crc ^ 0xFFFFFFFFu;
+    }
+
+    for (size_t i = 0; i < len; ++i) {
+        crc ^= (uint32_t)buf[i];
+        for (int b = 0; b < 8; ++b) {
+            uint32_t mask = -(int32_t)(crc & 1u);
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+
+    return crc ^ 0xFFFFFFFFu;
+}
+
+static int image_type_is_known(uint32_t t)
+{
+    return (t == IMG_TYPE_BOOTLOADER) || (t == IMG_TYPE_APP);
+}
+
+img_err_t img_header_parse(const uint8_t *buf, size_t buf_len, img_header_t *out)
+{
+    if (buf == NULL || out == NULL) {
+        return IMG_ERR_NULL_ARG;
+    }
+    if (buf_len < sizeof(img_header_t)) {
+        return IMG_ERR_BAD_SIZE;
+    }
+
+    /*
+     * The CRC covers every byte of the header up to (but excluding) the
+     * trailing header_crc field. We compute it directly on the raw buffer so
+     * struct member ordering is the single source of truth.
+     */
+    const size_t crc_offset = sizeof(img_header_t) - sizeof(uint32_t);
+    uint32_t expected_crc;
+    memcpy(&expected_crc, buf + crc_offset, sizeof(expected_crc));
+
+    uint32_t actual_crc = img_crc32(buf, crc_offset);
+    if (actual_crc != expected_crc) {
+        return IMG_ERR_BAD_CRC;
+    }
+
+    img_header_t hdr;
+    memcpy(&hdr, buf, sizeof(hdr));
+
+    if (hdr.magic != IMG_HEADER_MAGIC) {
+        return IMG_ERR_BAD_MAGIC;
+    }
+    if (hdr.header_version != IMG_HEADER_VERSION) {
+        return IMG_ERR_BAD_VERSION;
+    }
+    if (!image_type_is_known(hdr.image_type)) {
+        return IMG_ERR_BAD_TYPE;
+    }
+    if (hdr.payload_offset < sizeof(img_header_t)) {
+        return IMG_ERR_BAD_OFFSET;
+    }
+    if (hdr.payload_size == 0) {
+        return IMG_ERR_BAD_SIZE;
+    }
+
+    *out = hdr;
+    return IMG_OK;
+}
+
+img_err_t img_slot_metadata_parse(const uint8_t *buf, size_t buf_len,
+                                  img_slot_metadata_t *out)
+{
+    if (buf == NULL || out == NULL) {
+        return IMG_ERR_NULL_ARG;
+    }
+    if (buf_len < sizeof(img_slot_metadata_t)) {
+        return IMG_ERR_BAD_SIZE;
+    }
+
+    const size_t crc_offset = sizeof(img_slot_metadata_t) - sizeof(uint32_t);
+    uint32_t expected_crc;
+    memcpy(&expected_crc, buf + crc_offset, sizeof(expected_crc));
+
+    uint32_t actual_crc = img_crc32(buf, crc_offset);
+    if (actual_crc != expected_crc) {
+        return IMG_ERR_BAD_CRC;
+    }
+
+    img_slot_metadata_t md;
+    memcpy(&md, buf, sizeof(md));
+
+    if (md.magic != IMG_SLOT_METADATA_MAGIC) {
+        return IMG_ERR_BAD_MAGIC;
+    }
+    if (md.metadata_version != IMG_SLOT_METADATA_VERSION) {
+        return IMG_ERR_BAD_VERSION;
+    }
+
+    *out = md;
+    return IMG_OK;
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS = string_utils cli gpio exti rcc timer uart systick flash iwdg crc lowpower lib/skeleton
+SUBDIRS = string_utils cli gpio exti rcc timer uart systick flash iwdg crc lowpower lib/skeleton lib/img
 
 COVERAGE_INFO = coverage.info
 COVERAGE_FILT = coverage-filtered.info
@@ -64,6 +64,10 @@ run: all
 	@echo "Running lib/skeleton tests"
 	@echo "========================================"
 	@$(MAKE) -C lib/skeleton run
+	@echo "========================================"
+	@echo "Running lib/img tests"
+	@echo "========================================"
+	@$(MAKE) -C lib/img run
 	@echo "========================================"
 	@echo "All test suites passed"
 	@echo "========================================"

--- a/tests/lib/img/Makefile
+++ b/tests/lib/img/Makefile
@@ -1,0 +1,21 @@
+CC      = gcc
+CFLAGS  = -Wall -Wextra -Wno-unknown-pragmas -Wno-unknown-warning-option \
+          -I../../../lib/img/inc \
+          -I../../../3rd_party/unity/src \
+          $(EXTRA_CFLAGS)
+
+UNITY_SRC = ../../../3rd_party/unity/src/unity.c
+IMG_SRC = ../../../lib/img/src/img_header.c
+
+.PHONY: all run clean
+
+all: test_img_header.out
+
+run: all
+	./test_img_header.out
+
+test_img_header.out: test_img_header.c $(IMG_SRC) $(UNITY_SRC)
+	$(CC) $(CFLAGS) $^ -o $@
+
+clean:
+	rm -f *.out *.gcda *.gcno

--- a/tests/lib/img/test_img_header.c
+++ b/tests/lib/img/test_img_header.c
@@ -1,0 +1,429 @@
+#include "img_header.h"
+#include "unity.h"
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/*
+ * Build a valid header into raw_buf with the trailing header_crc field
+ * computed correctly. Tests then mutate raw_buf to exercise failure paths.
+ */
+static void build_valid_header_buf(uint8_t *raw_buf, img_header_t *seed)
+{
+    seed->magic           = IMG_HEADER_MAGIC;
+    seed->header_version  = IMG_HEADER_VERSION;
+    seed->image_version   = 0x00010203u;
+    seed->image_type      = IMG_TYPE_APP;
+    seed->payload_size    = 1024u;
+    seed->payload_offset  = sizeof(img_header_t);
+
+    for (int i = 0; i < IMG_SHA256_SIZE; ++i) {
+        seed->sha256[i] = (uint8_t)i;
+    }
+    for (int i = 0; i < IMG_SIGNATURE_SIZE; ++i) {
+        seed->signature[i] = (uint8_t)(0x80u + i);
+    }
+    for (int i = 0; i < 4; ++i) {
+        seed->reserved[i] = 0;
+    }
+    seed->header_crc = 0; /* placeholder; recomputed below */
+
+    memcpy(raw_buf, seed, sizeof(img_header_t));
+
+    const size_t crc_offset = sizeof(img_header_t) - sizeof(uint32_t);
+    uint32_t crc = img_crc32(raw_buf, crc_offset);
+    memcpy(raw_buf + crc_offset, &crc, sizeof(crc));
+    seed->header_crc = crc;
+}
+
+static void build_valid_metadata_buf(uint8_t *raw_buf, img_slot_metadata_t *seed)
+{
+    seed->magic             = IMG_SLOT_METADATA_MAGIC;
+    seed->metadata_version  = IMG_SLOT_METADATA_VERSION;
+    seed->active            = 1u;
+    seed->fail_count        = 0u;
+    seed->monotonic_counter = 7u;
+    for (int i = 0; i < 3; ++i) {
+        seed->reserved[i] = 0;
+    }
+    seed->metadata_crc = 0;
+
+    memcpy(raw_buf, seed, sizeof(img_slot_metadata_t));
+
+    const size_t crc_offset = sizeof(img_slot_metadata_t) - sizeof(uint32_t);
+    uint32_t crc = img_crc32(raw_buf, crc_offset);
+    memcpy(raw_buf + crc_offset, &crc, sizeof(crc));
+    seed->metadata_crc = crc;
+}
+
+/* ---------- CRC-32 ---------- */
+
+void test_crc32_known_vector_123456789(void)
+{
+    /* Standard reference: CRC-32 of "123456789" = 0xCBF43926. */
+    const uint8_t v[] = "123456789";
+    TEST_ASSERT_EQUAL_HEX32(0xCBF43926u, img_crc32(v, sizeof(v) - 1));
+}
+
+void test_crc32_empty_buffer_is_zero(void)
+{
+    /* CRC-32 of zero-length input is 0 (init XOR final XOR cancel out). */
+    const uint8_t v[1] = {0};
+    TEST_ASSERT_EQUAL_HEX32(0x00000000u, img_crc32(v, 0));
+}
+
+/* ---------- Header round-trip ---------- */
+
+void test_header_round_trip(void)
+{
+    uint8_t raw[sizeof(img_header_t)];
+    img_header_t seed;
+    build_valid_header_buf(raw, &seed);
+
+    img_header_t out;
+    memset(&out, 0, sizeof(out));
+
+    TEST_ASSERT_EQUAL_INT(IMG_OK, img_header_parse(raw, sizeof(raw), &out));
+    TEST_ASSERT_EQUAL_HEX32(IMG_HEADER_MAGIC, out.magic);
+    TEST_ASSERT_EQUAL_UINT32(IMG_HEADER_VERSION, out.header_version);
+    TEST_ASSERT_EQUAL_UINT32(seed.image_version, out.image_version);
+    TEST_ASSERT_EQUAL_UINT32(IMG_TYPE_APP, out.image_type);
+    TEST_ASSERT_EQUAL_UINT32(seed.payload_size, out.payload_size);
+    TEST_ASSERT_EQUAL_UINT32(seed.payload_offset, out.payload_offset);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(seed.sha256, out.sha256, IMG_SHA256_SIZE);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(seed.signature, out.signature, IMG_SIGNATURE_SIZE);
+    TEST_ASSERT_EQUAL_UINT32(seed.header_crc, out.header_crc);
+}
+
+void test_header_accepts_bootloader_type(void)
+{
+    uint8_t raw[sizeof(img_header_t)];
+    img_header_t seed;
+    build_valid_header_buf(raw, &seed);
+
+    /* Override image_type to BOOTLOADER and recompute the CRC. */
+    uint32_t bootloader_type = IMG_TYPE_BOOTLOADER;
+    memcpy(raw + offsetof(img_header_t, image_type), &bootloader_type,
+           sizeof(bootloader_type));
+    const size_t crc_offset = sizeof(img_header_t) - sizeof(uint32_t);
+    uint32_t crc = img_crc32(raw, crc_offset);
+    memcpy(raw + crc_offset, &crc, sizeof(crc));
+
+    img_header_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_OK, img_header_parse(raw, sizeof(raw), &out));
+    TEST_ASSERT_EQUAL_UINT32(IMG_TYPE_BOOTLOADER, out.image_type);
+}
+
+/* ---------- Header failure paths ---------- */
+
+void test_header_buffer_too_small(void)
+{
+    uint8_t raw[sizeof(img_header_t)];
+    img_header_t seed;
+    build_valid_header_buf(raw, &seed);
+
+    img_header_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_BAD_SIZE,
+                          img_header_parse(raw, sizeof(img_header_t) - 1, &out));
+}
+
+void test_header_zero_length_buffer(void)
+{
+    uint8_t raw[sizeof(img_header_t)];
+    img_header_t seed;
+    build_valid_header_buf(raw, &seed);
+
+    img_header_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_BAD_SIZE, img_header_parse(raw, 0, &out));
+}
+
+void test_header_bad_magic(void)
+{
+    uint8_t raw[sizeof(img_header_t)];
+    img_header_t seed;
+    build_valid_header_buf(raw, &seed);
+
+    /* Replace magic, then recompute the CRC so we reach the magic check. */
+    uint32_t bogus = 0xDEADBEEFu;
+    memcpy(raw, &bogus, sizeof(bogus));
+    const size_t crc_offset = sizeof(img_header_t) - sizeof(uint32_t);
+    uint32_t crc = img_crc32(raw, crc_offset);
+    memcpy(raw + crc_offset, &crc, sizeof(crc));
+
+    img_header_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_BAD_MAGIC,
+                          img_header_parse(raw, sizeof(raw), &out));
+}
+
+void test_header_bad_version_zero(void)
+{
+    uint8_t raw[sizeof(img_header_t)];
+    img_header_t seed;
+    build_valid_header_buf(raw, &seed);
+
+    uint32_t bad = 0u;
+    memcpy(raw + offsetof(img_header_t, header_version), &bad, sizeof(bad));
+    const size_t crc_offset = sizeof(img_header_t) - sizeof(uint32_t);
+    uint32_t crc = img_crc32(raw, crc_offset);
+    memcpy(raw + crc_offset, &crc, sizeof(crc));
+
+    img_header_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_BAD_VERSION,
+                          img_header_parse(raw, sizeof(raw), &out));
+}
+
+void test_header_bad_version_99(void)
+{
+    uint8_t raw[sizeof(img_header_t)];
+    img_header_t seed;
+    build_valid_header_buf(raw, &seed);
+
+    uint32_t bad = 99u;
+    memcpy(raw + offsetof(img_header_t, header_version), &bad, sizeof(bad));
+    const size_t crc_offset = sizeof(img_header_t) - sizeof(uint32_t);
+    uint32_t crc = img_crc32(raw, crc_offset);
+    memcpy(raw + crc_offset, &crc, sizeof(crc));
+
+    img_header_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_BAD_VERSION,
+                          img_header_parse(raw, sizeof(raw), &out));
+}
+
+void test_header_bad_image_type(void)
+{
+    uint8_t raw[sizeof(img_header_t)];
+    img_header_t seed;
+    build_valid_header_buf(raw, &seed);
+
+    uint32_t bad = 0xFFu;
+    memcpy(raw + offsetof(img_header_t, image_type), &bad, sizeof(bad));
+    const size_t crc_offset = sizeof(img_header_t) - sizeof(uint32_t);
+    uint32_t crc = img_crc32(raw, crc_offset);
+    memcpy(raw + crc_offset, &crc, sizeof(crc));
+
+    img_header_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_BAD_TYPE,
+                          img_header_parse(raw, sizeof(raw), &out));
+}
+
+void test_header_zero_image_type(void)
+{
+    uint8_t raw[sizeof(img_header_t)];
+    img_header_t seed;
+    build_valid_header_buf(raw, &seed);
+
+    uint32_t bad = 0u;
+    memcpy(raw + offsetof(img_header_t, image_type), &bad, sizeof(bad));
+    const size_t crc_offset = sizeof(img_header_t) - sizeof(uint32_t);
+    uint32_t crc = img_crc32(raw, crc_offset);
+    memcpy(raw + crc_offset, &crc, sizeof(crc));
+
+    img_header_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_BAD_TYPE,
+                          img_header_parse(raw, sizeof(raw), &out));
+}
+
+void test_header_payload_offset_too_small(void)
+{
+    uint8_t raw[sizeof(img_header_t)];
+    img_header_t seed;
+    build_valid_header_buf(raw, &seed);
+
+    /* offset less than the header itself overlaps the header. */
+    uint32_t bad = (uint32_t)(sizeof(img_header_t) - 1);
+    memcpy(raw + offsetof(img_header_t, payload_offset), &bad, sizeof(bad));
+    const size_t crc_offset = sizeof(img_header_t) - sizeof(uint32_t);
+    uint32_t crc = img_crc32(raw, crc_offset);
+    memcpy(raw + crc_offset, &crc, sizeof(crc));
+
+    img_header_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_BAD_OFFSET,
+                          img_header_parse(raw, sizeof(raw), &out));
+}
+
+void test_header_zero_payload_size(void)
+{
+    uint8_t raw[sizeof(img_header_t)];
+    img_header_t seed;
+    build_valid_header_buf(raw, &seed);
+
+    uint32_t bad = 0u;
+    memcpy(raw + offsetof(img_header_t, payload_size), &bad, sizeof(bad));
+    const size_t crc_offset = sizeof(img_header_t) - sizeof(uint32_t);
+    uint32_t crc = img_crc32(raw, crc_offset);
+    memcpy(raw + crc_offset, &crc, sizeof(crc));
+
+    img_header_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_BAD_SIZE,
+                          img_header_parse(raw, sizeof(raw), &out));
+}
+
+void test_header_tampered_byte_fails_crc(void)
+{
+    uint8_t raw[sizeof(img_header_t)];
+    img_header_t seed;
+    build_valid_header_buf(raw, &seed);
+
+    /* Flip one byte deep in the signature region. CRC must catch it. */
+    raw[offsetof(img_header_t, signature) + 5] ^= 0xA5u;
+
+    img_header_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_BAD_CRC,
+                          img_header_parse(raw, sizeof(raw), &out));
+}
+
+void test_header_null_buf(void)
+{
+    img_header_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_NULL_ARG,
+                          img_header_parse(NULL, sizeof(img_header_t), &out));
+}
+
+void test_header_null_out(void)
+{
+    uint8_t raw[sizeof(img_header_t)];
+    img_header_t seed;
+    build_valid_header_buf(raw, &seed);
+
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_NULL_ARG,
+                          img_header_parse(raw, sizeof(raw), NULL));
+}
+
+/* ---------- Slot metadata round-trip ---------- */
+
+void test_metadata_round_trip(void)
+{
+    uint8_t raw[sizeof(img_slot_metadata_t)];
+    img_slot_metadata_t seed;
+    build_valid_metadata_buf(raw, &seed);
+
+    img_slot_metadata_t out;
+    memset(&out, 0, sizeof(out));
+
+    TEST_ASSERT_EQUAL_INT(IMG_OK,
+                          img_slot_metadata_parse(raw, sizeof(raw), &out));
+    TEST_ASSERT_EQUAL_HEX32(IMG_SLOT_METADATA_MAGIC, out.magic);
+    TEST_ASSERT_EQUAL_UINT32(IMG_SLOT_METADATA_VERSION, out.metadata_version);
+    TEST_ASSERT_EQUAL_UINT32(seed.active, out.active);
+    TEST_ASSERT_EQUAL_UINT32(seed.fail_count, out.fail_count);
+    TEST_ASSERT_EQUAL_UINT32(seed.monotonic_counter, out.monotonic_counter);
+    TEST_ASSERT_EQUAL_UINT32(seed.metadata_crc, out.metadata_crc);
+}
+
+/* ---------- Slot metadata failure paths ---------- */
+
+void test_metadata_buffer_too_small(void)
+{
+    uint8_t raw[sizeof(img_slot_metadata_t)];
+    img_slot_metadata_t seed;
+    build_valid_metadata_buf(raw, &seed);
+
+    img_slot_metadata_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_BAD_SIZE,
+                          img_slot_metadata_parse(raw,
+                                                  sizeof(img_slot_metadata_t) - 1,
+                                                  &out));
+}
+
+void test_metadata_bad_magic(void)
+{
+    uint8_t raw[sizeof(img_slot_metadata_t)];
+    img_slot_metadata_t seed;
+    build_valid_metadata_buf(raw, &seed);
+
+    uint32_t bogus = 0xCAFEBABEu;
+    memcpy(raw, &bogus, sizeof(bogus));
+    const size_t crc_offset = sizeof(img_slot_metadata_t) - sizeof(uint32_t);
+    uint32_t crc = img_crc32(raw, crc_offset);
+    memcpy(raw + crc_offset, &crc, sizeof(crc));
+
+    img_slot_metadata_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_BAD_MAGIC,
+                          img_slot_metadata_parse(raw, sizeof(raw), &out));
+}
+
+void test_metadata_bad_version(void)
+{
+    uint8_t raw[sizeof(img_slot_metadata_t)];
+    img_slot_metadata_t seed;
+    build_valid_metadata_buf(raw, &seed);
+
+    uint32_t bad = 99u;
+    memcpy(raw + offsetof(img_slot_metadata_t, metadata_version), &bad,
+           sizeof(bad));
+    const size_t crc_offset = sizeof(img_slot_metadata_t) - sizeof(uint32_t);
+    uint32_t crc = img_crc32(raw, crc_offset);
+    memcpy(raw + crc_offset, &crc, sizeof(crc));
+
+    img_slot_metadata_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_BAD_VERSION,
+                          img_slot_metadata_parse(raw, sizeof(raw), &out));
+}
+
+void test_metadata_tampered_byte_fails_crc(void)
+{
+    uint8_t raw[sizeof(img_slot_metadata_t)];
+    img_slot_metadata_t seed;
+    build_valid_metadata_buf(raw, &seed);
+
+    raw[offsetof(img_slot_metadata_t, fail_count)] ^= 0x55u;
+
+    img_slot_metadata_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_BAD_CRC,
+                          img_slot_metadata_parse(raw, sizeof(raw), &out));
+}
+
+void test_metadata_null_buf(void)
+{
+    img_slot_metadata_t out;
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_NULL_ARG,
+                          img_slot_metadata_parse(NULL,
+                                                  sizeof(img_slot_metadata_t),
+                                                  &out));
+}
+
+void test_metadata_null_out(void)
+{
+    uint8_t raw[sizeof(img_slot_metadata_t)];
+    img_slot_metadata_t seed;
+    build_valid_metadata_buf(raw, &seed);
+
+    TEST_ASSERT_EQUAL_INT(IMG_ERR_NULL_ARG,
+                          img_slot_metadata_parse(raw, sizeof(raw), NULL));
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    /* CRC */
+    RUN_TEST(test_crc32_known_vector_123456789);
+    RUN_TEST(test_crc32_empty_buffer_is_zero);
+    /* Header */
+    RUN_TEST(test_header_round_trip);
+    RUN_TEST(test_header_accepts_bootloader_type);
+    RUN_TEST(test_header_buffer_too_small);
+    RUN_TEST(test_header_zero_length_buffer);
+    RUN_TEST(test_header_bad_magic);
+    RUN_TEST(test_header_bad_version_zero);
+    RUN_TEST(test_header_bad_version_99);
+    RUN_TEST(test_header_bad_image_type);
+    RUN_TEST(test_header_zero_image_type);
+    RUN_TEST(test_header_payload_offset_too_small);
+    RUN_TEST(test_header_zero_payload_size);
+    RUN_TEST(test_header_tampered_byte_fails_crc);
+    RUN_TEST(test_header_null_buf);
+    RUN_TEST(test_header_null_out);
+    /* Metadata */
+    RUN_TEST(test_metadata_round_trip);
+    RUN_TEST(test_metadata_buffer_too_small);
+    RUN_TEST(test_metadata_bad_magic);
+    RUN_TEST(test_metadata_bad_version);
+    RUN_TEST(test_metadata_tampered_byte_fails_crc);
+    RUN_TEST(test_metadata_null_buf);
+    RUN_TEST(test_metadata_null_out);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

- Adds `lib/img/` middleware: 140-byte `img_header_t` and 36-byte `img_slot_metadata_t` packed structs (with `_Static_assert` size pins), plus a pure-C parser that validates buffer size, CRC-32 (IEEE 802.3 / zlib, software-only), magic, version, image type, and payload sanity.
- Wires the new lib into `lib/Makefile` and `tests/Makefile`; 23 new Unity host tests exercise round-trip and every failure path including a single-byte tamper caught by the CRC.
- Documents the on-flash layout, CRC spec, parser API, and error codes in `docs/wiki/plans/001-bootloader/image-format.md`; cross-linked from the plan and from the wiki index.

## Test plan

- [x] `make test` — 14 suites, 532 host tests, 0 failures (lib/img contributes 23 new tests)
- [x] `make all` — `cli_simple` firmware builds clean with `arm-none-eabi-gcc` (lib/img compiles for ARM)
- [x] CI `host-tests` job green
- [x] CI `firmware-build` job green

Closes #143.
Part of Plan 001 (#137).