### PR TITLE
Plan 001: mark Phase 1.4 done, file Phase 1.5 (#137)

### DIFF
--- a/docs/wiki/plans/001-bootloader-and-security.md
+++ b/docs/wiki/plans/001-bootloader-and-security.md
@@ -86,7 +86,7 @@ See [image-format.md](001-bootloader/image-format.md).
 
 ### Phase 1.4 — Host tooling: `keygen.py`, `sign_image.py`
 
-**Status:** filed — [#148](https://github.com/ViniBR01/stm32-bare-metal/issues/148)
+**Status:** done — landed in PR [#150](https://github.com/ViniBR01/stm32-bare-metal/pull/150) for [#148](https://github.com/ViniBR01/stm32-bare-metal/issues/148). Three-way verification (micro-ecc round-trip, Python `cryptography`, OpenSSL `pkeyutl`) confirmed cross-language compatibility.
 
 **Scope:**
 - `keygen.py`: generate P-256 keypair, emit `bootloader_pubkey.c` with `const uint8_t pubkey[64]`
@@ -99,6 +99,8 @@ See [image-format.md](001-bootloader/image-format.md).
 See [signing.md](001-bootloader/signing.md).
 
 ### Phase 1.5 — Bootloader skeleton (no crypto yet)
+
+**Status:** filed — [#151](https://github.com/ViniBR01/stm32-bare-metal/issues/151)
 
 **Scope:**
 - New `apps/bootloader/loader/` with `linker/bootloader_ls.ld` (16 KB at 0x08000000)


### PR DESCRIPTION
## Summary

- Marks Phase 1.4 ([#148](https://github.com/ViniBR01/stm32-bare-metal/issues/148)) done in the plan doc with a back-link to PR [#150](https://github.com/ViniBR01/stm32-bare-metal/pull/150).
- Files Phase 1.5 ([#151](https://github.com/ViniBR01/stm32-bare-metal/issues/151)) — bootloader skeleton + jump-to-app. First on-target step in Plan 001; introduces \`apps/bootloader/loader/\`, the bootloader and app linker scripts (\`linker/bootloader_ls.ld\`, \`linker/app_ls.ld\`), and a signed \`app_blinky_signed\` to validate the bootloader→app jump path on real hardware. Signature verification is deliberately deferred to Phase 1.6.
- Master tracking issue [#137](https://github.com/ViniBR01/stm32-bare-metal/issues/137) updated separately to tick 1.4 and reference #151.

## Test plan

- [x] \`make test\` passes
- [x] \`make all\` passes
- [x] CI host-tests, firmware-build, hil-tests jobs green
- [x] [#137](https://github.com/ViniBR01/stm32-bare-metal/issues/137) checklist shows 1.4 ticked, with 1.5 referencing #151