### PR TITLE
Plan 001: mark Phases 1.2/1.3 done, file Phase 1.4 (#137)

### DIFF
--- a/docs/wiki/plans/001-bootloader-and-security.md
+++ b/docs/wiki/plans/001-bootloader-and-security.md
@@ -59,7 +59,7 @@ Adds `drivers/src/flash.c` with sector erase, word/halfword/byte program, lock/u
 
 ### Phase 1.2 — Image header & metadata format
 
-**Status:** filed — [#143](https://github.com/ViniBR01/stm32-bare-metal/issues/143)
+**Status:** done — landed in PR [#146](https://github.com/ViniBR01/stm32-bare-metal/pull/146) for [#143](https://github.com/ViniBR01/stm32-bare-metal/issues/143).
 
 **Scope:**
 - Define `lib/img/img_header.h`: magic, version, size, SHA-256, ECDSA signature, image type
@@ -73,7 +73,7 @@ See [image-format.md](001-bootloader/image-format.md).
 
 ### Phase 1.3 — Crypto primitives in `lib/crypto/`
 
-**Status:** filed — [#144](https://github.com/ViniBR01/stm32-bare-metal/issues/144)
+**Status:** done — landed in PR [#147](https://github.com/ViniBR01/stm32-bare-metal/pull/147) for [#144](https://github.com/ViniBR01/stm32-bare-metal/issues/144). Algorithm decision: stay with ECDSA-P256; on-target verify time to be measured in Phase 1.6 against the <500 ms budget.
 
 **Scope:**
 - Vendor micro-ecc (single C file, MIT license)
@@ -85,6 +85,8 @@ See [image-format.md](001-bootloader/image-format.md).
 **Validation:** Host tests pass FIPS vectors; ECDSA verify completes in <500 ms on a 100 MHz F411 (measured later in HIL).
 
 ### Phase 1.4 — Host tooling: `keygen.py`, `sign_image.py`
+
+**Status:** filed — [#148](https://github.com/ViniBR01/stm32-bare-metal/issues/148)
 
 **Scope:**
 - `keygen.py`: generate P-256 keypair, emit `bootloader_pubkey.c` with `const uint8_t pubkey[64]`


### PR DESCRIPTION
## Summary

- Marks Phase 1.2 ([#143](https://github.com/ViniBR01/stm32-bare-metal/issues/143)) and Phase 1.3 ([#144](https://github.com/ViniBR01/stm32-bare-metal/issues/144)) done in the plan doc, with PR back-links to [#146](https://github.com/ViniBR01/stm32-bare-metal/pull/146) and [#147](https://github.com/ViniBR01/stm32-bare-metal/pull/147).
- Files Phase 1.4 ([#148](https://github.com/ViniBR01/stm32-bare-metal/issues/148)) — host tooling for `keygen.py` / `sign_image.py`, which depends on the now-landed `lib/img` and `lib/crypto`.
- Master tracking issue [#137](https://github.com/ViniBR01/stm32-bare-metal/issues/137) updated separately to tick 1.2/1.3 and reference #148.

## Test plan

- [x] `make test` passes
- [x] `make all` passes
- [x] CI host-tests, firmware-build, hil-tests jobs green
- [x] [#137](https://github.com/ViniBR01/stm32-bare-metal/issues/137) checklist shows 1.2 and 1.3 ticked, with 1.4 referencing #148