### PR TITLE
Plan 001 Phase 1.7: A/B slots + verify-fail fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,3 +148,19 @@ jobs:
           path: verify-results.xml
           reporter: java-junit
           fail-on-error: false
+
+      # Plan 001 Phase 1.7 — A/B slot fallback test.  Builds slot-A
+      # and slot-B variants of app_blinky_signed, drives the chip
+      # through four scenarios (clean A, clean B, A bad fallback to B,
+      # both bad halt), and asserts the bootloader log lines.
+      - name: Run A/B slot test
+        run: python3 scripts/run_ab_slot_test.py --board ci --timeout 25 --junit-xml ab-slot-results.xml
+
+      - name: Publish A/B slot test results
+        uses: dorny/test-reporter@v3
+        if: always()
+        with:
+          name: A/B Slot Test
+          path: ab-slot-results.xml
+          reporter: java-junit
+          fail-on-error: false

--- a/Makefile.common
+++ b/Makefile.common
@@ -97,10 +97,20 @@ CFLAGS := $(CFLAGS_BASE) $(COMMON_INCLUDES) -DLOG_LEVEL=$(LOG_LEVEL) $(HIL_TEST_
 # expansion so a later override of LDSCRIPT takes effect at link time.
 LDSCRIPT ?= $(LINKER_DIR)/app_ls.ld
 
-# Default slot base.  Phase 1.7 will introduce a slot-B build that overrides
-# this.  The value is forwarded to the linker as a --defsym so app_ls.ld
-# can compute the FLASH ORIGIN.
-SLOT_BASE ?= 0x08010000
+# Slot selector + base address.  Set SLOT=B to build for slot B; default is A.
+# The value is forwarded to the linker as a --defsym so app_ls.ld can compute
+# FLASH ORIGIN, and embedded into output paths so A and B builds don't
+# clobber each other.
+SLOT      ?= A
+ifeq ($(SLOT),A)
+  SLOT_BASE   ?= 0x08010000
+  SLOT_SUFFIX :=
+else ifeq ($(SLOT),B)
+  SLOT_BASE   ?= 0x08040000
+  SLOT_SUFFIX := _b
+else
+  $(error SLOT must be A or B, got '$(SLOT)')
+endif
 
 # Linker flags
 LDFLAGS = $(MCU_FLAGS) -flto -T $(LDSCRIPT) -Wl,--gc-sections \
@@ -117,6 +127,7 @@ UTILS_LIB := $(BUILD_DIR)/utils/libutils.a
 UNITY_ARM_LIB := $(BUILD_DIR)/3rd_party/libunity_arm.a
 IMG_LIB := $(BUILD_DIR)/lib/img/libimg.a
 CRYPTO_LIB := $(BUILD_DIR)/lib/crypto/libcrypto.a
+FLASH_LIB := $(BUILD_DIR)/lib/flash/libflash.a
 
 #==============================================================================
 # Plan 001 signing artifacts
@@ -182,5 +193,6 @@ clean-module:
 export CC CP OD SZ AR
 export MCU_FLAGS CFLAGS LDFLAGS LDSCRIPT
 export ROOT_DIR BUILD_DIR HIL_TEST LIB_DIR
-export DRIVERS_LIB STARTUP_OBJ PRINTF_LIB LOG_C_LIB UTILS_LIB UNITY_ARM_LIB IMG_LIB CRYPTO_LIB
+export DRIVERS_LIB STARTUP_OBJ PRINTF_LIB LOG_C_LIB UTILS_LIB UNITY_ARM_LIB IMG_LIB CRYPTO_LIB FLASH_LIB
 export KEYS_DIR KEY_SEED DEV_PRIV BL_PUBKEY_C
+export SLOT SLOT_BASE SLOT_SUFFIX

--- a/apps/bootloader/app_blinky_signed/Makefile
+++ b/apps/bootloader/app_blinky_signed/Makefile
@@ -21,15 +21,14 @@ include ../../../Makefile.common
 # Slot-A linker script
 #==============================================================================
 LDSCRIPT := $(LINKER_DIR)/app_ls.ld
-SLOT_BASE ?= 0x08010000
 LDFLAGS  += -Wl,--defsym=SLOT_BASE=$(SLOT_BASE)
 
-LOCAL_BUILD_DIR := $(BUILD_DIR)/apps/bootloader/app_blinky_signed
+LOCAL_BUILD_DIR := $(BUILD_DIR)/apps/bootloader/app_blinky_signed$(SLOT_SUFFIX)
 
 OBJ  := $(LOCAL_BUILD_DIR)/main.o
-ELF  := $(LOCAL_BUILD_DIR)/app_blinky_signed.elf
-BIN  := $(LOCAL_BUILD_DIR)/app_blinky_signed.bin
-SBIN := $(LOCAL_BUILD_DIR)/app_blinky_signed.signed.bin
+ELF  := $(LOCAL_BUILD_DIR)/app_blinky_signed$(SLOT_SUFFIX).elf
+BIN  := $(LOCAL_BUILD_DIR)/app_blinky_signed$(SLOT_SUFFIX).bin
+SBIN := $(LOCAL_BUILD_DIR)/app_blinky_signed$(SLOT_SUFFIX).signed.bin
 
 DEPS := $(DRIVERS_LIB) $(STARTUP_OBJ)
 

--- a/apps/bootloader/loader/Makefile
+++ b/apps/bootloader/loader/Makefile
@@ -33,12 +33,18 @@ LOCAL_BUILD_DIR := $(BUILD_DIR)/apps/bootloader/loader
 LOADER_SRCS := main.c $(BL_PUBKEY_C)
 LOADER_OBJS := $(LOCAL_BUILD_DIR)/main.o $(LOCAL_BUILD_DIR)/bootloader_pubkey.o
 
-# Bootloader-specific includes: lib/img (header parser) + lib/crypto (Phase 1.6).
-LOADER_CFLAGS := -I$(LIB_DIR)/img/inc -I$(LIB_DIR)/crypto/inc
+# Bootloader-specific includes:
+#   lib/img    — header + slot metadata parser
+#   lib/crypto — SHA-256 + ECDSA verify (Phase 1.6)
+#   lib/flash  — slot-id constants only (Phase 1.7); the bootloader links
+#                no flash mutation code, just the address constants from
+#                the public header.
+LOADER_CFLAGS := -I$(LIB_DIR)/img/inc -I$(LIB_DIR)/crypto/inc -I$(LIB_DIR)/flash/inc
 
 # CRYPTO_LIB ahead of IMG_LIB so the linker resolves crypto symbols first
 # inside the start-group; IMG_LIB does not depend on crypto, so order is
-# only meaningful for predictability.
+# only meaningful for predictability.  No FLASH_LIB — the bootloader uses
+# only inlined constants from flash_slot.h, not any libflash.a symbols.
 LOADER_DEPS := $(CRYPTO_LIB) $(IMG_LIB) $(DRIVERS_LIB) $(STARTUP_OBJ)
 
 .PHONY: all clean help bootloader

--- a/apps/bootloader/loader/main.c
+++ b/apps/bootloader/loader/main.c
@@ -1,12 +1,23 @@
 /*
- * Bootloader — Plan 001 Phase 1.5 (skeleton) + Phase 1.6 (verify-and-jump).
+ * Bootloader — Plan 001 Phase 1.5 (skeleton) + 1.6 (verify) + 1.7 (A/B + fallback).
  *
- * Lives in sector 0 (0x08000000, 16 KB).  After parsing the slot-A
- * img_header_t (lib/img), Phase 1.6 computes SHA-256 over the payload,
- * compares it constant-time against hdr.sha256, then verifies an
- * ECDSA-P256 signature against the bootloader_pubkey baked into this
- * image at link time.  Verify time is captured with the DWT cycle counter
- * and logged on success.  Any failure halts; slot-B fallback is Phase 1.7.
+ * Lives in sector 0 (0x08000000, 16 KB).  Boot flow:
+ *
+ *   1. Read both slot-metadata blobs (sectors 1 and 2).  Pick the active
+ *      slot:
+ *        - exactly one active + CRC valid     → that slot
+ *        - both active                        → higher monotonic_counter
+ *        - neither / both invalid             → default to A
+ *   2. Verify the active slot's image (header parse + SHA-256 + ECDSA).
+ *      On failure, fall back to the other slot and verify it.
+ *   3. If both slots fail verify, halt with a distinct log line.
+ *   4. Otherwise jump.
+ *
+ * Phase 1.6's verify call is invoked unchanged from a small wrapper —
+ * Phase 1.7 only adds the slot-pick + retry around it.  fail_count and
+ * monotonic_counter live in the metadata struct but the bootloader does
+ * not yet write them; that lands with rollback-on-crash semantics in a
+ * later phase together with Phase 1.9 anti-rollback.
  */
 
 #include <stdint.h>
@@ -15,22 +26,12 @@
 #include "stm32f4xx.h"
 
 #include "crypto.h"
+#include "flash_slot.h"
 #include "img_header.h"
 #include "led2.h"
 #include "uart.h"
 
-/*
- * Public key emitted by tools/keygen.py into $(BL_PUBKEY_C) and compiled
- * into this image.  The matching private key signs every app the bootloader
- * is asked to verify.  See Makefile.common's `keys` target.
- */
 extern const uint8_t bootloader_pubkey[CRYPTO_ECDSA_P256_PUBKEY_LEN];
-
-/*
- * Slot A starts at sector 4 (0x08010000).  The signed image lives there:
- * 140-byte img_header_t followed by the raw payload (vector table + code).
- */
-#define SLOT_A_BASE  0x08010000u
 
 /* Fixed-buffer console — no printf, no DMA: keeps sector-0 footprint tiny. */
 static void uart_print(const char *s)
@@ -53,10 +54,9 @@ static void uart_print_hex32(uint32_t v)
     uart_print(buf);
 }
 
-/* Decimal print for a uint32_t — used by the verify-time log line. */
 static void uart_print_dec32(uint32_t v)
 {
-    char buf[11];  /* 4294967295 fits in 10 digits + NUL */
+    char buf[11];
     int  i = (int)sizeof(buf) - 1;
     buf[i--] = '\0';
     if (v == 0) {
@@ -68,6 +68,11 @@ static void uart_print_dec32(uint32_t v)
         }
     }
     uart_print(&buf[i + 1]);
+}
+
+static const char *slot_name(flash_slot_id_t s)
+{
+    return (s == FLASH_SLOT_A) ? "A" : "B";
 }
 
 /* Slow blink + halt.  Visible failure mode for a stuck rig. */
@@ -105,49 +110,107 @@ static void __attribute__((noreturn)) jump_to_app(uint32_t app_base)
     __asm volatile ("cpsie i");
     ((void (*)(void))app_reset)();
 
-    /* Unreachable. */
     for (;;) { }
 }
 
-int main(void)
+/*
+ * Read the metadata blob for `slot`.  Returns 1 if the parse succeeded
+ * (the buffer was a valid img_slot_metadata_t with matching magic, CRC,
+ * version), 0 otherwise.  An all-0xFF (erased) sector counts as
+ * "invalid" because the CRC will never match.
+ */
+/*
+ * The bootloader uses just the slot-base / metadata-address constants
+ * from lib/flash, not any of its mutation code, so we resolve them
+ * inline rather than linking libflash.a into sector 0.
+ */
+static uint32_t slot_base_inline(flash_slot_id_t s)
 {
-    /* SystemInit (called from Reset_Handler before main) already brought
-     * the system clock up to 100 MHz from HSI via PLL.  Calling rcc_init
-     * a second time would attempt to clear PLLON while PLL is the active
-     * sysclk source — the chip stalls in that combination — so we just
-     * bring up USART2 here. */
-    uart_init();
+    return (s == FLASH_SLOT_A) ? FLASH_SLOT_A_BASE : FLASH_SLOT_B_BASE;
+}
 
-    uart_print("\r\nBL: stm32-bare-metal bootloader (Phase 1.6)\r\n");
+static uint32_t slot_metadata_inline(flash_slot_id_t s)
+{
+    return (s == FLASH_SLOT_A) ? FLASH_SLOT_A_METADATA : FLASH_SLOT_B_METADATA;
+}
+
+static int read_slot_metadata(flash_slot_id_t slot, img_slot_metadata_t *out)
+{
+    img_err_t rc = img_slot_metadata_parse((const uint8_t *)slot_metadata_inline(slot),
+                                           sizeof(img_slot_metadata_t),
+                                           out);
+    return (rc == IMG_OK) ? 1 : 0;
+}
+
+/*
+ * Pick the active slot to verify first.
+ *
+ *   - If only one metadata blob is valid AND it has active != 0    → that slot
+ *   - If both valid AND both active                                → higher
+ *                                                                    monotonic_counter
+ *                                                                    wins (ties → A)
+ *   - If only one valid (active or not)                            → that slot
+ *   - If neither valid                                             → A (skeleton-
+ *                                                                    compatible
+ *                                                                    default)
+ */
+static flash_slot_id_t pick_active_slot(int a_ok, const img_slot_metadata_t *a,
+                                        int b_ok, const img_slot_metadata_t *b)
+{
+    if (a_ok && b_ok) {
+        if (a->active && !b->active) return FLASH_SLOT_A;
+        if (b->active && !a->active) return FLASH_SLOT_B;
+        return (b->monotonic_counter > a->monotonic_counter) ? FLASH_SLOT_B
+                                                             : FLASH_SLOT_A;
+    }
+    if (a_ok) return FLASH_SLOT_A;
+    if (b_ok) return FLASH_SLOT_B;
+    return FLASH_SLOT_A;
+}
+
+/*
+ * Run header parse + SHA-256 + ECDSA verify on `slot`.  On success, sets
+ * *app_base_out to the absolute address of the app vector table and
+ * returns IMG_OK.  Logs every step with a slot annotation so HIL can
+ * grep the path.  Returns the same img_err_t used by Phase 1.6 plus
+ * IMG_OK on full success; signature-rejection is mapped to a non-OK
+ * value (we reuse IMG_ERR_BAD_CRC since the failure means "this image
+ * cannot be trusted" and the parser already exhausts the existing
+ * codes).
+ */
+typedef enum {
+    VERIFY_OK              = 0,
+    VERIFY_FAIL_PARSE      = 1,
+    VERIFY_FAIL_TYPE       = 2,
+    VERIFY_FAIL_SHA        = 3,
+    VERIFY_FAIL_ECDSA      = 4,
+} verify_status_t;
+
+static verify_status_t verify_slot(flash_slot_id_t slot, uint32_t *app_base_out,
+                                   uint32_t *cycles_out)
+{
+    const uint32_t slot_base = slot_base_inline(slot);
 
     img_header_t hdr;
-    img_err_t rc = img_header_parse((const uint8_t *)SLOT_A_BASE,
+    img_err_t rc = img_header_parse((const uint8_t *)slot_base,
                                     sizeof(img_header_t), &hdr);
     if (rc != IMG_OK) {
-        uart_print("BL: slot A header parse failed: rc=");
+        uart_print("BL: slot ");
+        uart_print(slot_name(slot));
+        uart_print(" header parse failed: rc=");
         uart_print_hex32((uint32_t)rc);
         uart_print("\r\n");
-        bootloader_halt();
+        return VERIFY_FAIL_PARSE;
     }
 
     if (hdr.image_type != IMG_TYPE_APP) {
-        uart_print("BL: slot A image_type != APP\r\n");
-        bootloader_halt();
+        uart_print("BL: slot ");
+        uart_print(slot_name(slot));
+        uart_print(" image_type != APP\r\n");
+        return VERIFY_FAIL_TYPE;
     }
 
-    /*
-     * Phase 1.6 — verify the signed payload before jumping.
-     *
-     * 1. Compute SHA-256 over the payload region in flash.
-     * 2. Constant-time compare against hdr.sha256 (catches plain bit-flips
-     *    and short-circuits the expensive ECDSA path on a clearly tampered
-     *    image, while still hitting verify even for header-clean tampers).
-     * 3. ECDSA-P256 verify the signature against the computed digest.
-     *
-     * DWT->CYCCNT brackets the whole verify so the log captures the full
-     * cost, not just the ECDSA step.  Hard cap is 500 ms per Plan 001 §1.3.
-     */
-    const uint8_t *payload = (const uint8_t *)(SLOT_A_BASE + hdr.payload_offset);
+    const uint8_t *payload = (const uint8_t *)(slot_base + hdr.payload_offset);
 
     CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
     DWT->CYCCNT = 0;
@@ -157,29 +220,82 @@ int main(void)
     crypto_sha256(payload, hdr.payload_size, computed);
 
     if (crypto_memcmp_ct(computed, hdr.sha256, CRYPTO_SHA256_DIGEST_LEN) != 0) {
-        uart_print("BL: verify FAILED: sha mismatch\r\n");
-        bootloader_halt();
+        uart_print("BL: slot ");
+        uart_print(slot_name(slot));
+        uart_print(" verify FAILED: sha mismatch\r\n");
+        return VERIFY_FAIL_SHA;
     }
 
     if (crypto_ecdsa_p256_verify(bootloader_pubkey, computed, hdr.signature) != 1) {
-        uart_print("BL: verify FAILED: ecdsa reject\r\n");
-        bootloader_halt();
+        uart_print("BL: slot ");
+        uart_print(slot_name(slot));
+        uart_print(" verify FAILED: ecdsa reject\r\n");
+        return VERIFY_FAIL_ECDSA;
     }
 
-    uint32_t cycles = DWT->CYCCNT;
-    /* SYSCLK is 100 MHz; 100 000 cycles == 1 ms.  Verify completes in tens
-     * of millions of cycles, so neither this division nor the uint32_t
-     * format width can overflow for any realistic payload. */
-    uint32_t ms = cycles / 100000u;
+    *cycles_out = DWT->CYCCNT;
+    *app_base_out = slot_base + hdr.payload_offset;
+    return VERIFY_OK;
+}
 
-    uart_print("BL: verify ok in ");
+int main(void)
+{
+    uart_init();
+
+    uart_print("\r\nBL: stm32-bare-metal bootloader (Phase 1.7)\r\n");
+
+    /* Read both metadata blobs.  All-FF (erased) sector → parse fails →
+     * treat as "invalid" without halting; that's how a fresh chip with
+     * no metadata yet still boots slot A. */
+    img_slot_metadata_t md_a, md_b;
+    int a_ok = read_slot_metadata(FLASH_SLOT_A, &md_a);
+    int b_ok = read_slot_metadata(FLASH_SLOT_B, &md_b);
+
+    uart_print("BL: metadata A=");
+    uart_print(a_ok ? "ok" : "invalid");
+    uart_print(" B=");
+    uart_print(b_ok ? "ok" : "invalid");
+    uart_print("\r\n");
+
+    flash_slot_id_t first  = pick_active_slot(a_ok, &md_a, b_ok, &md_b);
+    flash_slot_id_t second = (first == FLASH_SLOT_A) ? FLASH_SLOT_B : FLASH_SLOT_A;
+
+    uart_print("BL: trying slot ");
+    uart_print(slot_name(first));
+    uart_print("\r\n");
+
+    uint32_t app_base = 0u;
+    uint32_t cycles   = 0u;
+
+    flash_slot_id_t winner;
+    verify_status_t st = verify_slot(first, &app_base, &cycles);
+    if (st == VERIFY_OK) {
+        winner = first;
+    } else {
+        uart_print("BL: falling back to slot ");
+        uart_print(slot_name(second));
+        uart_print("\r\n");
+        st = verify_slot(second, &app_base, &cycles);
+        if (st == VERIFY_OK) {
+            winner = second;
+        } else {
+            uart_print("BL: both slots failed verify\r\n");
+            bootloader_halt();
+        }
+    }
+
+    uint32_t ms = cycles / 100000u;
+    uart_print("BL: verify ok slot=");
+    uart_print(slot_name(winner));
+    uart_print(" in ");
     uart_print_dec32(cycles);
     uart_print(" cycles (~");
     uart_print_dec32(ms);
     uart_print(" ms)\r\n");
 
-    uint32_t app_base = SLOT_A_BASE + hdr.payload_offset;
-    uart_print("BL: jumping to slot A @ ");
+    uart_print("BL: jumping to slot ");
+    uart_print(slot_name(winner));
+    uart_print(" @ ");
     uart_print_hex32(app_base);
     uart_print("\r\n");
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -40,6 +40,7 @@ Multi-phase project plans. Each plan's phases are sized as individual GitHub iss
 | [plans/001-bootloader/signing.md](plans/001-bootloader/signing.md) | Plan 001 Phase 1.4 — host signing workflow (`keygen.py`, `sign_image.py`) |
 | [plans/001-bootloader/bootloader-skeleton.md](plans/001-bootloader/bootloader-skeleton.md) | Plan 001 Phase 1.5 — bootloader skeleton, slot-A app linker, manual flash + recovery |
 | [plans/001-bootloader/verify-and-jump.md](plans/001-bootloader/verify-and-jump.md) | Plan 001 Phase 1.6 — bootloader signature verification (SHA-256 + ECDSA-P256), DWT-timed verify, sector-0 size guard |
+| [plans/001-bootloader/ab-slots.md](plans/001-bootloader/ab-slots.md) | Plan 001 Phase 1.7 — A/B slot fallback, dual metadata sectors, lib/flash middleware, SLOT=B build knob, partition_dump.py |
 | [plans/002-comms-and-dsp-baseband.md](plans/002-comms-and-dsp-baseband.md) | Two-board comms (UART/SPI/I²C) + software BPSK modem with FEC |
 
 ## Decisions

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -4,6 +4,47 @@ Chronological record of significant changes. Newest entries at the top.
 Format: `## [YYYY-MM-DD] <type> | <title> (<PR/Issue>)`
 Types: `merge`, `decision`, `milestone`, `infra`
 
+## [2026-05-31] milestone | Plan 001 Phase 1.7 — A/B slots and fallback (#158)
+
+The bootloader now reads two slot-metadata blobs from sectors 1 and 2,
+picks an active slot using a deterministic decision tree, verifies it,
+and falls back to the other slot on any failure. If both fail, it logs
+`BL: both slots failed verify` and halts. Phase 1.6's verify call is
+reused unchanged inside a small wrapper; this phase only adds the
+slot-pick + retry around it.
+
+New `SLOT={A,B}` Makefile knob: any app linked with `app_ls.ld` can
+target either slot. Slot-B output paths carry a `_b` suffix so they
+do not clobber slot-A artefacts. `make EXAMPLE=cli_simple SLOT=B`
+produces a slot-B-linked signed image at 0x08040000.
+
+`lib/flash/` middleware lands with `flash_slot_validate_range()`
+(refuses sector-0 overlap), `flash_slot_erase()`, and
+`flash_slot_commit_metadata()` (erase-then-program-then-readback,
+power-cut-safe). 14 host unit tests cover the validators; the
+mutating helpers are exercised by the new HIL test.
+
+`tools/partition_dump.py` decodes both metadata blobs and image
+headers from a connected board (or a 512 KB flash dump). Useful for
+HIL debugging and for confirming the right slot is active after an
+OTA-style swap.
+
+`scripts/run_ab_slot_test.py` wires four HIL passes into CI:
+
+- clean A active → boots A, no fallback
+- clean B active → boots B, no fallback
+- A corrupt + active, B clean → fallback to B, app boots
+- both corrupt → halt, app never runs
+
+All four pass on the dev board with verify times ~143 ms (slot A) and
+~149 ms (slot B). loader.bin grew from 10 748 → 11 692 bytes
+(~4.5 KB headroom in sector 0).
+
+Scope cut: rollback-on-crash semantics (bootloader incrementing
+`fail_count` before each jump) deferred to land alongside Phase 1.9
+anti-rollback writes. The metadata struct already carries the field;
+the bootloader does not yet write it.
+
 ## [2026-05-31] milestone | Plan 001 Phase 1.6 — verify-and-jump (#156)
 
 Bootloader now verifies the slot-A image before jumping: SHA-256 over the

--- a/docs/wiki/plans/001-bootloader-and-security.md
+++ b/docs/wiki/plans/001-bootloader-and-security.md
@@ -131,14 +131,20 @@ See [verify-and-jump.md](001-bootloader/verify-and-jump.md).
 
 ### Phase 1.7 — A/B slots and fallback
 
+**Status:** in progress — [#158](https://github.com/ViniBR01/stm32-bare-metal/issues/158)
+
 **Scope:**
-- `lib/flash/` middleware (absorbed from former Phase 1.1 scope): slot-erase wrapper, atomic metadata commit primitive, sector-range validator
-- Slot metadata in dedicated sector with active flag, fail counter
-- Bootloader picks active slot, increments fail counter before jump, app must clear it after init (rollback-on-crash)
-- If active slot verify fails, try the other slot; if both fail, halt with diagnostics
-- `partition_dump.py` host tool to read and pretty-print
+- `lib/flash/` middleware: slot-erase wrapper, atomic metadata commit primitive, sector-range validator (refuses sector 0 overlap).
+- Slot metadata in dedicated sectors (A in sector 1, B in sector 2), each carrying `active`, `fail_count`, `monotonic_counter`.
+- Bootloader picks active slot using a deterministic decision tree (one-active wins, both-active resolves on `monotonic_counter`, neither-valid defaults to A).
+- If active slot verify fails, try the other slot; if both fail, halt with diagnostics.
+- New `SLOT={A,B}` Makefile knob: any app linked with `app_ls.ld` builds for either slot.
+- `tools/partition_dump.py` host tool to read and pretty-print metadata + headers.
+- **Deferred to a later phase:** rollback-on-crash semantics (bootloader incrementing `fail_count` before jump). The 16 KB metadata sector erase + reprogram on every boot is too costly to land alongside the slot-pick logic and is more naturally combined with Phase 1.9 anti-rollback writes.
 
 **Validation:** HIL tests for: clean A→A boot, clean B→B boot, A bad → fallback to B, both bad → halt.
+
+See [ab-slots.md](001-bootloader/ab-slots.md).
 
 ### Phase 1.8 — OTA over UART (`framing` lib + `ota_send.py`)
 

--- a/docs/wiki/plans/001-bootloader/ab-slots.md
+++ b/docs/wiki/plans/001-bootloader/ab-slots.md
@@ -1,0 +1,198 @@
+# A/B Slots and Fallback (Plan 001 Phase 1.7)
+
+This page documents the dual-slot bootloader path landed by Phase 1.7.
+Phase 1.6's verify call is reused unchanged; Phase 1.7 only adds the
+slot-pick + retry around it.
+
+## Memory map
+
+```
+0x08000000  ┌───────────────────────────────┐  Sector 0,  16 KB
+            │ Bootloader (apps/bootloader/  │     linker/bootloader_ls.ld
+            │ loader)                       │     never re-flashed by CI
+0x08004000  ├───────────────────────────────┤  Sector 1,  16 KB
+            │ Slot A metadata               │     img_slot_metadata_t (36 B)
+            │ (img_slot_metadata_t)         │     written via flash_slot_commit_metadata
+0x08008000  ├───────────────────────────────┤  Sector 2,  16 KB
+            │ Slot B metadata               │
+            │ (img_slot_metadata_t)         │
+0x0800C000  ├───────────────────────────────┤  Sector 3,  16 KB
+            │ Reserved                      │     anti-rollback log (Phase 1.9)
+0x08010000  ├───────────────────────────────┤  Sector 4,  64 KB  (slot A)
+            │ img_header_t (140 B)          │     written by sign_image.py
+            │ + payload (vectors + .text)   │     linker/app_ls.ld at SLOT_BASE
+0x08020000  ├───────────────────────────────┤  Sector 5, 128 KB  (slot A)
+            │ slot A continued              │
+0x08040000  ├───────────────────────────────┤  Sector 6, 128 KB  (slot B)
+            │ Slot B image                  │     same linker, SLOT_BASE=0x08040000
+0x08060000  ├───────────────────────────────┤  Sector 7, 128 KB
+            │ Reserved                      │
+0x08080000  └───────────────────────────────┘  end of flash (512 KB)
+```
+
+Each slot is capped at 192 KB by `__slot_size_bytes` in
+`linker/app_ls.ld`. Slot A occupies sectors 4 + 5 (192 KB exactly).
+Slot B currently occupies sector 6 (128 KB) with sector 7 reserved;
+linker caps slot-B builds at 128 KB to keep the door open for an
+anti-rollback counter or a slot-history log in the spare sector.
+
+## Slot-pick decision tree
+
+```
+read metadata A (sector 1)
+read metadata B (sector 2)
+
+A.valid && B.valid:
+   A.active && !B.active           → first = A
+   B.active && !A.active           → first = B
+   both active                     → higher monotonic_counter wins
+A.valid only                       → first = A
+B.valid only                       → first = B
+neither valid (e.g. fresh chip)    → first = A     (skeleton-compatible)
+
+second = the other slot
+
+verify(first):
+   ok                              → jump
+   fail                            → log "falling back to slot <other>"
+                                     verify(second):
+                                        ok    → jump
+                                        fail  → log "both slots failed"
+                                                halt
+```
+
+An "all-FF" (erased) metadata sector is treated as **invalid**
+because the CRC will not match. This is what Phase 1.5/1.6 hardware
+shows on the very first boot: both metadata blobs are absent, so the
+bootloader defaults to slot A — exactly the prior behaviour.
+
+## Log-line grammar
+
+| Line | Meaning |
+|---|---|
+| `BL: stm32-bare-metal bootloader (Phase 1.7)` | Bootloader started |
+| `BL: metadata A=<ok\|invalid> B=<ok\|invalid>` | Both metadata blobs read |
+| `BL: trying slot <X>` | Active slot picked, about to verify it |
+| `BL: slot <X> header parse failed: rc=0xNNNNNNNN` | Header CRC / magic / size / type failed |
+| `BL: slot <X> image_type != APP` | Image type wrong |
+| `BL: slot <X> verify FAILED: sha mismatch` | SHA-256 of payload != header.sha256 |
+| `BL: slot <X> verify FAILED: ecdsa reject` | ECDSA P-256 verify returned 0 |
+| `BL: falling back to slot <Y>` | First slot failed; trying the other |
+| `BL: verify ok slot=<X> in <N> cycles (~<M> ms)` | Success |
+| `BL: jumping to slot <X> @ 0xNNNNNNNN` | About to jump_to_app |
+| `BL: both slots failed verify` | Both slots failed — bootloader halts |
+
+`scripts/run_ab_slot_test.py` greps these lines to verify all four
+fallback scenarios on hardware.
+
+## SLOT=A / SLOT=B build knob
+
+Every app linked with `linker/app_ls.ld` accepts a slot selector:
+
+```
+make EXAMPLE=app_blinky_signed              # SLOT=A → 0x08010000
+make EXAMPLE=app_blinky_signed SLOT=B       # SLOT=B → 0x08040000
+make EXAMPLE=cli_simple SLOT=B              # any app, slot B
+```
+
+Slot-B output paths carry a `_b` suffix so they cannot clobber the
+slot-A artefacts:
+
+```
+build/apps/bootloader/app_blinky_signed/app_blinky_signed.signed.bin       (SLOT=A)
+build/apps/bootloader/app_blinky_signed_b/app_blinky_signed_b.signed.bin   (SLOT=B)
+```
+
+`SLOT_BASE`, `SLOT_SUFFIX`, and `SLOT` are exported from
+`Makefile.common` for sub-make consumption. Default behaviour
+(`SLOT=A`) is bit-identical to pre-Phase-1.7 builds.
+
+## `lib/flash` middleware
+
+Located at `lib/flash/`. The bootloader does **not** link `libflash.a`
+yet (it only reads metadata); the middleware exists for the OTA path
+that lands in Phase 1.8.
+
+| Function | Purpose |
+|---|---|
+| `flash_slot_validate_range(addr, len)` | Refuses any range overlapping sector 0 (bootloader). Foundation primitive for any caller that wants a sanity check before invoking `flash_write_*` directly. |
+| `flash_slot_erase(slot)` | Erase every sector backing the slot's payload region. |
+| `flash_slot_commit_metadata(slot, md)` | Erase the metadata sector, program a packed `img_slot_metadata_t`, read back, compare. Returns `ERR_VERIFY` on byte mismatch. |
+| `flash_slot_base_address(slot)` | Returns the absolute payload base. |
+| `flash_slot_metadata_address(slot)` | Returns the absolute metadata sector address. |
+
+Power-cut safety: `flash_slot_commit_metadata` erases first, then
+writes. An interrupt between the two leaves the sector all-0xFF, which
+the parser rejects (CRC mismatch); the bootloader falls back to the
+other slot. There is no torn-write window.
+
+Host unit tests cover the validators and address-mapping in
+`tests/lib/flash/test_flash_slot.c` (14 tests). The mutating helpers
+are exercised on real hardware by the HIL test (the host fake-flash
+buffer in `drivers/src/flash.c` covers only sector 0, which isn't
+enough to host-test slot-spanning erases).
+
+## `tools/partition_dump.py`
+
+Pretty-prints both metadata blobs and image headers from a connected
+board:
+
+```
+$ python3 tools/partition_dump.py --hla-serial 066CFF...
+=== Slot metadata ===
+  Slot A metadata @ 0x08004000
+    magic            : 0x534c4f54 ('SLOT')
+    metadata_version : 1
+    active           : 1
+    fail_count       : 0
+    monotonic_counter: 7
+    ...
+  Slot B metadata @ 0x08008000
+    INVALID: CRC mismatch
+=== Slot images ===
+  Slot A image header @ 0x08010000
+    magic            : 0x494d4748 ('IMGH')
+    image_type       : APP
+    payload_size     : 23264
+    payload sha256   : a80c41ff... (MATCH)
+  ...
+```
+
+Two backends: `--backend openocd` (default; live ST-LINK) and
+`--backend file` (offline, against a `dump_image` blob). The latter
+is handy for archiving a specific board state.
+
+## fail_count semantics — deferred
+
+The Phase 1.7 issue (#158) included a "rollback-on-crash" mechanic:
+bootloader increments `fail_count` before jump, app clears it after
+init. Implementing that in the bootloader requires a 16 KB sector
+erase + reprogram on every boot (~hundreds of milliseconds), which
+would more than triple boot time. Combined with the close coupling
+to Phase 1.9's `monotonic_counter` write, it makes more sense to
+land both in one pass.
+
+Phase 1.7 ships with `fail_count` and `monotonic_counter` already in
+the metadata struct and used by the slot-pick algorithm
+(`monotonic_counter` is the tiebreaker today), but neither is written
+by the bootloader yet. The host can pre-populate them via OpenOCD or
+`flash_slot_commit_metadata` on the device side once the OTA path
+exists.
+
+## Sector-0 budget
+
+Phase 1.6 left ~5.6 KB of headroom in the 16 KB bootloader sector.
+Phase 1.7 added the slot-pick + dual-verify path, growing
+`loader.bin` to ~11 700 bytes — about 4.5 KB of headroom remain. The
+post-link `stat` guard in
+[apps/bootloader/loader/Makefile](../../../../apps/bootloader/loader/Makefile)
+keeps this enforced.
+
+## Cross-references
+
+- Phase 1.5: [bootloader-skeleton.md](bootloader-skeleton.md) (the
+  unchanged jump path).
+- Phase 1.6: [verify-and-jump.md](verify-and-jump.md) (the per-slot
+  verify call).
+- Plan 001 overview:
+  [001-bootloader-and-security.md](../001-bootloader-and-security.md).

--- a/docs/wiki/plans/001-bootloader/bootloader-skeleton.md
+++ b/docs/wiki/plans/001-bootloader/bootloader-skeleton.md
@@ -16,8 +16,11 @@ documented here, so the boot sequence below is still accurate; only the
             │ Bootloader (apps/bootloader/  │     linker/bootloader_ls.ld
             │ loader)                       │     never re-flashed by CI
 0x08004000  ├───────────────────────────────┤  Sector 1,  16 KB
-            │ Reserved — slot metadata      │  Phase 1.7 will populate this
-0x0800C000  │ (Phase 1.7)                   │
+            │ Slot A metadata (Phase 1.7)   │  see ab-slots.md
+0x08008000  ├───────────────────────────────┤  Sector 2,  16 KB
+            │ Slot B metadata (Phase 1.7)   │
+0x0800C000  ├───────────────────────────────┤  Sector 3,  16 KB
+            │ Reserved (Phase 1.9)          │
 0x08010000  ├───────────────────────────────┤  Sector 4,  64 KB  (slot A)
             │ img_header_t (140 B)          │     written by sign_image.py
             │ ─────────────                 │
@@ -25,8 +28,10 @@ documented here, so the boot sequence below is still accurate; only the
             │ .rodata + ...                 │     ORIGIN = SLOT_BASE + 0x8C
 0x08020000  ├───────────────────────────────┤  Sector 5, 128 KB
             │ slot A continued              │
-0x08040000  ├───────────────────────────────┤  Sector 6+ (slot B in 1.7)
-            │ ...                           │
+0x08040000  ├───────────────────────────────┤  Sector 6, 128 KB  (slot B)
+            │ Slot B image (Phase 1.7)      │     same linker, SLOT_BASE override
+0x08060000  ├───────────────────────────────┤  Sector 7, 128 KB
+            │ Reserved                      │
 0x08080000  └───────────────────────────────┘  end of flash (512 KB)
 ```
 

--- a/drivers/inc/error.h
+++ b/drivers/inc/error.h
@@ -16,6 +16,7 @@ typedef enum {
     ERR_INVALID_ARG = -1,   /**< Bad parameter (NULL, out of range, etc.) */
     ERR_TIMEOUT     = -2,   /**< Hardware did not become ready in time */
     ERR_BUSY        = -3,   /**< Resource already in use / already allocated */
+    ERR_VERIFY      = -4,   /**< Read-back / integrity check did not match write */
 } err_t;
 
 #endif /* ERROR_H */

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -15,7 +15,7 @@ include ../Makefile.common
 # Subdirectories — each is a single middleware library.
 # Add a new lib by creating lib/<name>/{Makefile,inc,src} and listing it here.
 #==============================================================================
-SUBDIRS := skeleton crypto img
+SUBDIRS := skeleton crypto img flash
 
 #==============================================================================
 # Build rules

--- a/lib/flash/Makefile
+++ b/lib/flash/Makefile
@@ -1,0 +1,59 @@
+#==============================================================================
+# Slot-aware Flash Middleware Library Makefile
+#
+# Wraps drivers/src/flash.c with slot-erase / metadata-commit primitives and
+# a sector-range validator that refuses to touch the bootloader sector.
+# Mirrors lib/img/Makefile.
+#==============================================================================
+
+# Module name for identification
+MODULE_NAME := lib_flash
+
+# Default target
+.DEFAULT_GOAL := all
+
+# Include common definitions
+include ../../Makefile.common
+
+#==============================================================================
+# Local directories
+#==============================================================================
+LOCAL_SRC_DIR := src
+LOCAL_INC_DIR := inc
+LOCAL_BUILD_DIR := $(BUILD_DIR)/lib/flash
+
+#==============================================================================
+# Source files
+#==============================================================================
+LOCAL_SRCS := $(wildcard $(LOCAL_SRC_DIR)/*.c)
+LOCAL_OBJS := $(patsubst $(LOCAL_SRC_DIR)/%.c,$(LOCAL_BUILD_DIR)/%.o,$(LOCAL_SRCS))
+
+#==============================================================================
+# Target library
+#==============================================================================
+TARGET_LIB := $(LOCAL_BUILD_DIR)/libflash.a
+
+#==============================================================================
+# Build rules
+#==============================================================================
+.PHONY: all clean
+
+all: $(TARGET_LIB)
+
+# Build the slot-aware flash library.
+$(TARGET_LIB): $(LOCAL_OBJS)
+	$(make-build-dir)
+	@echo "Creating flash library..."
+	$(AR) rcs $@ $^
+	@echo "Flash library created: $@"
+
+# Compile sources.  -I$(LIB_DIR)/img/inc pulls img_slot_metadata_t in.
+$(LOCAL_BUILD_DIR)/%.o: $(LOCAL_SRC_DIR)/%.c
+	$(make-build-dir)
+	@echo "Compiling flash: $<"
+	$(CC) $(CFLAGS) -I$(LOCAL_INC_DIR) -I$(LIB_DIR)/img/inc -o $@ $<
+
+# Clean local build artifacts.
+clean:
+	@echo "Cleaning flash..."
+	@rm -rf $(LOCAL_BUILD_DIR)

--- a/lib/flash/inc/flash_slot.h
+++ b/lib/flash/inc/flash_slot.h
@@ -1,0 +1,108 @@
+/*
+ * lib/flash — slot-aware flash middleware (Plan 001 Phase 1.7).
+ *
+ * Wraps the low-level drivers/src/flash.c API with three protections that
+ * keep bootloader/slot operations safe:
+ *
+ *  - flash_slot_validate_range(): refuses any range that overlaps the
+ *    bootloader sector (sector 0).  Kept as a separate predicate so the
+ *    bootloader can call it before invoking the lower-level erase/write
+ *    primitives directly.
+ *
+ *  - flash_slot_erase(): erases the sector range backing a slot.  Knows
+ *    the SLOT_A / SLOT_B sector maps so callers cannot accidentally
+ *    pass in a number that belongs to the wrong slot or to the
+ *    metadata sector.
+ *
+ *  - flash_slot_commit_metadata(): writes a complete img_slot_metadata_t
+ *    into a freshly-erased metadata sector and reads it back to confirm
+ *    the bytes landed.  Power-cut safety: the slot metadata sector is
+ *    erased first, then written; an interruption between erase and write
+ *    leaves the sector blank, which the bootloader treats as "metadata
+ *    invalid" and falls back accordingly.
+ *
+ * No dynamic allocation.  Compiles for both host (UNIT_TEST) and
+ * arm-none-eabi targets.  Bootloader links libflash.a only when slot
+ * mutation is needed; the verify-and-jump path stays read-only.
+ */
+#ifndef LIB_FLASH_SLOT_H
+#define LIB_FLASH_SLOT_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "error.h"
+#include "img_header.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Slot identifiers.  The numeric values double as array indices in
+ * partition_dump.py output and in any future slot-history code. */
+typedef enum {
+    FLASH_SLOT_A = 0,
+    FLASH_SLOT_B = 1,
+} flash_slot_id_t;
+
+/* On-flash addresses.  These constants are the single source of truth
+ * for the partition layout — the linker scripts, sign_image.py, and the
+ * bootloader all derive their values from these. */
+#define FLASH_SLOT_A_BASE         0x08010000u  /* Sector 4         */
+#define FLASH_SLOT_B_BASE         0x08040000u  /* Sector 6         */
+#define FLASH_SLOT_SIZE           (192u * 1024u)
+#define FLASH_SLOT_A_METADATA     0x08004000u  /* Sector 1, 16 KB  */
+#define FLASH_SLOT_B_METADATA     0x08008000u  /* Sector 2, 16 KB  */
+
+#define FLASH_BOOTLOADER_SECTOR   0u
+
+/*
+ * Validate that a flash range is safe to erase or program.  Returns
+ * ERR_OK if [start, start + len) is entirely within on-chip flash AND
+ * does not overlap the bootloader sector.  Returns ERR_INVALID_ARG
+ * otherwise.
+ */
+err_t flash_slot_validate_range(uint32_t start, size_t len);
+
+/*
+ * Erase every sector backing the given slot.  For both A and B that's a
+ * 192 KB region.  Internally calls flash_unlock(), iterates the sector
+ * list, calls flash_lock() on exit (or on error).  Slow — ~hundreds of
+ * milliseconds — but only invoked from OTA code paths.
+ */
+err_t flash_slot_erase(flash_slot_id_t slot);
+
+/*
+ * Erase the metadata sector for `slot` and write `md` into it at the
+ * sector base.  The metadata struct's CRC must already be populated by
+ * the caller; this function does NOT recompute it.  After programming,
+ * the bytes are read back and compared to `md`; ERR_VERIFY is returned
+ * on mismatch.
+ *
+ * Power-cut safety: the metadata sector is erased before the write, so
+ * an interruption between the two steps leaves the sector all-0xFF —
+ * the parser will reject it (CRC mismatch on an FF sector) and the
+ * bootloader will fall back to the other slot.  No partial-write
+ * window.
+ */
+err_t flash_slot_commit_metadata(flash_slot_id_t slot,
+                                 const img_slot_metadata_t *md);
+
+/*
+ * Returns the absolute flash address of the slot's payload region (i.e.
+ * the address where the signed image's img_header_t would be flashed).
+ * 0 if `slot` is invalid.
+ */
+uint32_t flash_slot_base_address(flash_slot_id_t slot);
+
+/*
+ * Returns the absolute flash address of the slot's metadata sector.
+ * 0 if `slot` is invalid.
+ */
+uint32_t flash_slot_metadata_address(flash_slot_id_t slot);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIB_FLASH_SLOT_H */

--- a/lib/flash/src/flash_slot.c
+++ b/lib/flash/src/flash_slot.c
@@ -1,0 +1,151 @@
+#include "flash_slot.h"
+
+#include <string.h>
+
+#include "flash.h"
+
+/*
+ * Sector lists per slot.  Keeping them static + const lets -O2 fold each
+ * loop into a small straight-line erase-then-erase sequence.
+ *
+ * Slot A: sectors 4 (64 KB) + 5 (128 KB)            = 192 KB
+ * Slot B: sector  6 (128 KB) + half of sector 7     = capped at 192 KB
+ *   In practice we erase only sector 6 because sector 7 is reserved for
+ *   future use (anti-rollback log, if Phase 1.9 pursues that route).
+ *   The linker script caps slot-B builds at 128 KB through __slot_size_bytes
+ *   so they cannot land inside sector 7.  See linker/app_ls.ld.
+ */
+static const uint8_t slot_a_sectors[] = { 4u, 5u };
+static const uint8_t slot_b_sectors[] = { 6u };
+
+#define SLOT_A_METADATA_SECTOR  1u
+#define SLOT_B_METADATA_SECTOR  2u
+
+err_t flash_slot_validate_range(uint32_t start, size_t len)
+{
+    if (len == 0u) {
+        return ERR_INVALID_ARG;
+    }
+
+    /* Reject ranges that overflow uint32_t arithmetic. */
+    uint32_t end_minus_one;
+    if (__builtin_add_overflow(start, len - 1u, &end_minus_one)) {
+        return ERR_INVALID_ARG;
+    }
+
+    /* Whole range must live in on-chip flash. */
+    if (start < FLASH_BASE_ADDR || end_minus_one > FLASH_END_ADDR) {
+        return ERR_INVALID_ARG;
+    }
+
+    /* Reject any overlap with the bootloader sector.  Sector 0 spans
+     * 0x08000000..0x08003FFF (16 KB). */
+    const uint32_t bl_start = FLASH_BASE_ADDR;
+    const uint32_t bl_end   = FLASH_BASE_ADDR + (16u * 1024u) - 1u;
+    if (!(end_minus_one < bl_start || start > bl_end)) {
+        return ERR_INVALID_ARG;
+    }
+
+    return ERR_OK;
+}
+
+uint32_t flash_slot_base_address(flash_slot_id_t slot)
+{
+    switch (slot) {
+    case FLASH_SLOT_A: return FLASH_SLOT_A_BASE;
+    case FLASH_SLOT_B: return FLASH_SLOT_B_BASE;
+    }
+    return 0u;
+}
+
+uint32_t flash_slot_metadata_address(flash_slot_id_t slot)
+{
+    switch (slot) {
+    case FLASH_SLOT_A: return FLASH_SLOT_A_METADATA;
+    case FLASH_SLOT_B: return FLASH_SLOT_B_METADATA;
+    }
+    return 0u;
+}
+
+static err_t erase_sectors(const uint8_t *sectors, size_t count)
+{
+    err_t rc = flash_unlock();
+    if (rc != ERR_OK) {
+        return rc;
+    }
+    for (size_t i = 0; i < count; ++i) {
+        rc = flash_erase_sector(sectors[i]);
+        if (rc != ERR_OK) {
+            flash_lock();
+            return rc;
+        }
+    }
+    flash_lock();
+    return ERR_OK;
+}
+
+err_t flash_slot_erase(flash_slot_id_t slot)
+{
+    switch (slot) {
+    case FLASH_SLOT_A:
+        return erase_sectors(slot_a_sectors,
+                             sizeof(slot_a_sectors) / sizeof(slot_a_sectors[0]));
+    case FLASH_SLOT_B:
+        return erase_sectors(slot_b_sectors,
+                             sizeof(slot_b_sectors) / sizeof(slot_b_sectors[0]));
+    }
+    return ERR_INVALID_ARG;
+}
+
+err_t flash_slot_commit_metadata(flash_slot_id_t slot,
+                                 const img_slot_metadata_t *md)
+{
+    if (md == NULL) {
+        return ERR_INVALID_ARG;
+    }
+
+    uint8_t metadata_sector;
+    switch (slot) {
+    case FLASH_SLOT_A: metadata_sector = SLOT_A_METADATA_SECTOR; break;
+    case FLASH_SLOT_B: metadata_sector = SLOT_B_METADATA_SECTOR; break;
+    default:           return ERR_INVALID_ARG;
+    }
+
+    const uint32_t addr = flash_slot_metadata_address(slot);
+    if (addr == 0u) {
+        return ERR_INVALID_ARG;
+    }
+
+    /* Erase first.  A power-cut between erase and write leaves the
+     * sector all-0xFF, which the parser rejects (CRC fails on FF). */
+    err_t rc = flash_unlock();
+    if (rc != ERR_OK) {
+        return rc;
+    }
+    rc = flash_erase_sector(metadata_sector);
+    if (rc != ERR_OK) {
+        flash_lock();
+        return rc;
+    }
+
+    rc = flash_write_bytes(addr,
+                           (const uint8_t *)md,
+                           sizeof(*md));
+    flash_lock();
+    if (rc != ERR_OK) {
+        return rc;
+    }
+
+    /* Read-back verify.  Catches both flash-cell weakness and a
+     * write-without-prior-erase (would leave 0-bits cleared from FF
+     * to whatever, but stuck wrong-1-bits would survive). */
+    uint8_t back[sizeof(*md)];
+    rc = flash_read_bytes(addr, back, sizeof(back));
+    if (rc != ERR_OK) {
+        return rc;
+    }
+    if (memcmp(back, md, sizeof(back)) != 0) {
+        return ERR_VERIFY;
+    }
+    return ERR_OK;
+}

--- a/scripts/run_ab_slot_test.py
+++ b/scripts/run_ab_slot_test.py
@@ -214,13 +214,51 @@ def capture_lines(port: str, timeout: int) -> list[str]:
 
 
 def reset_and_capture(hla_serial: str, timeout: int) -> list[str]:
-    """Reset the chip via OpenOCD, then drain UART."""
-    openocd(hla_serial, "reset run")
-    time.sleep(2)
+    """Open the serial port first to drain any prior-boot output, THEN
+    issue a reset.  Programming the slot already booted the chip once
+    (OpenOCD's `program ... reset exit`); without this ordering we'd
+    capture a mix of the prior boot and the new one."""
     port = hil.find_serial_port(hla_serial=hla_serial)
     if not port:
         hil.log_error("Serial port not found")
         return []
+    try:
+        import serial
+    except ImportError:
+        hil.log_error("pyserial not installed")
+        return []
+
+    # Open + drain.
+    ser = None
+    last_err = None
+    for _ in range(3):
+        try:
+            ser = serial.Serial(port, 115200, timeout=0.2)
+            break
+        except Exception as e:
+            last_err = e
+            time.sleep(1.0)
+    if ser is None:
+        hil.log_error(f"Serial open failed: {last_err}")
+        return []
+    try:
+        ser.reset_input_buffer()
+        # Drain any in-flight bytes from the previous post-flash boot.
+        deadline = time.time() + 1.5
+        while time.time() < deadline:
+            if ser.in_waiting:
+                ser.read(ser.in_waiting)
+                deadline = time.time() + 0.3
+            else:
+                time.sleep(0.05)
+        ser.reset_input_buffer()
+    finally:
+        try: ser.close()
+        except Exception: pass
+
+    # Now reset and recapture.
+    openocd(hla_serial, "reset run")
+    time.sleep(0.5)
     return capture_lines(port, timeout)
 
 

--- a/scripts/run_ab_slot_test.py
+++ b/scripts/run_ab_slot_test.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Plan 001 Phase 1.7 A/B slot HIL test.
+
+Four passes covering the slot-pick + fallback decision tree implemented
+in apps/bootloader/loader/main.c.  All passes flash the bootloader's
+metadata sectors via OpenOCD before each scenario so the test does not
+depend on whatever metadata happens to be on the board between runs.
+
+  Pass 1  Slot A active (clean), slot B erased
+            → boot expects "trying slot A" + "verify ok slot=A"
+              + "APP: blinky alive".  No fallback.
+
+  Pass 2  Slot B active (clean), slot A erased.
+            → boot expects "trying slot B" + "verify ok slot=B" +
+              "APP: blinky alive".  No fallback.
+
+  Pass 3  Slot A corrupt (payload byte flipped), slot B clean,
+          slot A active.
+            → boot expects "trying slot A" + "verify FAILED" + "falling
+              back to slot B" + "verify ok slot=B" + "APP: blinky alive".
+
+  Pass 4  Both slots corrupt.
+            → boot expects "both slots failed verify".  APP: blinky alive
+              must NOT appear.
+
+Slot map (must match lib/flash/inc/flash_slot.h):
+   slot A payload   : 0x08010000
+   slot B payload   : 0x08040000
+   slot A metadata  : 0x08004000  (sector 1)
+   slot B metadata  : 0x08008000  (sector 2)
+
+Exit codes:
+    0  all four passes succeeded
+    1  one or more passes failed an assertion
+    2  build / flash / serial-open error
+"""
+
+import argparse
+import re
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from xml.etree.ElementTree import Element, SubElement, ElementTree, indent
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import run_hil_tests as hil  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+import _img_format as fmt  # noqa: E402
+
+SLOT_A_BASE      = 0x08010000
+SLOT_B_BASE      = 0x08040000
+SLOT_A_METADATA  = 0x08004000
+SLOT_B_METADATA  = 0x08008000
+
+VERIFY_OK_RE   = re.compile(r"BL:\s+verify\s+ok\s+slot=(\w)")
+VERIFY_FAIL_RE = re.compile(r"BL:\s+slot\s+(\w)\s+verify\s+FAILED:")
+FALLBACK_RE    = re.compile(r"BL:\s+falling\s+back\s+to\s+slot\s+(\w)")
+TRYING_RE      = re.compile(r"BL:\s+trying\s+slot\s+(\w)")
+BOTH_FAIL      = "BL: both slots failed verify"
+APP_ALIVE      = "APP: blinky alive"
+
+
+# -------------------- Build helpers --------------------
+
+def build_app_for_slot(project_root: Path, slot: str) -> Path:
+    hil.log_info(f"Building app_blinky_signed for slot {slot}...")
+    subprocess.run(
+        ["make", "EXAMPLE=app_blinky_signed", f"SLOT={slot}"],
+        cwd=project_root, check=True, timeout=120,
+    )
+    suffix = "" if slot == "A" else "_b"
+    signed = (project_root / "build" / "apps" / "bootloader"
+              / f"app_blinky_signed{suffix}"
+              / f"app_blinky_signed{suffix}.signed.bin")
+    if not signed.exists():
+        raise RuntimeError(f"expected {signed} after build")
+    return signed
+
+
+def make_tampered(signed: Path) -> Path:
+    raw = bytearray(signed.read_bytes())
+    payload_offset = struct.unpack_from("<I", raw, 20)[0]
+    if len(raw) < payload_offset + 8:
+        raise RuntimeError(f"signed image {signed} unexpectedly small")
+    raw[payload_offset + 4] ^= 0xFF
+    tmp = Path(tempfile.mkstemp(prefix="tampered_", suffix=".signed.bin")[1])
+    tmp.write_bytes(bytes(raw))
+    return tmp
+
+
+def make_metadata_blob(active: int, fail_count: int, monotonic: int) -> bytes:
+    """Pack a valid 36-byte img_slot_metadata_t."""
+    return fmt.pack_slot_metadata(
+        active=active, fail_count=fail_count, monotonic_counter=monotonic,
+    )
+
+
+def metadata_to_file(blob: bytes) -> Path:
+    """Write a metadata blob to a tmp file for openocd `program`."""
+    tmp = Path(tempfile.mkstemp(prefix="md_", suffix=".bin")[1])
+    tmp.write_bytes(blob)
+    return tmp
+
+
+# -------------------- Flash helpers --------------------
+
+def openocd(hla_serial: str, *commands: str, timeout: int = 30) -> None:
+    """Run OpenOCD with -c init/reset halt/<commands>/exit."""
+    cmd = ["openocd"]
+    if hla_serial:
+        cmd += ["-c", f"hla_serial {hla_serial}"]
+    cmd += ["-f", "board/st_nucleo_f4.cfg",
+            "-c", "init", "-c", "reset halt"]
+    for c in commands:
+        cmd += ["-c", c]
+    cmd += ["-c", "exit"]
+    subprocess.run(cmd, check=True, capture_output=True, timeout=timeout)
+
+
+def erase_metadata_sector(hla_serial: str, slot: str) -> None:
+    """Erase the slot-N metadata sector (sector 1 for A, sector 2 for B)."""
+    sector = 1 if slot == "A" else 2
+    openocd(hla_serial,
+            "flash banks",
+            f"flash erase_sector 0 {sector} {sector}")
+
+
+def program_metadata(hla_serial: str, slot: str, blob: bytes) -> None:
+    """Erase + program the metadata sector for `slot` with `blob`."""
+    addr = SLOT_A_METADATA if slot == "A" else SLOT_B_METADATA
+    f = metadata_to_file(blob)
+    try:
+        openocd(hla_serial,
+                f"program {f} {addr:#010x} verify")
+    finally:
+        try: f.unlink()
+        except OSError: pass
+
+
+def erase_slot_payload(hla_serial: str, slot: str) -> None:
+    """Erase every sector backing a slot's payload region."""
+    if slot == "A":
+        # Sectors 4 (0x10000), 5 (0x20000)
+        sectors = [4, 5]
+    else:
+        # Sector 6 (0x40000)
+        sectors = [6]
+    cmds = []
+    for s in sectors:
+        cmds.append(f"flash erase_sector 0 {s} {s}")
+    openocd(hla_serial, *cmds)
+
+
+# -------------------- Serial capture --------------------
+
+def capture_lines(port: str, timeout: int) -> list[str]:
+    try:
+        import serial
+    except ImportError:
+        hil.log_error("pyserial not installed. Run: pip3 install pyserial")
+        return []
+
+    lines: list[str] = []
+    ser = None
+    last_err = None
+    for _ in range(3):
+        try:
+            ser = serial.Serial(port, 115200, timeout=2)
+            break
+        except Exception as e:
+            last_err = e
+            time.sleep(1.0)
+    if ser is None:
+        hil.log_error(f"Serial open failed for {port}: {last_err}")
+        sys.stdout.flush()
+        return []
+    try:
+        ser.reset_input_buffer()
+        time.sleep(0.5)
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if ser.in_waiting:
+                line = ser.readline().decode("utf-8", errors="ignore").rstrip()
+                if line:
+                    lines.append(line)
+                    print(f"  {line}")
+                    if APP_ALIVE in line:
+                        # Read a tiny tail to capture anything else queued.
+                        time.sleep(0.5)
+                        while ser.in_waiting:
+                            l2 = ser.readline().decode("utf-8", errors="ignore").rstrip()
+                            if l2:
+                                lines.append(l2)
+                                print(f"  {l2}")
+                        break
+                    if BOTH_FAIL in line:
+                        time.sleep(2.0)
+                        while ser.in_waiting:
+                            l2 = ser.readline().decode("utf-8", errors="ignore").rstrip()
+                            if l2:
+                                lines.append(l2)
+                                print(f"  {l2}")
+                        break
+            else:
+                time.sleep(0.05)
+    finally:
+        try: ser.close()
+        except Exception: pass
+    return lines
+
+
+def reset_and_capture(hla_serial: str, timeout: int) -> list[str]:
+    """Reset the chip via OpenOCD, then drain UART."""
+    openocd(hla_serial, "reset run")
+    time.sleep(2)
+    port = hil.find_serial_port(hla_serial=hla_serial)
+    if not port:
+        hil.log_error("Serial port not found")
+        return []
+    return capture_lines(port, timeout)
+
+
+# -------------------- Pass-level setup helpers --------------------
+
+def setup_clean_slot(hla_serial: str, slot: str, signed: Path) -> None:
+    base = SLOT_A_BASE if slot == "A" else SLOT_B_BASE
+    hil.log_info(f"Programming clean slot {slot}...")
+    if not hil.flash_firmware(signed, hla_serial=hla_serial, slot_base=base):
+        raise RuntimeError(f"flash slot {slot} failed")
+
+
+def setup_corrupt_slot(hla_serial: str, slot: str, signed: Path) -> None:
+    tampered = make_tampered(signed)
+    try:
+        base = SLOT_A_BASE if slot == "A" else SLOT_B_BASE
+        hil.log_info(f"Programming tampered slot {slot}...")
+        if not hil.flash_firmware(tampered, hla_serial=hla_serial, slot_base=base):
+            raise RuntimeError(f"flash tampered slot {slot} failed")
+    finally:
+        try: tampered.unlink()
+        except OSError: pass
+
+
+def setup_erased_slot(hla_serial: str, slot: str) -> None:
+    hil.log_info(f"Erasing slot {slot} payload sectors...")
+    erase_slot_payload(hla_serial, slot)
+
+
+# -------------------- Assertions --------------------
+
+def assert_pass1_a_active(lines: list[str]) -> tuple[bool, list[str]]:
+    fails = []
+    if not any(TRYING_RE.search(s) and TRYING_RE.search(s).group(1) == "A"
+               for s in lines):
+        fails.append("missing 'BL: trying slot A'")
+    if not any(VERIFY_OK_RE.search(s) and VERIFY_OK_RE.search(s).group(1) == "A"
+               for s in lines):
+        fails.append("missing 'BL: verify ok slot=A'")
+    if not any(APP_ALIVE in s for s in lines):
+        fails.append(f"missing {APP_ALIVE!r}")
+    if any(FALLBACK_RE.search(s) for s in lines):
+        fails.append("unexpected fallback line on a clean A boot")
+    return (not fails, fails)
+
+
+def assert_pass2_b_active(lines: list[str]) -> tuple[bool, list[str]]:
+    fails = []
+    if not any(TRYING_RE.search(s) and TRYING_RE.search(s).group(1) == "B"
+               for s in lines):
+        fails.append("missing 'BL: trying slot B'")
+    if not any(VERIFY_OK_RE.search(s) and VERIFY_OK_RE.search(s).group(1) == "B"
+               for s in lines):
+        fails.append("missing 'BL: verify ok slot=B'")
+    if not any(APP_ALIVE in s for s in lines):
+        fails.append(f"missing {APP_ALIVE!r}")
+    if any(FALLBACK_RE.search(s) for s in lines):
+        fails.append("unexpected fallback line on a clean B boot")
+    return (not fails, fails)
+
+
+def assert_pass3_a_bad_b_clean(lines: list[str]) -> tuple[bool, list[str]]:
+    fails = []
+    if not any(TRYING_RE.search(s) and TRYING_RE.search(s).group(1) == "A"
+               for s in lines):
+        fails.append("missing 'BL: trying slot A' (expected to try active first)")
+    if not any(VERIFY_FAIL_RE.search(s) and VERIFY_FAIL_RE.search(s).group(1) == "A"
+               for s in lines):
+        fails.append("missing 'BL: slot A verify FAILED:'")
+    if not any(FALLBACK_RE.search(s) and FALLBACK_RE.search(s).group(1) == "B"
+               for s in lines):
+        fails.append("missing 'BL: falling back to slot B'")
+    if not any(VERIFY_OK_RE.search(s) and VERIFY_OK_RE.search(s).group(1) == "B"
+               for s in lines):
+        fails.append("missing 'BL: verify ok slot=B' after fallback")
+    if not any(APP_ALIVE in s for s in lines):
+        fails.append(f"missing {APP_ALIVE!r}")
+    return (not fails, fails)
+
+
+def assert_pass4_both_bad(lines: list[str]) -> tuple[bool, list[str]]:
+    fails = []
+    if not any(BOTH_FAIL in s for s in lines):
+        fails.append(f"missing {BOTH_FAIL!r}")
+    if any(APP_ALIVE in s for s in lines):
+        fails.append(f"app started despite both slots bad — saw {APP_ALIVE!r}")
+    return (not fails, fails)
+
+
+# -------------------- JUnit XML --------------------
+
+def write_junit_xml(path: str, results: list[tuple[str, bool, list[str]]]) -> None:
+    suites = Element("testsuites")
+    failures_total = sum(0 if ok else 1 for (_, ok, _) in results)
+    suite = SubElement(suites, "testsuite",
+                       name="A/B slot fallback (Phase 1.7)",
+                       tests=str(len(results)),
+                       failures=str(failures_total),
+                       errors="0", time="0")
+    for name, ok, fails in results:
+        tc = SubElement(suite, "testcase", classname="ab_slot_test",
+                        name=name, time="0")
+        if not ok:
+            SubElement(tc, "failure", message="; ".join(fails) or "failed")
+    indent(suites)
+    ElementTree(suites).write(path, encoding="unicode", xml_declaration=True)
+
+
+# -------------------- Main --------------------
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        sys.stdout.reconfigure(line_buffering=True)
+    except Exception:
+        pass
+
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--board", choices=list(hil.BOARD_REGISTRY.keys()))
+    p.add_argument("--hla-serial", default=hil.DEFAULT_HLA_SERIAL)
+    p.add_argument("--timeout", type=int, default=20,
+                   help="Per-pass serial-capture timeout (seconds).")
+    p.add_argument("--junit-xml", default="ab-slot-results.xml")
+    args = p.parse_args(argv)
+
+    project_root = hil.get_project_root()
+    hla = hil.BOARD_REGISTRY[args.board] if args.board else args.hla_serial
+
+    try:
+        signed_a = build_app_for_slot(project_root, "A")
+        signed_b = build_app_for_slot(project_root, "B")
+    except Exception as e:
+        hil.log_error(f"Build failed: {e}")
+        write_junit_xml(args.junit_xml,
+                        [("build", False, [f"build failed: {e}"])])
+        return 2
+
+    md_a_active = make_metadata_blob(active=1, fail_count=0, monotonic=1)
+    md_b_active = make_metadata_blob(active=1, fail_count=0, monotonic=1)
+
+    results: list[tuple[str, bool, list[str]]] = []
+
+    # ---------- Pass 1: A active, B erased ----------
+    hil.log_info("=== Pass 1: clean slot A active, slot B erased ===")
+    try:
+        setup_clean_slot(hla, "A", signed_a)
+        setup_erased_slot(hla, "B")
+        program_metadata(hla, "A", md_a_active)
+        erase_metadata_sector(hla, "B")
+    except Exception as e:
+        hil.log_error(f"Pass 1 setup failed: {e}")
+        write_junit_xml(args.junit_xml,
+                        [("pass1_setup", False, [str(e)])])
+        return 2
+    lines = reset_and_capture(hla, args.timeout)
+    ok, fails = assert_pass1_a_active(lines)
+    results.append(("clean_A_active_boots_A", ok, fails))
+
+    # ---------- Pass 2: B active, A erased ----------
+    hil.log_info("=== Pass 2: clean slot B active, slot A erased ===")
+    try:
+        setup_clean_slot(hla, "B", signed_b)
+        setup_erased_slot(hla, "A")
+        program_metadata(hla, "B", md_b_active)
+        erase_metadata_sector(hla, "A")
+    except Exception as e:
+        hil.log_error(f"Pass 2 setup failed: {e}")
+        write_junit_xml(args.junit_xml, results +
+                        [("pass2_setup", False, [str(e)])])
+        return 2
+    lines = reset_and_capture(hla, args.timeout)
+    ok, fails = assert_pass2_b_active(lines)
+    results.append(("clean_B_active_boots_B", ok, fails))
+
+    # ---------- Pass 3: A corrupt + active, B clean ----------
+    hil.log_info("=== Pass 3: A corrupt (active), B clean → fallback to B ===")
+    try:
+        setup_corrupt_slot(hla, "A", signed_a)
+        setup_clean_slot(hla, "B", signed_b)
+        program_metadata(hla, "A", md_a_active)
+        erase_metadata_sector(hla, "B")
+    except Exception as e:
+        hil.log_error(f"Pass 3 setup failed: {e}")
+        write_junit_xml(args.junit_xml, results +
+                        [("pass3_setup", False, [str(e)])])
+        return 2
+    lines = reset_and_capture(hla, args.timeout)
+    ok, fails = assert_pass3_a_bad_b_clean(lines)
+    results.append(("corrupt_A_active_falls_back_to_B", ok, fails))
+
+    # ---------- Pass 4: both corrupt ----------
+    hil.log_info("=== Pass 4: both slots corrupt → halt ===")
+    try:
+        setup_corrupt_slot(hla, "A", signed_a)
+        setup_corrupt_slot(hla, "B", signed_b)
+        program_metadata(hla, "A", md_a_active)
+        erase_metadata_sector(hla, "B")
+    except Exception as e:
+        hil.log_error(f"Pass 4 setup failed: {e}")
+        write_junit_xml(args.junit_xml, results +
+                        [("pass4_setup", False, [str(e)])])
+        return 2
+    lines = reset_and_capture(hla, args.timeout)
+    ok, fails = assert_pass4_both_bad(lines)
+    results.append(("both_slots_bad_halt", ok, fails))
+
+    # ---------- Restore a sane state for following CI steps ----------
+    hil.log_info("=== Restoring clean slot A image ===")
+    try:
+        setup_clean_slot(hla, "A", signed_a)
+        setup_erased_slot(hla, "B")
+        erase_metadata_sector(hla, "A")
+        erase_metadata_sector(hla, "B")
+    except Exception as e:
+        hil.log_warning(f"Restore step had a problem (non-fatal): {e}")
+
+    write_junit_xml(args.junit_xml, results)
+
+    all_ok = all(ok for (_, ok, _) in results)
+    if all_ok:
+        hil.log_success("A/B slot test passed (4/4)")
+        return 0
+    for name, ok, fails in results:
+        if not ok:
+            hil.log_error(f"  {name} failed: {'; '.join(fails)}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_verify_test.py
+++ b/scripts/run_verify_test.py
@@ -49,10 +49,24 @@ CYCLES_PER_MS_AT_100_MHZ = 100_000
 HARD_CAP_MS = 500
 HARD_CAP_CYCLES = HARD_CAP_MS * CYCLES_PER_MS_AT_100_MHZ
 
+"""Log-line patterns.
+
+Phase 1.6 emitted:
+    BL: verify ok in <N> cycles (~<M> ms)
+    BL: verify FAILED: <reason>
+
+Phase 1.7 added a slot annotation:
+    BL: verify ok slot=<X> in <N> cycles (~<M> ms)
+    BL: slot <X> verify FAILED: <reason>
+
+The regexes accept either form so this script keeps working if a future
+phase tweaks the format again — the cycle count and the FAILED keyword
+are the load-bearing parts.
+"""
 VERIFY_OK_RE = re.compile(
-    r"BL:\s+verify\s+ok\s+in\s+(\d+)\s+cycles\s+\(~(\d+)\s+ms\)"
+    r"BL:\s+verify\s+ok(?:\s+slot=\w+)?\s+in\s+(\d+)\s+cycles\s+\(~(\d+)\s+ms\)"
 )
-VERIFY_FAIL_PREFIX = "BL: verify FAILED:"
+VERIFY_FAIL_RE = re.compile(r"BL:(?:\s+slot\s+\w+)?\s+verify\s+FAILED:")
 APP_ALIVE_LINE = "APP: blinky alive"
 
 
@@ -147,7 +161,7 @@ def capture_lines(port: str, timeout: int, stop_on_fail: bool = False) -> list[s
                 if line:
                     lines.append(line)
                     print(f"  {line}")
-                    if stop_on_fail and VERIFY_FAIL_PREFIX in line:
+                    if stop_on_fail and VERIFY_FAIL_RE.search(line):
                         # Keep reading briefly to confirm the app does NOT come up.
                         time.sleep(2.0)
                         while ser.in_waiting:
@@ -195,8 +209,8 @@ def assert_clean_pass(lines: list[str]) -> tuple[bool, list[str]]:
 
 def assert_tampered_pass(lines: list[str]) -> tuple[bool, list[str]]:
     failures: list[str] = []
-    if not any(VERIFY_FAIL_PREFIX in s for s in lines):
-        failures.append(f"missing '{VERIFY_FAIL_PREFIX} <reason>' line")
+    if not any(VERIFY_FAIL_RE.search(s) for s in lines):
+        failures.append("missing 'BL: ... verify FAILED: <reason>' line")
     if any(APP_ALIVE_LINE in s for s in lines):
         failures.append(
             f"app started despite tampered image — saw {APP_ALIVE_LINE!r}"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS = string_utils cli gpio exti rcc timer uart systick flash iwdg crc lowpower lib/skeleton lib/crypto lib/img tools/sign_roundtrip
+SUBDIRS = string_utils cli gpio exti rcc timer uart systick flash iwdg crc lowpower lib/skeleton lib/crypto lib/img lib/flash tools/sign_roundtrip
 
 COVERAGE_INFO = coverage.info
 COVERAGE_FILT = coverage-filtered.info
@@ -72,6 +72,10 @@ run: all
 	@echo "Running lib/img tests"
 	@echo "========================================"
 	@$(MAKE) -C lib/img run
+	@echo "========================================"
+	@echo "Running lib/flash tests"
+	@echo "========================================"
+	@$(MAKE) -C lib/flash run
 	@echo "========================================"
 	@echo "Running tools/sign_roundtrip tests"
 	@echo "========================================"

--- a/tests/lib/flash/Makefile
+++ b/tests/lib/flash/Makefile
@@ -1,0 +1,32 @@
+CC      = gcc
+CFLAGS  = -Wall -Wextra -Wno-unknown-pragmas -Wno-unknown-warning-option \
+          -DUNIT_TEST \
+          -I../../../lib/flash/inc \
+          -I../../../lib/img/inc \
+          -I../../../drivers/inc \
+          -I../../driver_stubs \
+          -I../../../chip_headers/CMSIS/Include \
+          -I../../../chip_headers/CMSIS/Device/ST/STM32F4xx/Include \
+          -I../../../3rd_party/unity/src \
+          $(EXTRA_CFLAGS)
+
+UNITY_SRC        = ../../../3rd_party/unity/src/unity.c
+FLASH_SLOT_SRC   = ../../../lib/flash/src/flash_slot.c
+FLASH_DRIVER_SRC = ../../../drivers/src/flash.c
+TEST_PERIPH_SRC  = ../../driver_stubs/test_periph.c
+
+.PHONY: all run clean
+
+all: test_flash_slot.out
+
+run: all
+	./test_flash_slot.out
+
+# Link the real flash driver (UNIT_TEST mode → fake buffer) so the
+# slot-erase / commit-metadata calls have something to land in even
+# when the host tests don't exercise them directly.
+test_flash_slot.out: test_flash_slot.c $(FLASH_SLOT_SRC) $(FLASH_DRIVER_SRC) $(TEST_PERIPH_SRC) $(UNITY_SRC)
+	$(CC) $(CFLAGS) $^ -o $@
+
+clean:
+	rm -f *.out *.o *.gcda *.gcno

--- a/tests/lib/flash/test_flash_slot.c
+++ b/tests/lib/flash/test_flash_slot.c
@@ -1,0 +1,138 @@
+#include "flash_slot.h"
+#include "unity.h"
+
+#include <stdint.h>
+
+/*
+ * Host tests for the pure-logic surface of lib/flash:
+ *
+ *   - flash_slot_validate_range()   — bootloader-sector overlap detection
+ *   - flash_slot_base_address()     — slot id → flash address
+ *   - flash_slot_metadata_address() — slot id → metadata sector address
+ *
+ * The mutating primitives (flash_slot_erase, flash_slot_commit_metadata)
+ * are exercised end-to-end on real hardware by scripts/run_ab_slot_test.py.
+ * The fake flash buffer in drivers/src/flash.c covers only the first
+ * 16 KB sector, which isn't enough to host-test slot erases that span
+ * sectors 4–6 (192 KB).
+ */
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* ---------- flash_slot_base_address ---------- */
+
+void test_base_addr_slot_a(void)
+{
+    TEST_ASSERT_EQUAL_HEX32(0x08010000u, flash_slot_base_address(FLASH_SLOT_A));
+}
+
+void test_base_addr_slot_b(void)
+{
+    TEST_ASSERT_EQUAL_HEX32(0x08040000u, flash_slot_base_address(FLASH_SLOT_B));
+}
+
+void test_base_addr_invalid_returns_zero(void)
+{
+    TEST_ASSERT_EQUAL_HEX32(0u, flash_slot_base_address((flash_slot_id_t)99));
+}
+
+/* ---------- flash_slot_metadata_address ---------- */
+
+void test_metadata_addr_slot_a(void)
+{
+    TEST_ASSERT_EQUAL_HEX32(0x08004000u, flash_slot_metadata_address(FLASH_SLOT_A));
+}
+
+void test_metadata_addr_slot_b(void)
+{
+    TEST_ASSERT_EQUAL_HEX32(0x08008000u, flash_slot_metadata_address(FLASH_SLOT_B));
+}
+
+void test_metadata_addr_invalid_returns_zero(void)
+{
+    TEST_ASSERT_EQUAL_HEX32(0u, flash_slot_metadata_address((flash_slot_id_t)42));
+}
+
+/* ---------- flash_slot_validate_range ---------- */
+
+void test_validate_range_zero_length_rejected(void)
+{
+    TEST_ASSERT_EQUAL_INT(ERR_INVALID_ARG,
+                          flash_slot_validate_range(0x08010000u, 0u));
+}
+
+void test_validate_range_below_flash_rejected(void)
+{
+    TEST_ASSERT_EQUAL_INT(ERR_INVALID_ARG,
+                          flash_slot_validate_range(0x07FFFFFFu, 16u));
+}
+
+void test_validate_range_past_flash_end_rejected(void)
+{
+    /* Last byte just past sector 7 end (0x0807FFFF). */
+    TEST_ASSERT_EQUAL_INT(ERR_INVALID_ARG,
+                          flash_slot_validate_range(0x0807FFFFu, 2u));
+}
+
+void test_validate_range_inside_bootloader_rejected(void)
+{
+    /* Anywhere inside sector 0 (0x08000000..0x08003FFF) must be refused. */
+    TEST_ASSERT_EQUAL_INT(ERR_INVALID_ARG,
+                          flash_slot_validate_range(0x08000000u, 4u));
+    TEST_ASSERT_EQUAL_INT(ERR_INVALID_ARG,
+                          flash_slot_validate_range(0x08002000u, 1u));
+    TEST_ASSERT_EQUAL_INT(ERR_INVALID_ARG,
+                          flash_slot_validate_range(0x08003FFCu, 4u));
+}
+
+void test_validate_range_straddling_bootloader_boundary_rejected(void)
+{
+    /* Range that starts just before sector 0's end and crosses into sector 1
+     * still touches the bootloader sector and must be refused. */
+    TEST_ASSERT_EQUAL_INT(ERR_INVALID_ARG,
+                          flash_slot_validate_range(0x08003FFCu, 16u));
+}
+
+void test_validate_range_slot_a_metadata_accepted(void)
+{
+    /* Sector 1 (16 KB) — the slot-A metadata location. */
+    TEST_ASSERT_EQUAL_INT(ERR_OK,
+                          flash_slot_validate_range(0x08004000u, 36u));
+}
+
+void test_validate_range_slot_a_payload_accepted(void)
+{
+    TEST_ASSERT_EQUAL_INT(ERR_OK,
+                          flash_slot_validate_range(0x08010000u, 192u * 1024u));
+}
+
+void test_validate_range_slot_b_payload_accepted(void)
+{
+    TEST_ASSERT_EQUAL_INT(ERR_OK,
+                          flash_slot_validate_range(0x08040000u, 128u * 1024u));
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_base_addr_slot_a);
+    RUN_TEST(test_base_addr_slot_b);
+    RUN_TEST(test_base_addr_invalid_returns_zero);
+
+    RUN_TEST(test_metadata_addr_slot_a);
+    RUN_TEST(test_metadata_addr_slot_b);
+    RUN_TEST(test_metadata_addr_invalid_returns_zero);
+
+    RUN_TEST(test_validate_range_zero_length_rejected);
+    RUN_TEST(test_validate_range_below_flash_rejected);
+    RUN_TEST(test_validate_range_past_flash_end_rejected);
+    RUN_TEST(test_validate_range_inside_bootloader_rejected);
+    RUN_TEST(test_validate_range_straddling_bootloader_boundary_rejected);
+    RUN_TEST(test_validate_range_slot_a_metadata_accepted);
+    RUN_TEST(test_validate_range_slot_a_payload_accepted);
+    RUN_TEST(test_validate_range_slot_b_payload_accepted);
+
+    return UNITY_END();
+}

--- a/tools/partition_dump.py
+++ b/tools/partition_dump.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Pretty-print slot metadata + image headers from a flashed STM32F411 board.
+
+Phase 1.7 / Plan 001 debugging tool.  Reads the four interesting regions
+of on-chip flash (slot A metadata, slot B metadata, slot A header, slot B
+header) and decodes them against the format spec in tools/_img_format.py.
+
+Two read backends:
+
+  --backend openocd   Drive openocd `mdb`/`mdw` to dump bytes via ST-LINK.
+                      Default; matches scripts/run_hil_tests.py.
+  --backend file      Read from a local 512 KB flash dump file (handy
+                      offline; produced via openocd `dump_image`).
+
+Exit codes:
+    0  succeeded; output is pretty-printed
+    1  parse failed (CRC / magic / version mismatch)
+    2  read backend failed (openocd not present, dump file unreadable)
+
+Usage:
+  python3 tools/partition_dump.py
+  python3 tools/partition_dump.py --hla-serial 066BFF...
+  python3 tools/partition_dump.py --backend file --image build/flash_dump.bin
+"""
+
+import argparse
+import hashlib
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Allow running as a script from anywhere.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _img_format as fmt  # noqa: E402
+
+# Slot map — single source of truth is lib/flash/inc/flash_slot.h on the
+# C side.  Keep these in sync; the round-trip test in tests/tools/ would
+# catch a drift only if we wrote a sign step that targeted slot B.
+SLOT_A_BASE     = 0x08010000
+SLOT_B_BASE     = 0x08040000
+SLOT_A_METADATA = 0x08004000
+SLOT_B_METADATA = 0x08008000
+FLASH_BASE      = 0x08000000
+FLASH_LEN       = 512 * 1024  # 0x80000
+
+
+def read_openocd(addr: int, length: int, hla_serial: str) -> bytes:
+    """Dump `length` bytes starting at `addr` via openocd to a tmpfile."""
+    tmp = Path(tempfile.mkstemp(prefix="pd_", suffix=".bin")[1])
+    cmd = ["openocd"]
+    if hla_serial:
+        cmd += ["-c", f"hla_serial {hla_serial}"]
+    cmd += [
+        "-f", "board/st_nucleo_f4.cfg",
+        "-c", "init",
+        "-c", "reset halt",
+        "-c", f"dump_image {tmp} {addr:#010x} {length}",
+        "-c", "exit",
+    ]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, timeout=30)
+        return tmp.read_bytes()
+    finally:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+
+
+def read_file(addr: int, length: int, image: Path) -> bytes:
+    """Read `length` bytes from a 512 KB flash dump."""
+    blob = image.read_bytes()
+    if len(blob) < FLASH_LEN:
+        raise RuntimeError(f"image {image} is {len(blob)} bytes, expected >= {FLASH_LEN}")
+    off = addr - FLASH_BASE
+    if off < 0 or off + length > len(blob):
+        raise RuntimeError(f"address {addr:#010x} not covered by image of {len(blob)} bytes")
+    return blob[off : off + length]
+
+
+def parse_metadata(buf: bytes) -> dict | None:
+    """Parse 36-byte slot-metadata buffer.  Returns None on CRC/magic mismatch."""
+    if len(buf) < fmt.IMG_SLOT_METADATA_SIZE:
+        return None
+    pre = buf[: fmt.IMG_SLOT_METADATA_SIZE - 4]
+    crc_stored = struct.unpack_from("<I", buf, fmt.IMG_SLOT_METADATA_SIZE - 4)[0]
+    if fmt.crc32(pre) != crc_stored:
+        return {"valid": False, "raw": buf, "reason": "CRC mismatch"}
+    fields = struct.unpack(fmt._SLOT_PRECRC_FMT, pre)
+    magic, ver, active, fail, monotonic, *_ = fields
+    if magic != fmt.IMG_SLOT_METADATA_MAGIC:
+        return {"valid": False, "raw": buf, "reason": f"bad magic {magic:#010x}"}
+    if ver != fmt.IMG_SLOT_METADATA_VERSION:
+        return {"valid": False, "raw": buf, "reason": f"bad version {ver}"}
+    return {
+        "valid": True,
+        "magic": magic, "version": ver,
+        "active": active, "fail_count": fail,
+        "monotonic_counter": monotonic,
+        "crc": crc_stored,
+    }
+
+
+def parse_header(buf: bytes) -> dict | None:
+    if len(buf) < fmt.IMG_HEADER_SIZE:
+        return None
+    if buf == b"\xff" * len(buf):
+        return {"valid": False, "reason": "erased (all 0xFF)"}
+    pre = buf[: fmt.IMG_HEADER_SIZE - 4]
+    crc_stored = struct.unpack_from("<I", buf, fmt.IMG_HEADER_SIZE - 4)[0]
+    if fmt.crc32(pre) != crc_stored:
+        return {"valid": False, "reason": f"CRC mismatch (stored={crc_stored:#010x})"}
+    fields = struct.unpack(fmt._HEADER_PRECRC_FMT, pre)
+    magic, hver, iver, itype, psize, poff, sha, sig, *_ = fields
+    if magic != fmt.IMG_HEADER_MAGIC:
+        return {"valid": False, "reason": f"bad magic {magic:#010x}"}
+    return {
+        "valid": True,
+        "magic": magic, "header_version": hver, "image_version": iver,
+        "image_type": itype, "payload_size": psize, "payload_offset": poff,
+        "sha256": sha, "signature": sig, "crc": crc_stored,
+    }
+
+
+def fmt_bytes_short(b: bytes, n: int = 8) -> str:
+    head = b[:n].hex()
+    suffix = "..." if len(b) > n else ""
+    return f"{head}{suffix}"
+
+
+def render_metadata(name: str, addr: int, info: dict | None) -> None:
+    print(f"  Slot {name} metadata @ {addr:#010x}")
+    if info is None:
+        print("    (read failed)")
+        return
+    if not info.get("valid"):
+        print(f"    INVALID: {info.get('reason', 'unknown')}")
+        return
+    print(f"    magic            : {info['magic']:#010x} ('SLOT')")
+    print(f"    metadata_version : {info['version']}")
+    print(f"    active           : {info['active']}")
+    print(f"    fail_count       : {info['fail_count']}")
+    print(f"    monotonic_counter: {info['monotonic_counter']}")
+    print(f"    crc              : {info['crc']:#010x}")
+
+
+def render_header(name: str, addr: int, info: dict | None,
+                  payload: bytes | None = None) -> None:
+    print(f"  Slot {name} image header @ {addr:#010x}")
+    if info is None or not info.get("valid"):
+        reason = info.get("reason", "read failed") if info else "read failed"
+        print(f"    INVALID: {reason}")
+        return
+    type_name = {1: "BOOTLOADER", 2: "APP"}.get(info["image_type"],
+                                                f"UNKNOWN({info['image_type']})")
+    print(f"    magic            : {info['magic']:#010x} ('IMGH')")
+    print(f"    header_version   : {info['header_version']}")
+    print(f"    image_version    : {info['image_version']}")
+    print(f"    image_type       : {type_name}")
+    print(f"    payload_size     : {info['payload_size']}")
+    print(f"    payload_offset   : {info['payload_offset']}")
+    print(f"    sha256           : {fmt_bytes_short(info['sha256'], 16)}")
+    print(f"    signature        : {fmt_bytes_short(info['signature'], 16)}")
+    print(f"    crc              : {info['crc']:#010x}")
+    if payload is not None:
+        actual = hashlib.sha256(payload).hexdigest()
+        match = "MATCH" if bytes.fromhex(actual) == info["sha256"] else "MISMATCH"
+        print(f"    payload sha256   : {actual[:32]}... ({match})")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--backend", choices=["openocd", "file"], default="openocd")
+    p.add_argument("--hla-serial", default="",
+                   help="ST-LINK serial when --backend=openocd. Optional if "
+                        "only one probe is connected.")
+    p.add_argument("--image", type=Path,
+                   help="Flash dump file when --backend=file (must be >= 512 KB).")
+    p.add_argument("--no-payload-check", action="store_true",
+                   help="Skip recomputing payload SHA-256 (faster on big slots).")
+    args = p.parse_args(argv)
+
+    if args.backend == "file" and args.image is None:
+        p.error("--backend=file requires --image")
+
+    def reader(addr: int, length: int) -> bytes:
+        if args.backend == "openocd":
+            return read_openocd(addr, length, args.hla_serial)
+        return read_file(addr, length, args.image)
+
+    try:
+        md_a_buf = reader(SLOT_A_METADATA, fmt.IMG_SLOT_METADATA_SIZE)
+        md_b_buf = reader(SLOT_B_METADATA, fmt.IMG_SLOT_METADATA_SIZE)
+    except Exception as e:
+        print(f"ERROR: metadata read failed: {e}", file=sys.stderr)
+        return 2
+
+    print("=== Slot metadata ===")
+    render_metadata("A", SLOT_A_METADATA, parse_metadata(md_a_buf))
+    render_metadata("B", SLOT_B_METADATA, parse_metadata(md_b_buf))
+
+    # Read just the header for each slot to get payload_size, then read
+    # the payload only if we want the SHA cross-check.
+    print("\n=== Slot images ===")
+    for name, base in (("A", SLOT_A_BASE), ("B", SLOT_B_BASE)):
+        try:
+            hdr_buf = reader(base, fmt.IMG_HEADER_SIZE)
+        except Exception as e:
+            print(f"  Slot {name} image header @ {base:#010x}")
+            print(f"    READ FAILED: {e}")
+            continue
+        info = parse_header(hdr_buf)
+        payload = None
+        if (info and info.get("valid") and not args.no_payload_check
+                and info["payload_size"] <= 256 * 1024):
+            try:
+                payload = reader(base + info["payload_offset"], info["payload_size"])
+            except Exception as e:
+                print(f"  (could not read payload for SHA check: {e})")
+        render_header(name, base, info, payload)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #158.

## Summary

- Bootloader reads two slot-metadata blobs (sectors 1 + 2), picks an active slot via a deterministic decision tree, verifies it, and falls back to the other slot on any failure. Both bad → halt.
- New \`SLOT={A,B}\` Makefile knob: any app linked with \`app_ls.ld\` builds for either slot. Slot-B output paths carry a \`_b\` suffix so they can't clobber slot-A artefacts.
- New \`lib/flash/\` middleware: \`flash_slot_validate_range()\` (refuses sector-0 overlap), \`flash_slot_erase()\`, \`flash_slot_commit_metadata()\` (erase-then-program-then-readback). 14 host tests cover the validators.
- New \`tools/partition_dump.py\`: pretty-prints both metadata blobs and headers from a board (or a 512 KB flash dump).
- New \`scripts/run_ab_slot_test.py\`: 4-pass HIL test (clean A, clean B, A bad → fallback to B, both bad → halt).
- \`loader.bin\`: 10 748 → 11 624 bytes (~4.7 KB headroom remaining in sector 0).

## Bootloader log-line grammar (Phase 1.7 additions)

\`\`\`
BL: stm32-bare-metal bootloader (Phase 1.7)
BL: metadata A=<ok|invalid> B=<ok|invalid>
BL: trying slot <X>
BL: slot <X> verify FAILED: <reason>
BL: falling back to slot <Y>
BL: verify ok slot=<X> in <N> cycles (~<M> ms)
BL: both slots failed verify
\`\`\`

## Scope cut: rollback-on-crash deferred

The issue listed bootloader-side \`fail_count\` increment before every jump. Implementing that requires a 16 KB sector erase + reprogram on every boot (~hundreds of milliseconds) and ties more cleanly to Phase 1.9 anti-rollback writes. The metadata struct already carries \`fail_count\` and \`monotonic_counter\` (the latter is the slot-pick tiebreaker today); the bootloader just doesn't yet write either. Documented in [ab-slots.md](docs/wiki/plans/001-bootloader/ab-slots.md) and the Plan 001 status section.

## Test plan

- [x] \`make test\` — 14 new host tests pass alongside the existing suite
- [x] \`make all\` — every app builds clean (A and B variants for app_blinky_signed)
- [x] \`make EXAMPLE=cli_simple SLOT=B\` — slot-B-linked signed image lands at \`build/.../cli_simple_b/cli_simple_b.signed.bin\`
- [x] HIL on dev board — all 4 passes green (verify times: A ~143 ms, B ~149 ms)
- [x] CI \`host-tests\`
- [x] CI \`firmware-build\`
- [x] CI \`hil-tests\` (cli_simple → boot smoke → verify → A/B slot)

## Files

- New: \`lib/flash/{Makefile,inc/flash_slot.h,src/flash_slot.c}\`, \`tests/lib/flash/\`, \`tools/partition_dump.py\`, \`scripts/run_ab_slot_test.py\`, \`docs/wiki/plans/001-bootloader/ab-slots.md\`
- Modified: \`apps/bootloader/loader/{main.c,Makefile}\`, \`apps/bootloader/app_blinky_signed/Makefile\`, \`Makefile.common\`, \`lib/Makefile\`, \`tests/Makefile\`, \`drivers/inc/error.h\` (new \`ERR_VERIFY\`), \`.github/workflows/ci.yml\`, wiki index/log/skeleton/plan-001