### PR TITLE
Plan 001 Phase 1.8 (part 1): lib/framing — HDLC-style frame layer

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -128,6 +128,7 @@ UNITY_ARM_LIB := $(BUILD_DIR)/3rd_party/libunity_arm.a
 IMG_LIB := $(BUILD_DIR)/lib/img/libimg.a
 CRYPTO_LIB := $(BUILD_DIR)/lib/crypto/libcrypto.a
 FLASH_LIB := $(BUILD_DIR)/lib/flash/libflash.a
+FRAMING_LIB := $(BUILD_DIR)/lib/framing/libframing.a
 
 #==============================================================================
 # Plan 001 signing artifacts
@@ -193,6 +194,6 @@ clean-module:
 export CC CP OD SZ AR
 export MCU_FLAGS CFLAGS LDFLAGS LDSCRIPT
 export ROOT_DIR BUILD_DIR HIL_TEST LIB_DIR
-export DRIVERS_LIB STARTUP_OBJ PRINTF_LIB LOG_C_LIB UTILS_LIB UNITY_ARM_LIB IMG_LIB CRYPTO_LIB FLASH_LIB
+export DRIVERS_LIB STARTUP_OBJ PRINTF_LIB LOG_C_LIB UTILS_LIB UNITY_ARM_LIB IMG_LIB CRYPTO_LIB FLASH_LIB FRAMING_LIB
 export KEYS_DIR KEY_SEED DEV_PRIV BL_PUBKEY_C
 export SLOT SLOT_BASE SLOT_SUFFIX

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -4,6 +4,46 @@ Chronological record of significant changes. Newest entries at the top.
 Format: `## [YYYY-MM-DD] <type> | <title> (<PR/Issue>)`
 Types: `merge`, `decision`, `milestone`, `infra`
 
+## [2026-05-31] milestone | Plan 001 Phase 1.8 (part 1) — `lib/framing/` (#162)
+
+First half of Phase 1.8 lands: the reusable framing middleware. HDLC-style
+byte stream with `FLAG=0x7E`, `ESC=0x7D` byte-stuffing, CRC-16-CCITT
+(poly `0x1021`, init `0xFFFF`, no final XOR) over the unstuffed
+`[SEQ][TYPE][LEN_lo][LEN_hi][PAYLOAD]` span. Max payload 1024 B, frame
+types cover the OTA path (`OTA_BEGIN`/`CHUNK`/`END`), the link path
+(`DATA`/`ACK`/`NACK`), and ping/status.
+
+Three layers in one lib:
+
+- **Encoder** (`frame_encode`) — pure; computes worst-case stuffed size,
+  rejects oversize / NULL / bad-type / too-small-out-buf inputs.
+- **Decoder** (`frame_decoder_t`, `frame_decoder_feed`) — stateful byte
+  pump, fires an `rx_cb` on each CRC-valid frame and an `err_cb` on CRC
+  mismatch / truncation / oversize. Resyncs on the next `FLAG`.
+- **Reliable layer** (`frame_link_t`) — sliding-window-of-1 stop-and-wait
+  ARQ with timeout-based retransmit, NACK retransmit, configurable
+  retries, and duplicate-SEQ suppression on the receive side. Transport-
+  agnostic: caller hooks `write` and `now_ms`, so the same code drives
+  UART today and SPI in Plan 002 later.
+
+35 host unit tests (`tests/lib/framing/`) cover round-trip, byte-stuffing
+of `FLAG`/`ESC` payloads, byte-stuffing of `SEQ`, CRC mismatch dropping,
+truncation + resync, garbage-prefix silently dropped, idle-FLAG pair,
+oversize payload dropped, double-ESC malformed stuffing, trailing ESC
+before FLAG, byte-at-a-time feed, full-1024-byte payload round-trip,
+decoder reset, and the full link layer (init / send / overlap rejection /
+oversize rejection / write failure / ACK / NACK retry / timeout
+retransmit / max-retries exhausted / RX dedup). Coverage on
+`lib/framing/src/framing.c` is 95.3% (the 4.7% miss is the redundant-but-
+harmless transport-write-failure branch inside `link_retransmit` — the
+tick path exercises it via the timeout side instead). Meets the ≥95%
+bar Plan 002 §2.2 sets for this layer.
+
+The OTA receiver, app-side `ota_request` CLI command, `tools/ota_send.py`
+host driver, and HIL `run_ota_test.py` land in the second half of Phase
+1.8 in a follow-up PR — the framing layer is independently useful and is
+small enough to review on its own.
+
 ## [2026-05-31] milestone | Plan 001 Phase 1.7 — A/B slots and fallback (#158)
 
 The bootloader now reads two slot-metadata blobs from sectors 1 and 2,

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -15,7 +15,7 @@ include ../Makefile.common
 # Subdirectories — each is a single middleware library.
 # Add a new lib by creating lib/<name>/{Makefile,inc,src} and listing it here.
 #==============================================================================
-SUBDIRS := skeleton crypto img flash
+SUBDIRS := skeleton crypto img flash framing
 
 #==============================================================================
 # Build rules

--- a/lib/framing/Makefile
+++ b/lib/framing/Makefile
@@ -1,0 +1,63 @@
+#==============================================================================
+# Framing Library Makefile
+#
+# HDLC-style frame layer with byte-stuffing, CRC-16-CCITT, and a sliding-
+# window-of-1 reliable layer. Pure C with no peripheral dependencies, so the
+# same source compiles on the host (unit tests, tools/ota_send.py via Python
+# round-trip checks) and on the target (bootloader OTA receiver).
+#
+# Plan 001 Phase 1.8 introduced this lib; Plan 002 Phase 2.2 reuses it.
+# Mirrors lib/img/Makefile.
+#==============================================================================
+
+# Module name for identification
+MODULE_NAME := lib_framing
+
+# Default target
+.DEFAULT_GOAL := all
+
+# Include common definitions
+include ../../Makefile.common
+
+#==============================================================================
+# Local directories
+#==============================================================================
+LOCAL_SRC_DIR := src
+LOCAL_INC_DIR := inc
+LOCAL_BUILD_DIR := $(BUILD_DIR)/lib/framing
+
+#==============================================================================
+# Source files
+#==============================================================================
+LOCAL_SRCS := $(wildcard $(LOCAL_SRC_DIR)/*.c)
+LOCAL_OBJS := $(patsubst $(LOCAL_SRC_DIR)/%.c,$(LOCAL_BUILD_DIR)/%.o,$(LOCAL_SRCS))
+
+#==============================================================================
+# Target library
+#==============================================================================
+TARGET_LIB := $(LOCAL_BUILD_DIR)/libframing.a
+
+#==============================================================================
+# Build rules
+#==============================================================================
+.PHONY: all clean
+
+all: $(TARGET_LIB)
+
+# Build the framing library.
+$(TARGET_LIB): $(LOCAL_OBJS)
+	$(make-build-dir)
+	@echo "Creating framing library..."
+	$(AR) rcs $@ $^
+	@echo "Framing library created: $@"
+
+# Compile sources.
+$(LOCAL_BUILD_DIR)/%.o: $(LOCAL_SRC_DIR)/%.c
+	$(make-build-dir)
+	@echo "Compiling framing: $<"
+	$(CC) $(CFLAGS) -I$(LOCAL_INC_DIR) -o $@ $<
+
+# Clean local build artifacts.
+clean:
+	@echo "Cleaning framing..."
+	@rm -rf $(LOCAL_BUILD_DIR)

--- a/lib/framing/inc/framing.h
+++ b/lib/framing/inc/framing.h
@@ -1,0 +1,273 @@
+#ifndef LIB_FRAMING_H
+#define LIB_FRAMING_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * HDLC-inspired framing for the bootloader OTA path (Plan 001 Phase 1.8) and
+ * the inter-board comms link (Plan 002 Phase 2.2).
+ *
+ * Wire format (between two FLAG bytes, the inner span is byte-stuffed):
+ *
+ *   [FLAG] [SEQ] [TYPE] [LEN_lo] [LEN_hi] [PAYLOAD ...] [CRC_lo] [CRC_hi] [FLAG]
+ *
+ * - FLAG = 0x7E, ESC = 0x7D. Any FLAG/ESC byte inside the frame body is
+ *   replaced by ESC followed by (byte ^ 0x20). The decoder reverses the
+ *   substitution before CRC checking.
+ * - CRC is CRC-16-CCITT (poly 0x1021, init 0xFFFF, no final XOR) computed over
+ *   the unstuffed [SEQ][TYPE][LEN_lo][LEN_hi][PAYLOAD] span.
+ * - Maximum payload is FRAME_MAX_PAYLOAD bytes; larger transfers chunk over
+ *   multiple frames at the application layer.
+ *
+ * Both encoder and decoder are pure functions / pure state machines. They do
+ * not touch any peripheral and therefore work identically on the host (for
+ * unit tests and `tools/ota_send.py`) and on the target.
+ */
+
+#define FRAME_FLAG               0x7Eu
+#define FRAME_ESC                0x7Du
+#define FRAME_ESC_XOR            0x20u
+
+#define FRAME_MAX_PAYLOAD        1024u
+
+/* Bytes occupied by the [SEQ][TYPE][LEN_lo][LEN_hi][CRC_lo][CRC_hi] fields. */
+#define FRAME_FIXED_OVERHEAD     6u
+
+/*
+ * Worst-case encoded size: every byte in the body region (overhead + payload)
+ * may need an ESC prefix, plus the two FLAG sentinels.
+ *
+ *   2 (flags) + 2 * (FRAME_FIXED_OVERHEAD + payload_len)
+ */
+#define FRAME_MAX_ENCODED_SIZE                                                \
+    (2u + 2u * (FRAME_FIXED_OVERHEAD + FRAME_MAX_PAYLOAD))
+
+typedef enum {
+    FRAME_OK             =  0,
+    FRAME_ERR_NULL_ARG   = -1,
+    FRAME_ERR_OVERSIZE   = -2,  /* payload_len > FRAME_MAX_PAYLOAD */
+    FRAME_ERR_BUF_SMALL  = -3,  /* out_cap insufficient for worst-case stuffing */
+    FRAME_ERR_BAD_TYPE   = -4,
+    FRAME_ERR_CRC        = -5,  /* decoder: CRC mismatch (frame dropped) */
+    FRAME_ERR_TRUNC      = -6,  /* decoder: frame ended before LEN bytes consumed */
+} frame_err_t;
+
+typedef enum {
+    FRAME_TYPE_DATA       = 0,
+    FRAME_TYPE_ACK        = 1,
+    FRAME_TYPE_NACK       = 2,
+    FRAME_TYPE_OTA_BEGIN  = 3,
+    FRAME_TYPE_OTA_CHUNK  = 4,
+    FRAME_TYPE_OTA_END    = 5,
+    FRAME_TYPE_PING       = 6,
+    FRAME_TYPE_PONG       = 7,
+    FRAME_TYPE_STATUS     = 8,
+    FRAME_TYPE__MAX       = 8,  /* highest valid value, inclusive */
+} frame_type_t;
+
+/*
+ * CRC-16-CCITT, poly 0x1021, init 0xFFFF, no final XOR.
+ * Software-only; the STM32F4 hardware CRC engine implements CRC-32 with a
+ * fixed polynomial and cannot accelerate this.
+ */
+uint16_t frame_crc16(const uint8_t *buf, size_t len);
+
+/*
+ * Encode (seq, type, payload[0..payload_len)) into out_buf using HDLC-style
+ * framing with byte-stuffing and CRC-16-CCITT. Returns the number of bytes
+ * written into out_buf on success, or a negative frame_err_t.
+ *
+ * Failure modes:
+ *   - NULL out_buf, or NULL payload with payload_len > 0  -> FRAME_ERR_NULL_ARG
+ *   - payload_len > FRAME_MAX_PAYLOAD                     -> FRAME_ERR_OVERSIZE
+ *   - type > FRAME_TYPE__MAX                              -> FRAME_ERR_BAD_TYPE
+ *   - out_cap < worst-case encoded size for this payload  -> FRAME_ERR_BUF_SMALL
+ */
+int frame_encode(uint8_t seq, frame_type_t type,
+                 const uint8_t *payload, size_t payload_len,
+                 uint8_t *out_buf, size_t out_cap);
+
+/*
+ * Stateful decoder. The caller hands the decoder an external payload buffer at
+ * init time; the decoder reassembles each frame in place there. Whenever a
+ * complete, CRC-valid frame has been reconstructed, the registered callback
+ * fires with the decoded fields. On CRC mismatch or oversize input the frame
+ * is silently dropped and the decoder waits for the next FLAG to resync; the
+ * caller is also notified through the optional error callback so the higher
+ * layer can NACK or count drops.
+ */
+
+typedef void (*frame_rx_cb_t)(uint8_t seq, frame_type_t type,
+                              const uint8_t *payload, size_t len,
+                              void *user);
+
+typedef void (*frame_err_cb_t)(frame_err_t err, void *user);
+
+typedef struct {
+    /* Caller-owned callbacks + opaque user pointer. err_cb may be NULL. */
+    frame_rx_cb_t  rx_cb;
+    frame_err_cb_t err_cb;
+    void          *user;
+
+    /* Caller-owned reassembly buffer. */
+    uint8_t *payload_buf;
+    size_t   payload_buf_size;
+
+    /*
+     * Internal state. Treat as opaque from outside the module — exposed only
+     * so callers can stack-allocate the struct.
+     *
+     * field_idx counts bytes received in the [SEQ][TYPE][LEN_lo][LEN_hi]
+     * prefix; once it reaches 4 we switch to payload accumulation, then to
+     * CRC bytes after LEN bytes have been seen.
+     */
+    uint8_t  seq;
+    uint8_t  type;
+    uint16_t declared_len;
+    uint16_t payload_idx;
+    uint8_t  crc_bytes[2];
+    uint8_t  crc_idx;
+    uint8_t  field_idx;        /* 0..4 for header bytes */
+
+    uint8_t  in_frame;         /* 0 = idle, 1 = inside FLAG..FLAG */
+    uint8_t  in_escape;        /* last byte was ESC, next is XORed */
+    uint8_t  dropping;         /* current frame is poisoned, drop until FLAG */
+} frame_decoder_t;
+
+/*
+ * Wire up a decoder to its reassembly buffer and callbacks. The buffer must
+ * be at least FRAME_MAX_PAYLOAD bytes if you want to handle the largest
+ * frame type; smaller buffers cause oversized frames to be dropped (and an
+ * error reported via err_cb if registered).
+ *
+ * Returns FRAME_OK on success, FRAME_ERR_NULL_ARG if d/rx_cb/payload_buf is
+ * NULL, FRAME_ERR_OVERSIZE if payload_buf_size > FRAME_MAX_PAYLOAD (we
+ * intentionally cap the on-the-wire receive buffer at the protocol max so a
+ * caller that mis-sizes their buffer doesn't accidentally accept oversized
+ * frames).
+ */
+frame_err_t frame_decoder_init(frame_decoder_t *d,
+                               frame_rx_cb_t rx_cb,
+                               frame_err_cb_t err_cb,
+                               void *user,
+                               uint8_t *payload_buf,
+                               size_t payload_buf_size);
+
+/* Reset the decoder back to idle without changing its callbacks/buffer. */
+void frame_decoder_reset(frame_decoder_t *d);
+
+/* Feed n bytes into the decoder. Callbacks may fire during this call. */
+void frame_decoder_feed(frame_decoder_t *d, const uint8_t *bytes, size_t n);
+
+/* ------------------------------------------------------------------------
+ * Reliable layer (sliding window of 1)
+ *
+ * Wraps the encoder/decoder with stop-and-wait ARQ:
+ *  - send() encodes a DATA frame and starts a timeout
+ *  - on ACK with matching SEQ -> success, advance window
+ *  - on NACK or timeout       -> retransmit, up to max_retries
+ *  - duplicate SEQ on receive -> drop payload, ACK anyway (idempotent)
+ *  - bad CRC on receive       -> NACK with last good SEQ
+ *
+ * The link is transport-agnostic: the caller supplies a write callback that
+ * pushes encoded bytes onto whatever transport (UART/SPI/socket) is in use,
+ * plus a monotonic millisecond clock.
+ * ------------------------------------------------------------------------ */
+
+typedef int (*frame_link_write_cb_t)(const uint8_t *bytes, size_t n, void *user);
+typedef uint32_t (*frame_link_now_ms_cb_t)(void *user);
+
+typedef enum {
+    FRAME_LINK_IDLE        = 0,
+    FRAME_LINK_AWAITING_ACK = 1,
+} frame_link_state_t;
+
+typedef struct {
+    /* Transport hooks. */
+    frame_link_write_cb_t  write;
+    frame_link_now_ms_cb_t now_ms;
+    void                  *user;
+
+    /* Tunables. */
+    uint32_t timeout_ms;     /* how long to wait for ACK before retransmit */
+    uint8_t  max_retries;    /* total send attempts = 1 + max_retries */
+
+    /* Sender state. */
+    frame_link_state_t state;
+    uint8_t  tx_seq;
+    uint32_t tx_started_ms;
+    uint8_t  attempts;
+    uint8_t  pending_type;
+    uint16_t pending_len;
+    uint8_t  pending_payload[FRAME_MAX_PAYLOAD];
+    uint8_t  encoded[FRAME_MAX_ENCODED_SIZE];
+    size_t   encoded_len;
+
+    /* Receiver state (for duplicate suppression / NACK building). */
+    uint8_t  rx_have_last;
+    uint8_t  rx_last_seq;
+} frame_link_t;
+
+/*
+ * Initialise a link with the given transport hooks and tunables. Sets the
+ * initial sender SEQ to 0; the decoder side has no SEQ until the first frame
+ * arrives.
+ */
+frame_err_t frame_link_init(frame_link_t *link,
+                            frame_link_write_cb_t write_cb,
+                            frame_link_now_ms_cb_t now_ms_cb,
+                            void *user,
+                            uint32_t timeout_ms,
+                            uint8_t max_retries);
+
+/*
+ * Send a DATA frame and start the ARQ window. Returns FRAME_OK on success,
+ * an encoder error otherwise. Caller must drive frame_link_tick() periodically
+ * (or from the byte stream) to handle timeouts and retransmits.
+ *
+ * Returns FRAME_ERR_BUF_SMALL if a previous send is still awaiting ACK — the
+ * sliding window of 1 means the caller must wait for that send to resolve.
+ */
+frame_err_t frame_link_send(frame_link_t *link,
+                            frame_type_t type,
+                            const uint8_t *payload, size_t payload_len);
+
+/*
+ * Notify the link that an ACK was received for `seq`. If it matches the
+ * pending SEQ, the link advances to IDLE. Mismatched ACKs are ignored.
+ * Returns 1 if the ACK matched (caller can issue another send), 0 otherwise.
+ */
+int frame_link_on_ack(frame_link_t *link, uint8_t seq);
+
+/*
+ * Notify the link that a NACK was received. Triggers an immediate
+ * retransmit if attempts remain. Returns 1 if a retransmit was issued, 0 if
+ * max retries were exhausted (caller should treat the send as failed).
+ */
+int frame_link_on_nack(frame_link_t *link, uint8_t seq);
+
+/*
+ * Periodic timer: call this regularly to honour the ACK timeout. Returns:
+ *   1 if a retransmit was just issued
+ *   0 if there was nothing to do (idle or still within timeout)
+ *  -1 if the send has now permanently failed (max_retries exhausted)
+ */
+int frame_link_tick(frame_link_t *link);
+
+/*
+ * Receive helper. Call this from the decoder's rx_cb to apply duplicate
+ * suppression: returns 1 if the frame is fresh and should be processed,
+ * 0 if it duplicates the previous SEQ (caller should still ACK it).
+ */
+int frame_link_on_rx(frame_link_t *link, uint8_t seq);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIB_FRAMING_H */

--- a/lib/framing/src/framing.c
+++ b/lib/framing/src/framing.c
@@ -1,0 +1,534 @@
+#include "framing.h"
+
+#include <string.h>
+
+/* ------------------------------------------------------------------------
+ * CRC-16-CCITT (a.k.a. CRC-16/IBM-3740, "CCITT-FALSE")
+ *   poly = 0x1021, init = 0xFFFF, refin = refout = false, xorout = 0x0000
+ *   reference vector: crc16("123456789") == 0x29B1
+ *
+ * Bytewise (no precomputed table) — the framing layer is bandwidth-bound at
+ * 115200 baud and the CRC is computed over <= ~1030 bytes per frame, so the
+ * extra cycles relative to a 256-entry table are well below the per-byte
+ * UART time and the table would cost us 512 B of bootloader flash.
+ * ------------------------------------------------------------------------ */
+uint16_t frame_crc16(const uint8_t *buf, size_t len)
+{
+    uint16_t crc = 0xFFFFu;
+    if (buf == NULL) {
+        return crc;
+    }
+    for (size_t i = 0; i < len; ++i) {
+        crc ^= ((uint16_t)buf[i]) << 8;
+        for (int b = 0; b < 8; ++b) {
+            if (crc & 0x8000u) {
+                crc = (uint16_t)((crc << 1) ^ 0x1021u);
+            } else {
+                crc = (uint16_t)(crc << 1);
+            }
+        }
+    }
+    return crc;
+}
+
+/* ------------------------------------------------------------------------
+ * Encoder
+ * ------------------------------------------------------------------------ */
+
+/*
+ * Append `b` to out_buf, byte-stuffing if necessary. Returns 0 on success,
+ * -1 if there is no room in out_buf.
+ */
+static int emit_stuffed(uint8_t b, uint8_t *out_buf, size_t out_cap, size_t *idx)
+{
+    if (b == FRAME_FLAG || b == FRAME_ESC) {
+        if (*idx + 2 > out_cap) {
+            return -1;
+        }
+        out_buf[(*idx)++] = FRAME_ESC;
+        out_buf[(*idx)++] = (uint8_t)(b ^ FRAME_ESC_XOR);
+    } else {
+        if (*idx + 1 > out_cap) {
+            return -1;
+        }
+        out_buf[(*idx)++] = b;
+    }
+    return 0;
+}
+
+int frame_encode(uint8_t seq, frame_type_t type,
+                 const uint8_t *payload, size_t payload_len,
+                 uint8_t *out_buf, size_t out_cap)
+{
+    if (out_buf == NULL || (payload == NULL && payload_len > 0)) {
+        return FRAME_ERR_NULL_ARG;
+    }
+    if (payload_len > FRAME_MAX_PAYLOAD) {
+        return FRAME_ERR_OVERSIZE;
+    }
+    if ((unsigned)type > (unsigned)FRAME_TYPE__MAX) {
+        return FRAME_ERR_BAD_TYPE;
+    }
+
+    /*
+     * Worst-case encoded size for this payload: 2 FLAG bytes + every byte in
+     * the body region (4 header + payload + 2 CRC) potentially doubled by
+     * stuffing. Reject up-front so the caller doesn't have to know the
+     * formula.
+     */
+    const size_t worst_case =
+        2u + 2u * (FRAME_FIXED_OVERHEAD + payload_len);
+    if (out_cap < worst_case) {
+        return FRAME_ERR_BUF_SMALL;
+    }
+
+    /* Header: SEQ, TYPE, LEN_lo, LEN_hi. */
+    const uint8_t header[4] = {
+        seq,
+        (uint8_t)type,
+        (uint8_t)(payload_len & 0xFFu),
+        (uint8_t)((payload_len >> 8) & 0xFFu),
+    };
+
+    /*
+     * CRC covers [SEQ][TYPE][LEN_lo][LEN_hi][PAYLOAD] — the unstuffed body,
+     * NOT including FLAGs or the CRC bytes themselves.
+     */
+    uint16_t crc = frame_crc16(header, sizeof(header));
+    /* Continue the CRC over the payload without recomputing the header. */
+    if (payload_len > 0) {
+        /*
+         * frame_crc16 reinitialises crc to 0xFFFF, so we re-implement the
+         * inner loop here over (header || payload) by combining a buffer.
+         * For modest payloads we just CRC over a stack copy; for full-sized
+         * payloads (1024 B) that would blow the small bootloader stack, so
+         * we instead resume the CRC manually.
+         */
+        for (size_t i = 0; i < payload_len; ++i) {
+            crc ^= ((uint16_t)payload[i]) << 8;
+            for (int b = 0; b < 8; ++b) {
+                if (crc & 0x8000u) {
+                    crc = (uint16_t)((crc << 1) ^ 0x1021u);
+                } else {
+                    crc = (uint16_t)(crc << 1);
+                }
+            }
+        }
+    }
+
+    size_t idx = 0;
+    out_buf[idx++] = FRAME_FLAG;
+
+    for (size_t i = 0; i < sizeof(header); ++i) {
+        if (emit_stuffed(header[i], out_buf, out_cap, &idx) != 0) {
+            return FRAME_ERR_BUF_SMALL;
+        }
+    }
+    for (size_t i = 0; i < payload_len; ++i) {
+        if (emit_stuffed(payload[i], out_buf, out_cap, &idx) != 0) {
+            return FRAME_ERR_BUF_SMALL;
+        }
+    }
+
+    /* CRC on the wire is little-endian: low byte first, high byte second. */
+    if (emit_stuffed((uint8_t)(crc & 0xFFu),        out_buf, out_cap, &idx) != 0) {
+        return FRAME_ERR_BUF_SMALL;
+    }
+    if (emit_stuffed((uint8_t)((crc >> 8) & 0xFFu), out_buf, out_cap, &idx) != 0) {
+        return FRAME_ERR_BUF_SMALL;
+    }
+
+    if (idx + 1 > out_cap) {
+        return FRAME_ERR_BUF_SMALL;
+    }
+    out_buf[idx++] = FRAME_FLAG;
+
+    return (int)idx;
+}
+
+/* ------------------------------------------------------------------------
+ * Decoder
+ * ------------------------------------------------------------------------ */
+
+static void decoder_clear_frame_state(frame_decoder_t *d)
+{
+    d->seq          = 0;
+    d->type         = 0;
+    d->declared_len = 0;
+    d->payload_idx  = 0;
+    d->crc_idx      = 0;
+    d->field_idx    = 0;
+    d->in_escape    = 0;
+    d->dropping     = 0;
+}
+
+frame_err_t frame_decoder_init(frame_decoder_t *d,
+                               frame_rx_cb_t rx_cb,
+                               frame_err_cb_t err_cb,
+                               void *user,
+                               uint8_t *payload_buf,
+                               size_t payload_buf_size)
+{
+    if (d == NULL || rx_cb == NULL || payload_buf == NULL) {
+        return FRAME_ERR_NULL_ARG;
+    }
+    if (payload_buf_size > FRAME_MAX_PAYLOAD) {
+        return FRAME_ERR_OVERSIZE;
+    }
+
+    d->rx_cb            = rx_cb;
+    d->err_cb           = err_cb;
+    d->user             = user;
+    d->payload_buf      = payload_buf;
+    d->payload_buf_size = payload_buf_size;
+    d->in_frame         = 0;
+    decoder_clear_frame_state(d);
+    return FRAME_OK;
+}
+
+void frame_decoder_reset(frame_decoder_t *d)
+{
+    if (d == NULL) {
+        return;
+    }
+    d->in_frame = 0;
+    decoder_clear_frame_state(d);
+}
+
+/*
+ * Notify the err_cb (if registered) and mark the current frame as dropped so
+ * subsequent bytes are discarded until the next FLAG.
+ */
+static void decoder_drop(frame_decoder_t *d, frame_err_t err)
+{
+    if (!d->dropping) {
+        d->dropping = 1;
+        if (d->err_cb != NULL) {
+            d->err_cb(err, d->user);
+        }
+    }
+}
+
+/*
+ * Consume a single unstuffed body byte, advancing the field/payload/CRC
+ * sub-state machines. Anything past the expected byte count poisons the
+ * frame.
+ */
+static void decoder_consume_byte(frame_decoder_t *d, uint8_t b)
+{
+    if (d->dropping) {
+        return;
+    }
+
+    if (d->field_idx < 4) {
+        switch (d->field_idx) {
+            case 0: d->seq          = b;                                break;
+            case 1: d->type         = b;                                break;
+            case 2: d->declared_len = b;                                break;
+            case 3: d->declared_len |= (uint16_t)((uint16_t)b << 8);    break;
+            default: break;
+        }
+        d->field_idx++;
+
+        if (d->field_idx == 4) {
+            if (d->declared_len > FRAME_MAX_PAYLOAD ||
+                d->declared_len > d->payload_buf_size) {
+                decoder_drop(d, FRAME_ERR_OVERSIZE);
+                return;
+            }
+            if ((unsigned)d->type > (unsigned)FRAME_TYPE__MAX) {
+                /*
+                 * Unknown type with a CRC-valid frame still gets up-called as
+                 * the decoder is intentionally type-tolerant; it's the upper
+                 * layer's job to reject. We don't drop here.
+                 */
+            }
+        }
+        return;
+    }
+
+    if (d->payload_idx < d->declared_len) {
+        d->payload_buf[d->payload_idx++] = b;
+        return;
+    }
+
+    if (d->crc_idx < 2) {
+        d->crc_bytes[d->crc_idx++] = b;
+        return;
+    }
+
+    /* Body too long — caller sent more bytes than LEN advertised. */
+    decoder_drop(d, FRAME_ERR_TRUNC);
+}
+
+/*
+ * Closing FLAG handler: validate the assembled frame, fire callbacks,
+ * and reset for the next frame. The caller must set in_frame=1 again
+ * afterwards because the closing FLAG is also the opening FLAG of the next
+ * frame in HDLC.
+ */
+static void decoder_finalize(frame_decoder_t *d)
+{
+    /* Empty FLAG-FLAG pair (no body bytes seen) is a benign idle marker. */
+    if (!d->dropping && !d->in_escape && d->field_idx == 0) {
+        return;
+    }
+
+    if (d->dropping) {
+        /* Error was already reported via err_cb when we entered drop. */
+        return;
+    }
+
+    if (d->in_escape) {
+        if (d->err_cb != NULL) {
+            d->err_cb(FRAME_ERR_TRUNC, d->user);
+        }
+        return;
+    }
+
+    /*
+     * Frame must have all four header bytes, the full payload, and both CRC
+     * bytes consumed before the closing FLAG.
+     */
+    if (d->field_idx != 4 ||
+        d->payload_idx != d->declared_len ||
+        d->crc_idx != 2) {
+        if (d->err_cb != NULL) {
+            d->err_cb(FRAME_ERR_TRUNC, d->user);
+        }
+        return;
+    }
+
+    /* Recompute CRC over [seq, type, len_lo, len_hi, payload]. */
+    const uint8_t header[4] = {
+        d->seq,
+        d->type,
+        (uint8_t)(d->declared_len & 0xFFu),
+        (uint8_t)((d->declared_len >> 8) & 0xFFu),
+    };
+    uint16_t crc = frame_crc16(header, sizeof(header));
+    for (uint16_t i = 0; i < d->payload_idx; ++i) {
+        crc ^= ((uint16_t)d->payload_buf[i]) << 8;
+        for (int b = 0; b < 8; ++b) {
+            if (crc & 0x8000u) {
+                crc = (uint16_t)((crc << 1) ^ 0x1021u);
+            } else {
+                crc = (uint16_t)(crc << 1);
+            }
+        }
+    }
+
+    uint16_t recv_crc =
+        (uint16_t)d->crc_bytes[0] |
+        (uint16_t)((uint16_t)d->crc_bytes[1] << 8);
+
+    if (crc != recv_crc) {
+        if (d->err_cb != NULL) {
+            d->err_cb(FRAME_ERR_CRC, d->user);
+        }
+        return;
+    }
+
+    if ((unsigned)d->type > (unsigned)FRAME_TYPE__MAX) {
+        if (d->err_cb != NULL) {
+            d->err_cb(FRAME_ERR_BAD_TYPE, d->user);
+        }
+        return;
+    }
+
+    d->rx_cb(d->seq, (frame_type_t)d->type, d->payload_buf, d->payload_idx,
+             d->user);
+}
+
+void frame_decoder_feed(frame_decoder_t *d, const uint8_t *bytes, size_t n)
+{
+    if (d == NULL || bytes == NULL) {
+        return;
+    }
+
+    for (size_t i = 0; i < n; ++i) {
+        uint8_t b = bytes[i];
+
+        if (b == FRAME_FLAG) {
+            if (d->in_frame) {
+                decoder_finalize(d);
+            }
+            decoder_clear_frame_state(d);
+            d->in_frame = 1;
+            continue;
+        }
+
+        if (!d->in_frame) {
+            /* Garbage between frames is silently dropped. */
+            continue;
+        }
+
+        if (b == FRAME_ESC) {
+            if (d->in_escape) {
+                /* Two ESCs in a row — malformed stuffing. */
+                decoder_drop(d, FRAME_ERR_TRUNC);
+                d->in_escape = 0;
+                continue;
+            }
+            d->in_escape = 1;
+            continue;
+        }
+
+        if (d->in_escape) {
+            d->in_escape = 0;
+            b ^= FRAME_ESC_XOR;
+        }
+
+        decoder_consume_byte(d, b);
+    }
+}
+
+/* ------------------------------------------------------------------------
+ * Reliable layer (sliding window of 1)
+ * ------------------------------------------------------------------------ */
+
+frame_err_t frame_link_init(frame_link_t *link,
+                            frame_link_write_cb_t write_cb,
+                            frame_link_now_ms_cb_t now_ms_cb,
+                            void *user,
+                            uint32_t timeout_ms,
+                            uint8_t max_retries)
+{
+    if (link == NULL || write_cb == NULL || now_ms_cb == NULL) {
+        return FRAME_ERR_NULL_ARG;
+    }
+    memset(link, 0, sizeof(*link));
+    link->write       = write_cb;
+    link->now_ms      = now_ms_cb;
+    link->user        = user;
+    link->timeout_ms  = timeout_ms;
+    link->max_retries = max_retries;
+    link->state       = FRAME_LINK_IDLE;
+    link->tx_seq      = 0;
+    return FRAME_OK;
+}
+
+frame_err_t frame_link_send(frame_link_t *link,
+                            frame_type_t type,
+                            const uint8_t *payload, size_t payload_len)
+{
+    if (link == NULL) {
+        return FRAME_ERR_NULL_ARG;
+    }
+    if (link->state != FRAME_LINK_IDLE) {
+        /* Sliding window of 1: reject overlapping sends. */
+        return FRAME_ERR_BUF_SMALL;
+    }
+    if (payload_len > FRAME_MAX_PAYLOAD) {
+        return FRAME_ERR_OVERSIZE;
+    }
+
+    int n = frame_encode(link->tx_seq, type,
+                         payload, payload_len,
+                         link->encoded, sizeof(link->encoded));
+    if (n < 0) {
+        return (frame_err_t)n;
+    }
+
+    /* Stash the unencoded payload so retransmits can reuse the buffer. */
+    if (payload_len > 0 && payload != NULL) {
+        memcpy(link->pending_payload, payload, payload_len);
+    }
+    link->pending_type = (uint8_t)type;
+    link->pending_len  = (uint16_t)payload_len;
+    link->encoded_len  = (size_t)n;
+
+    if (link->write(link->encoded, link->encoded_len, link->user) != 0) {
+        /*
+         * Transport failure on first send: leave state IDLE so the caller can
+         * retry on its own terms. Do not advance tx_seq.
+         */
+        return FRAME_ERR_BUF_SMALL;
+    }
+
+    link->state         = FRAME_LINK_AWAITING_ACK;
+    link->tx_started_ms = link->now_ms(link->user);
+    link->attempts      = 1;
+    return FRAME_OK;
+}
+
+int frame_link_on_ack(frame_link_t *link, uint8_t seq)
+{
+    if (link == NULL || link->state != FRAME_LINK_AWAITING_ACK) {
+        return 0;
+    }
+    if (seq != link->tx_seq) {
+        return 0;
+    }
+    link->state  = FRAME_LINK_IDLE;
+    link->tx_seq = (uint8_t)(link->tx_seq + 1u);
+    return 1;
+}
+
+/*
+ * Perform a retransmit of the pending frame. Returns 1 on success, -1 if no
+ * attempts remain (caller should treat the send as failed and reset).
+ */
+static int link_retransmit(frame_link_t *link)
+{
+    if (link->attempts > link->max_retries) {
+        link->state = FRAME_LINK_IDLE;
+        return -1;
+    }
+    if (link->write(link->encoded, link->encoded_len, link->user) != 0) {
+        /*
+         * Treat a transport-write error like an attempted retransmit: count
+         * it against the budget so a stuck transport doesn't loop forever.
+         */
+        link->attempts++;
+        link->tx_started_ms = link->now_ms(link->user);
+        return 1;
+    }
+    link->attempts++;
+    link->tx_started_ms = link->now_ms(link->user);
+    return 1;
+}
+
+int frame_link_on_nack(frame_link_t *link, uint8_t seq)
+{
+    (void)seq;
+    if (link == NULL || link->state != FRAME_LINK_AWAITING_ACK) {
+        return 0;
+    }
+    /*
+     * In a sliding-window-of-1 link there is exactly one frame in flight at
+     * any time, so any NACK received while AWAITING_ACK refers to that frame.
+     * The seq carried in the NACK is the receiver's "last good" — i.e.
+     * informational — and intentionally ignored here.
+     */
+    return link_retransmit(link) > 0 ? 1 : 0;
+}
+
+int frame_link_tick(frame_link_t *link)
+{
+    if (link == NULL || link->state != FRAME_LINK_AWAITING_ACK) {
+        return 0;
+    }
+    uint32_t now = link->now_ms(link->user);
+    /*
+     * Use unsigned subtraction so wraparound past 2^32 still produces a
+     * monotonic delta as long as the timeout fits in 31 bits.
+     */
+    if ((uint32_t)(now - link->tx_started_ms) < link->timeout_ms) {
+        return 0;
+    }
+    return link_retransmit(link);
+}
+
+int frame_link_on_rx(frame_link_t *link, uint8_t seq)
+{
+    if (link == NULL) {
+        return 0;
+    }
+    if (link->rx_have_last && link->rx_last_seq == seq) {
+        return 0;
+    }
+    link->rx_have_last = 1;
+    link->rx_last_seq  = seq;
+    return 1;
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS = string_utils cli gpio exti rcc timer uart systick flash iwdg crc lowpower lib/skeleton lib/crypto lib/img lib/flash tools/sign_roundtrip
+SUBDIRS = string_utils cli gpio exti rcc timer uart systick flash iwdg crc lowpower lib/skeleton lib/crypto lib/img lib/flash lib/framing tools/sign_roundtrip
 
 COVERAGE_INFO = coverage.info
 COVERAGE_FILT = coverage-filtered.info
@@ -76,6 +76,10 @@ run: all
 	@echo "Running lib/flash tests"
 	@echo "========================================"
 	@$(MAKE) -C lib/flash run
+	@echo "========================================"
+	@echo "Running lib/framing tests"
+	@echo "========================================"
+	@$(MAKE) -C lib/framing run
 	@echo "========================================"
 	@echo "Running tools/sign_roundtrip tests"
 	@echo "========================================"

--- a/tests/lib/framing/Makefile
+++ b/tests/lib/framing/Makefile
@@ -1,0 +1,21 @@
+CC      = gcc
+CFLAGS  = -Wall -Wextra -Wno-unknown-pragmas -Wno-unknown-warning-option \
+          -I../../../lib/framing/inc \
+          -I../../../3rd_party/unity/src \
+          $(EXTRA_CFLAGS)
+
+UNITY_SRC = ../../../3rd_party/unity/src/unity.c
+FRAMING_SRC = ../../../lib/framing/src/framing.c
+
+.PHONY: all run clean
+
+all: test_framing.out
+
+run: all
+	./test_framing.out
+
+test_framing.out: test_framing.c $(FRAMING_SRC) $(UNITY_SRC)
+	$(CC) $(CFLAGS) $^ -o $@
+
+clean:
+	rm -f *.out *.gcda *.gcno

--- a/tests/lib/framing/test_framing.c
+++ b/tests/lib/framing/test_framing.c
@@ -1,0 +1,734 @@
+#include "framing.h"
+#include "unity.h"
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* ------------------------------------------------------------------------
+ * Common test fixtures
+ * ------------------------------------------------------------------------ */
+
+#define MAX_CAPTURED 8
+
+typedef struct {
+    uint8_t      seq;
+    frame_type_t type;
+    size_t       len;
+    uint8_t      payload[FRAME_MAX_PAYLOAD];
+} captured_frame_t;
+
+typedef struct {
+    captured_frame_t frames[MAX_CAPTURED];
+    size_t           count;
+    frame_err_t      last_err;
+    int              err_count;
+} capture_t;
+
+static void capture_rx_cb(uint8_t seq, frame_type_t type,
+                          const uint8_t *payload, size_t len, void *user)
+{
+    capture_t *c = (capture_t *)user;
+    if (c->count >= MAX_CAPTURED) {
+        return;
+    }
+    captured_frame_t *f = &c->frames[c->count++];
+    f->seq  = seq;
+    f->type = type;
+    f->len  = len;
+    if (len > 0) {
+        memcpy(f->payload, payload, len);
+    }
+}
+
+static void capture_err_cb(frame_err_t err, void *user)
+{
+    capture_t *c = (capture_t *)user;
+    c->last_err = err;
+    c->err_count++;
+}
+
+/* ------------------------------------------------------------------------
+ * frame_crc16 — known vectors
+ * ------------------------------------------------------------------------ */
+
+void test_crc16_known_vector_123456789(void)
+{
+    /* CRC-16/CCITT-FALSE("123456789") == 0x29B1 */
+    const uint8_t v[] = "123456789";
+    TEST_ASSERT_EQUAL_HEX16(0x29B1u, frame_crc16(v, sizeof(v) - 1));
+}
+
+void test_crc16_empty_input_is_init(void)
+{
+    /* Init value 0xFFFF is returned for length 0. */
+    const uint8_t v[1] = {0};
+    TEST_ASSERT_EQUAL_HEX16(0xFFFFu, frame_crc16(v, 0));
+    TEST_ASSERT_EQUAL_HEX16(0xFFFFu, frame_crc16(NULL, 0));
+}
+
+/* ------------------------------------------------------------------------
+ * Encoder happy path
+ * ------------------------------------------------------------------------ */
+
+void test_encode_empty_payload(void)
+{
+    uint8_t out[FRAME_MAX_ENCODED_SIZE];
+    int n = frame_encode(0x42, FRAME_TYPE_PING, NULL, 0, out, sizeof(out));
+
+    /* FLAG + seq + type + len_lo + len_hi + crc_lo + crc_hi + FLAG = 8 bytes
+     * with no stuffing required (none of those bytes are FLAG/ESC for the
+     * specific seq/type/CRC chosen). */
+    TEST_ASSERT_GREATER_OR_EQUAL_INT(8, n);
+    TEST_ASSERT_EQUAL_HEX8(FRAME_FLAG, out[0]);
+    TEST_ASSERT_EQUAL_HEX8(FRAME_FLAG, out[n - 1]);
+    TEST_ASSERT_EQUAL_HEX8(0x42, out[1]);
+    TEST_ASSERT_EQUAL_HEX8(FRAME_TYPE_PING, out[2]);
+}
+
+void test_encode_then_decode_roundtrip(void)
+{
+    const uint8_t payload[] = {0x01, 0x02, 0x03, 0xA5, 0xFF};
+    uint8_t out[FRAME_MAX_ENCODED_SIZE];
+    int n = frame_encode(7, FRAME_TYPE_DATA,
+                         payload, sizeof(payload),
+                         out, sizeof(out));
+    TEST_ASSERT_GREATER_THAN_INT(0, n);
+
+    capture_t cap = {0};
+    frame_decoder_t d;
+    uint8_t pbuf[FRAME_MAX_PAYLOAD];
+    TEST_ASSERT_EQUAL_INT(FRAME_OK,
+        frame_decoder_init(&d, capture_rx_cb, capture_err_cb, &cap,
+                           pbuf, sizeof(pbuf)));
+
+    frame_decoder_feed(&d, out, (size_t)n);
+
+    TEST_ASSERT_EQUAL_size_t(1u, cap.count);
+    TEST_ASSERT_EQUAL_INT(0, cap.err_count);
+    TEST_ASSERT_EQUAL_HEX8(7, cap.frames[0].seq);
+    TEST_ASSERT_EQUAL_INT(FRAME_TYPE_DATA, cap.frames[0].type);
+    TEST_ASSERT_EQUAL_size_t(sizeof(payload), cap.frames[0].len);
+    TEST_ASSERT_EQUAL_MEMORY(payload, cap.frames[0].payload, sizeof(payload));
+}
+
+/* ------------------------------------------------------------------------
+ * Byte-stuffing — payloads containing FLAG / ESC must round-trip cleanly
+ * ------------------------------------------------------------------------ */
+
+void test_encode_stuffs_flag_and_esc_in_payload(void)
+{
+    const uint8_t payload[] = {FRAME_FLAG, 0x00, FRAME_ESC, 0x55, FRAME_FLAG};
+    uint8_t out[FRAME_MAX_ENCODED_SIZE];
+    int n = frame_encode(1, FRAME_TYPE_DATA,
+                         payload, sizeof(payload),
+                         out, sizeof(out));
+    TEST_ASSERT_GREATER_THAN_INT(0, n);
+
+    /* Only the leading and trailing FLAG bytes should be FRAME_FLAG; every
+     * stuffed FLAG/ESC inside the body must have been escaped. */
+    int interior_flags = 0;
+    for (int i = 1; i < n - 1; ++i) {
+        if (out[i] == FRAME_FLAG) {
+            interior_flags++;
+        }
+    }
+    TEST_ASSERT_EQUAL_INT(0, interior_flags);
+
+    /* Round-trip restores the original payload. */
+    capture_t cap = {0};
+    frame_decoder_t d;
+    uint8_t pbuf[FRAME_MAX_PAYLOAD];
+    frame_decoder_init(&d, capture_rx_cb, capture_err_cb, &cap,
+                       pbuf, sizeof(pbuf));
+    frame_decoder_feed(&d, out, (size_t)n);
+
+    TEST_ASSERT_EQUAL_size_t(1u, cap.count);
+    TEST_ASSERT_EQUAL_size_t(sizeof(payload), cap.frames[0].len);
+    TEST_ASSERT_EQUAL_MEMORY(payload, cap.frames[0].payload, sizeof(payload));
+}
+
+void test_encode_stuffs_seq_when_seq_is_flag(void)
+{
+    /* SEQ field = 0x7E — must be stuffed too. */
+    uint8_t out[FRAME_MAX_ENCODED_SIZE];
+    int n = frame_encode(FRAME_FLAG, FRAME_TYPE_DATA, NULL, 0,
+                         out, sizeof(out));
+    TEST_ASSERT_GREATER_THAN_INT(0, n);
+
+    /* Bytes 1+2 should be ESC, FLAG^0x20. */
+    TEST_ASSERT_EQUAL_HEX8(FRAME_ESC,                 out[1]);
+    TEST_ASSERT_EQUAL_HEX8(FRAME_FLAG ^ FRAME_ESC_XOR, out[2]);
+
+    capture_t cap = {0};
+    frame_decoder_t d;
+    uint8_t pbuf[16];
+    frame_decoder_init(&d, capture_rx_cb, capture_err_cb, &cap, pbuf, sizeof(pbuf));
+    frame_decoder_feed(&d, out, (size_t)n);
+    TEST_ASSERT_EQUAL_size_t(1u, cap.count);
+    TEST_ASSERT_EQUAL_HEX8(FRAME_FLAG, cap.frames[0].seq);
+}
+
+/* ------------------------------------------------------------------------
+ * Encoder error paths
+ * ------------------------------------------------------------------------ */
+
+void test_encode_null_out_buf_rejected(void)
+{
+    int n = frame_encode(0, FRAME_TYPE_DATA, NULL, 0, NULL, 16);
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_NULL_ARG, n);
+}
+
+void test_encode_null_payload_with_nonzero_len_rejected(void)
+{
+    uint8_t out[16];
+    int n = frame_encode(0, FRAME_TYPE_DATA, NULL, 5, out, sizeof(out));
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_NULL_ARG, n);
+}
+
+void test_encode_oversize_payload_rejected(void)
+{
+    static uint8_t big[FRAME_MAX_PAYLOAD + 1];
+    uint8_t out[FRAME_MAX_ENCODED_SIZE];
+    int n = frame_encode(0, FRAME_TYPE_DATA, big, sizeof(big),
+                         out, sizeof(out));
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_OVERSIZE, n);
+}
+
+void test_encode_bad_type_rejected(void)
+{
+    uint8_t out[16];
+    int n = frame_encode(0, (frame_type_t)(FRAME_TYPE__MAX + 1),
+                         NULL, 0, out, sizeof(out));
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_BAD_TYPE, n);
+}
+
+void test_encode_buf_too_small_rejected(void)
+{
+    uint8_t payload[8] = {0};
+    uint8_t out[6]; /* far below worst-case for an 8-byte payload */
+    int n = frame_encode(0, FRAME_TYPE_DATA, payload, sizeof(payload),
+                         out, sizeof(out));
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_BUF_SMALL, n);
+}
+
+/* ------------------------------------------------------------------------
+ * Decoder error / edge cases
+ * ------------------------------------------------------------------------ */
+
+void test_decoder_init_null_args(void)
+{
+    frame_decoder_t d;
+    uint8_t pbuf[8];
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_NULL_ARG,
+        frame_decoder_init(NULL, capture_rx_cb, NULL, NULL, pbuf, sizeof(pbuf)));
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_NULL_ARG,
+        frame_decoder_init(&d, NULL, NULL, NULL, pbuf, sizeof(pbuf)));
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_NULL_ARG,
+        frame_decoder_init(&d, capture_rx_cb, NULL, NULL, NULL, 0));
+}
+
+void test_decoder_init_oversize_buf_rejected(void)
+{
+    frame_decoder_t d;
+    /* size + 1 confirms the cap is exclusive of FRAME_MAX_PAYLOAD+1. */
+    static uint8_t pbuf[FRAME_MAX_PAYLOAD + 1];
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_OVERSIZE,
+        frame_decoder_init(&d, capture_rx_cb, NULL, NULL,
+                           pbuf, sizeof(pbuf)));
+}
+
+void test_decoder_feed_null_args_safe(void)
+{
+    frame_decoder_t d;
+    uint8_t pbuf[8];
+    capture_t cap = {0};
+    frame_decoder_init(&d, capture_rx_cb, capture_err_cb, &cap,
+                       pbuf, sizeof(pbuf));
+
+    /* Either NULL pointer must early-return without crashing. */
+    frame_decoder_feed(NULL, NULL, 0);
+    frame_decoder_feed(&d, NULL, 0);
+    TEST_ASSERT_EQUAL_size_t(0u, cap.count);
+}
+
+void test_decoder_crc_mismatch_drops_frame_and_reports_err(void)
+{
+    const uint8_t payload[] = {0xCA, 0xFE};
+    uint8_t out[FRAME_MAX_ENCODED_SIZE];
+    int n = frame_encode(2, FRAME_TYPE_DATA, payload, sizeof(payload),
+                         out, sizeof(out));
+    TEST_ASSERT_GREATER_THAN_INT(0, n);
+
+    /* Flip a single payload byte — CRC must reject. The mutated byte must not
+     * become a special FLAG/ESC sentinel; XOR with 0x01 keeps 0xCA -> 0xCB. */
+    out[5] ^= 0x01u;
+
+    capture_t cap = {0};
+    frame_decoder_t d;
+    uint8_t pbuf[FRAME_MAX_PAYLOAD];
+    frame_decoder_init(&d, capture_rx_cb, capture_err_cb, &cap, pbuf, sizeof(pbuf));
+    frame_decoder_feed(&d, out, (size_t)n);
+
+    TEST_ASSERT_EQUAL_size_t(0u, cap.count);
+    TEST_ASSERT_EQUAL_INT(1, cap.err_count);
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_CRC, cap.last_err);
+}
+
+void test_decoder_truncation_then_resync(void)
+{
+    const uint8_t payload[] = {0xDE, 0xAD};
+    uint8_t out[FRAME_MAX_ENCODED_SIZE];
+    int n = frame_encode(5, FRAME_TYPE_DATA, payload, sizeof(payload),
+                         out, sizeof(out));
+    TEST_ASSERT_GREATER_THAN_INT(0, n);
+
+    capture_t cap = {0};
+    frame_decoder_t d;
+    uint8_t pbuf[FRAME_MAX_PAYLOAD];
+    frame_decoder_init(&d, capture_rx_cb, capture_err_cb, &cap, pbuf, sizeof(pbuf));
+
+    /* Half a frame — decoder stays mid-frame, no callback fires. */
+    frame_decoder_feed(&d, out, (size_t)(n / 2));
+    TEST_ASSERT_EQUAL_size_t(0u, cap.count);
+
+    /* Now feed a fresh, complete frame. The truncated half-frame must be
+     * abandoned (closing FLAG of a partial body fires err_cb), and the new
+     * frame must decode cleanly. */
+    int n2 = frame_encode(6, FRAME_TYPE_PING, NULL, 0, out, sizeof(out));
+    frame_decoder_feed(&d, out, (size_t)n2);
+
+    TEST_ASSERT_EQUAL_size_t(1u, cap.count);
+    TEST_ASSERT_EQUAL_HEX8(6, cap.frames[0].seq);
+    TEST_ASSERT_EQUAL_INT(FRAME_TYPE_PING, cap.frames[0].type);
+    TEST_ASSERT_GREATER_OR_EQUAL_INT(1, cap.err_count);
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_TRUNC, cap.last_err);
+}
+
+void test_decoder_garbage_prefix_silently_dropped(void)
+{
+    const uint8_t junk[] = {0x00, 0x55, 0xAA, 0x33}; /* before any FLAG */
+    const uint8_t payload[] = {0xBE, 0xEF};
+    uint8_t out[FRAME_MAX_ENCODED_SIZE];
+    int n = frame_encode(11, FRAME_TYPE_DATA, payload, sizeof(payload),
+                         out, sizeof(out));
+
+    capture_t cap = {0};
+    frame_decoder_t d;
+    uint8_t pbuf[FRAME_MAX_PAYLOAD];
+    frame_decoder_init(&d, capture_rx_cb, capture_err_cb, &cap, pbuf, sizeof(pbuf));
+
+    frame_decoder_feed(&d, junk, sizeof(junk));
+    TEST_ASSERT_EQUAL_INT(0, cap.err_count);
+
+    frame_decoder_feed(&d, out, (size_t)n);
+    TEST_ASSERT_EQUAL_size_t(1u, cap.count);
+    TEST_ASSERT_EQUAL_INT(0, cap.err_count);
+}
+
+void test_decoder_idle_flag_pair_ignored(void)
+{
+    /* Two adjacent FLAGs (HDLC idle marker) must not produce a frame or err. */
+    const uint8_t flags[] = {FRAME_FLAG, FRAME_FLAG, FRAME_FLAG};
+    capture_t cap = {0};
+    frame_decoder_t d;
+    uint8_t pbuf[8];
+    frame_decoder_init(&d, capture_rx_cb, capture_err_cb, &cap, pbuf, sizeof(pbuf));
+    frame_decoder_feed(&d, flags, sizeof(flags));
+    TEST_ASSERT_EQUAL_size_t(0u, cap.count);
+    TEST_ASSERT_EQUAL_INT(0, cap.err_count);
+}
+
+void test_decoder_oversize_payload_dropped(void)
+{
+    /* Hand-craft a frame whose LEN field claims more bytes than the
+     * decoder's payload buffer can hold. */
+    uint8_t buf[64];
+    size_t i = 0;
+    buf[i++] = FRAME_FLAG;
+    buf[i++] = 0x00;          /* seq */
+    buf[i++] = FRAME_TYPE_DATA;
+    buf[i++] = 0x10;          /* len_lo = 16 */
+    buf[i++] = 0x00;          /* len_hi */
+    /* No need to fill 16 payload bytes — the decoder must drop on the
+     * field-complete check before consuming payload. */
+
+    capture_t cap = {0};
+    frame_decoder_t d;
+    uint8_t pbuf[8]; /* < 16 advertised */
+    frame_decoder_init(&d, capture_rx_cb, capture_err_cb, &cap, pbuf, sizeof(pbuf));
+    frame_decoder_feed(&d, buf, i);
+    TEST_ASSERT_EQUAL_size_t(0u, cap.count);
+    TEST_ASSERT_EQUAL_INT(1, cap.err_count);
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_OVERSIZE, cap.last_err);
+}
+
+void test_decoder_double_esc_drops_frame(void)
+{
+    /* ESC followed immediately by another ESC is illegal stuffing. */
+    const uint8_t bad[] = {FRAME_FLAG, FRAME_ESC, FRAME_ESC, FRAME_FLAG};
+    capture_t cap = {0};
+    frame_decoder_t d;
+    uint8_t pbuf[8];
+    frame_decoder_init(&d, capture_rx_cb, capture_err_cb, &cap, pbuf, sizeof(pbuf));
+    frame_decoder_feed(&d, bad, sizeof(bad));
+    TEST_ASSERT_EQUAL_size_t(0u, cap.count);
+    TEST_ASSERT_EQUAL_INT(1, cap.err_count);
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_TRUNC, cap.last_err);
+}
+
+void test_decoder_trailing_esc_before_flag_drops_frame(void)
+{
+    /* A frame whose body ends with a lone ESC immediately before the closing
+     * FLAG is malformed (the ESC must be followed by the XORed byte). */
+    const uint8_t bad[] = {FRAME_FLAG, 0x01, 0x02, 0x00, 0x00, FRAME_ESC, FRAME_FLAG};
+    capture_t cap = {0};
+    frame_decoder_t d;
+    uint8_t pbuf[8];
+    frame_decoder_init(&d, capture_rx_cb, capture_err_cb, &cap, pbuf, sizeof(pbuf));
+    frame_decoder_feed(&d, bad, sizeof(bad));
+    TEST_ASSERT_EQUAL_size_t(0u, cap.count);
+    TEST_ASSERT_EQUAL_INT(1, cap.err_count);
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_TRUNC, cap.last_err);
+}
+
+void test_decoder_bad_type_with_valid_crc_reports_err(void)
+{
+    /* Build a frame that has a CRC-valid body but TYPE > FRAME_TYPE__MAX.
+     * Easiest: encode normally then mutate the type byte and recompute CRC
+     * by hand. We instead just bypass the encoder and stuff manually. */
+    const uint8_t header[4] = {0x00, 0xFF /* bogus type */, 0x00, 0x00};
+    uint16_t crc = frame_crc16(header, sizeof(header));
+
+    uint8_t buf[16];
+    size_t i = 0;
+    buf[i++] = FRAME_FLAG;
+    buf[i++] = header[0];
+    buf[i++] = header[1];  /* not FLAG/ESC -> no stuffing */
+    buf[i++] = header[2];
+    buf[i++] = header[3];
+    buf[i++] = (uint8_t)(crc & 0xFFu);
+    buf[i++] = (uint8_t)((crc >> 8) & 0xFFu);
+    buf[i++] = FRAME_FLAG;
+
+    capture_t cap = {0};
+    frame_decoder_t d;
+    uint8_t pbuf[8];
+    frame_decoder_init(&d, capture_rx_cb, capture_err_cb, &cap, pbuf, sizeof(pbuf));
+    frame_decoder_feed(&d, buf, i);
+
+    TEST_ASSERT_EQUAL_size_t(0u, cap.count);
+    TEST_ASSERT_EQUAL_INT(1, cap.err_count);
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_BAD_TYPE, cap.last_err);
+}
+
+void test_decoder_byte_at_a_time_feed(void)
+{
+    const uint8_t payload[] = {0x10, 0x20, 0x30, 0x40};
+    uint8_t out[FRAME_MAX_ENCODED_SIZE];
+    int n = frame_encode(9, FRAME_TYPE_OTA_CHUNK,
+                         payload, sizeof(payload),
+                         out, sizeof(out));
+
+    capture_t cap = {0};
+    frame_decoder_t d;
+    uint8_t pbuf[FRAME_MAX_PAYLOAD];
+    frame_decoder_init(&d, capture_rx_cb, capture_err_cb, &cap, pbuf, sizeof(pbuf));
+
+    /* Feed one byte at a time — the decoder must reassemble correctly. */
+    for (int i = 0; i < n; ++i) {
+        frame_decoder_feed(&d, &out[i], 1);
+    }
+    TEST_ASSERT_EQUAL_size_t(1u, cap.count);
+    TEST_ASSERT_EQUAL_HEX8(9, cap.frames[0].seq);
+    TEST_ASSERT_EQUAL_size_t(sizeof(payload), cap.frames[0].len);
+}
+
+void test_decoder_max_payload_round_trip(void)
+{
+    static uint8_t big[FRAME_MAX_PAYLOAD];
+    for (size_t i = 0; i < sizeof(big); ++i) {
+        big[i] = (uint8_t)(i & 0xFFu);
+    }
+    static uint8_t out[FRAME_MAX_ENCODED_SIZE];
+    int n = frame_encode(0, FRAME_TYPE_DATA, big, sizeof(big),
+                         out, sizeof(out));
+    TEST_ASSERT_GREATER_THAN_INT(0, n);
+
+    capture_t cap = {0};
+    frame_decoder_t d;
+    static uint8_t pbuf[FRAME_MAX_PAYLOAD];
+    frame_decoder_init(&d, capture_rx_cb, capture_err_cb, &cap, pbuf, sizeof(pbuf));
+    frame_decoder_feed(&d, out, (size_t)n);
+
+    TEST_ASSERT_EQUAL_size_t(1u, cap.count);
+    TEST_ASSERT_EQUAL_size_t(sizeof(big), cap.frames[0].len);
+    TEST_ASSERT_EQUAL_MEMORY(big, cap.frames[0].payload, sizeof(big));
+}
+
+void test_decoder_reset_clears_in_progress_frame(void)
+{
+    capture_t cap = {0};
+    frame_decoder_t d;
+    uint8_t pbuf[8];
+    frame_decoder_init(&d, capture_rx_cb, capture_err_cb, &cap, pbuf, sizeof(pbuf));
+
+    /* Start a frame mid-stream, then reset before completing it. */
+    const uint8_t partial[] = {FRAME_FLAG, 0x01, 0x02};
+    frame_decoder_feed(&d, partial, sizeof(partial));
+    frame_decoder_reset(&d);
+    frame_decoder_reset(NULL); /* no-op, must not crash */
+
+    /* Reset should also discard the carried in_frame=1, so a subsequent
+     * fresh frame must decode without surfacing the partial as a TRUNC. */
+    uint8_t out[FRAME_MAX_ENCODED_SIZE];
+    int n = frame_encode(3, FRAME_TYPE_PING, NULL, 0, out, sizeof(out));
+    frame_decoder_feed(&d, out, (size_t)n);
+
+    TEST_ASSERT_EQUAL_size_t(1u, cap.count);
+    TEST_ASSERT_EQUAL_HEX8(3, cap.frames[0].seq);
+    /* No truncation error because the partial was reset, not finalised. */
+    TEST_ASSERT_EQUAL_INT(0, cap.err_count);
+}
+
+/* ------------------------------------------------------------------------
+ * Reliable layer (frame_link)
+ * ------------------------------------------------------------------------ */
+
+typedef struct {
+    uint8_t  bytes[FRAME_MAX_ENCODED_SIZE];
+    size_t   len;
+    int      writes;
+    int      write_should_fail;
+    uint32_t now;
+} link_io_t;
+
+static int link_write_cb(const uint8_t *bytes, size_t n, void *user)
+{
+    link_io_t *io = (link_io_t *)user;
+    if (io->write_should_fail) {
+        return -1;
+    }
+    io->writes++;
+    if (n > sizeof(io->bytes)) n = sizeof(io->bytes);
+    memcpy(io->bytes, bytes, n);
+    io->len = n;
+    return 0;
+}
+
+static uint32_t link_now_ms_cb(void *user)
+{
+    link_io_t *io = (link_io_t *)user;
+    return io->now;
+}
+
+void test_link_init_null_args(void)
+{
+    frame_link_t link;
+    link_io_t io = {0};
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_NULL_ARG,
+        frame_link_init(NULL, link_write_cb, link_now_ms_cb, &io, 100, 3));
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_NULL_ARG,
+        frame_link_init(&link, NULL, link_now_ms_cb, &io, 100, 3));
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_NULL_ARG,
+        frame_link_init(&link, link_write_cb, NULL, &io, 100, 3));
+}
+
+void test_link_send_then_ack_advances_seq(void)
+{
+    frame_link_t link;
+    link_io_t io = {0};
+    frame_link_init(&link, link_write_cb, link_now_ms_cb, &io, 100, 3);
+
+    const uint8_t payload[] = {0xAB};
+    TEST_ASSERT_EQUAL_INT(FRAME_OK,
+        frame_link_send(&link, FRAME_TYPE_DATA, payload, sizeof(payload)));
+    TEST_ASSERT_EQUAL_INT(1, io.writes);
+
+    /* ACK with wrong seq is ignored. */
+    TEST_ASSERT_EQUAL_INT(0, frame_link_on_ack(&link, 99));
+
+    /* Correct ACK advances the link to IDLE; tx_seq increments. */
+    TEST_ASSERT_EQUAL_INT(1, frame_link_on_ack(&link, 0));
+    TEST_ASSERT_EQUAL_INT(0, frame_link_on_ack(&link, 0)); /* now IDLE */
+
+    /* Next send uses seq 1. */
+    TEST_ASSERT_EQUAL_INT(FRAME_OK,
+        frame_link_send(&link, FRAME_TYPE_DATA, payload, sizeof(payload)));
+    TEST_ASSERT_EQUAL_INT(1, frame_link_on_ack(&link, 1));
+}
+
+void test_link_send_overlap_rejected(void)
+{
+    frame_link_t link;
+    link_io_t io = {0};
+    frame_link_init(&link, link_write_cb, link_now_ms_cb, &io, 100, 3);
+
+    const uint8_t payload[] = {0xAB};
+    frame_link_send(&link, FRAME_TYPE_DATA, payload, sizeof(payload));
+    /* Sliding-window-of-1: a second send while AWAITING_ACK must fail. */
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_BUF_SMALL,
+        frame_link_send(&link, FRAME_TYPE_DATA, payload, sizeof(payload)));
+}
+
+void test_link_send_oversize_rejected(void)
+{
+    frame_link_t link;
+    link_io_t io = {0};
+    frame_link_init(&link, link_write_cb, link_now_ms_cb, &io, 100, 3);
+    static uint8_t big[FRAME_MAX_PAYLOAD + 1];
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_OVERSIZE,
+        frame_link_send(&link, FRAME_TYPE_DATA, big, sizeof(big)));
+}
+
+void test_link_send_null_link_rejected(void)
+{
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_NULL_ARG,
+        frame_link_send(NULL, FRAME_TYPE_DATA, NULL, 0));
+    TEST_ASSERT_EQUAL_INT(0, frame_link_on_ack(NULL, 0));
+    TEST_ASSERT_EQUAL_INT(0, frame_link_on_nack(NULL, 0));
+    TEST_ASSERT_EQUAL_INT(0, frame_link_tick(NULL));
+    TEST_ASSERT_EQUAL_INT(0, frame_link_on_rx(NULL, 0));
+}
+
+void test_link_send_write_failure_keeps_state_idle(void)
+{
+    frame_link_t link;
+    link_io_t io = {0};
+    frame_link_init(&link, link_write_cb, link_now_ms_cb, &io, 100, 3);
+
+    io.write_should_fail = 1;
+    const uint8_t payload[] = {0xAB};
+    TEST_ASSERT_EQUAL_INT(FRAME_ERR_BUF_SMALL,
+        frame_link_send(&link, FRAME_TYPE_DATA, payload, sizeof(payload)));
+
+    /* State remained IDLE — caller can retry without overlap. */
+    io.write_should_fail = 0;
+    TEST_ASSERT_EQUAL_INT(FRAME_OK,
+        frame_link_send(&link, FRAME_TYPE_DATA, payload, sizeof(payload)));
+}
+
+void test_link_nack_triggers_retransmit(void)
+{
+    frame_link_t link;
+    link_io_t io = {0};
+    frame_link_init(&link, link_write_cb, link_now_ms_cb, &io, 100, 2);
+
+    const uint8_t payload[] = {0xAB};
+    frame_link_send(&link, FRAME_TYPE_DATA, payload, sizeof(payload));
+    TEST_ASSERT_EQUAL_INT(1, io.writes);
+
+    /* First NACK -> retransmit attempt #2. */
+    TEST_ASSERT_EQUAL_INT(1, frame_link_on_nack(&link, 0));
+    TEST_ASSERT_EQUAL_INT(2, io.writes);
+
+    /* Second NACK -> retransmit attempt #3 (last allowed: 1 + max_retries). */
+    TEST_ASSERT_EQUAL_INT(1, frame_link_on_nack(&link, 0));
+    TEST_ASSERT_EQUAL_INT(3, io.writes);
+
+    /* Third NACK -> exhausted, link returns to IDLE. */
+    TEST_ASSERT_EQUAL_INT(0, frame_link_on_nack(&link, 0));
+}
+
+void test_link_tick_retransmits_after_timeout(void)
+{
+    frame_link_t link;
+    link_io_t io = {0};
+    frame_link_init(&link, link_write_cb, link_now_ms_cb, &io, 100, 2);
+
+    const uint8_t payload[] = {0xAB};
+    frame_link_send(&link, FRAME_TYPE_DATA, payload, sizeof(payload));
+
+    /* Tick before timeout -> nothing happens. */
+    io.now = 50;
+    TEST_ASSERT_EQUAL_INT(0, frame_link_tick(&link));
+    TEST_ASSERT_EQUAL_INT(1, io.writes);
+
+    /* Tick at timeout boundary -> retransmit. */
+    io.now = 100;
+    TEST_ASSERT_EQUAL_INT(1, frame_link_tick(&link));
+    TEST_ASSERT_EQUAL_INT(2, io.writes);
+
+    /* Two more ticks past their respective timeouts -> third attempt then exhausted. */
+    io.now = 250;
+    TEST_ASSERT_EQUAL_INT(1, frame_link_tick(&link));
+    io.now = 400;
+    TEST_ASSERT_EQUAL_INT(-1, frame_link_tick(&link));
+}
+
+void test_link_tick_idle_link_is_noop(void)
+{
+    frame_link_t link;
+    link_io_t io = {0};
+    frame_link_init(&link, link_write_cb, link_now_ms_cb, &io, 100, 2);
+    /* Never sent — link is IDLE. */
+    TEST_ASSERT_EQUAL_INT(0, frame_link_tick(&link));
+}
+
+void test_link_on_rx_dedups_repeated_seq(void)
+{
+    frame_link_t link;
+    link_io_t io = {0};
+    frame_link_init(&link, link_write_cb, link_now_ms_cb, &io, 100, 2);
+
+    /* First time we've seen seq=42 -> fresh. */
+    TEST_ASSERT_EQUAL_INT(1, frame_link_on_rx(&link, 42));
+    /* Same seq again -> duplicate (caller still ACKs it). */
+    TEST_ASSERT_EQUAL_INT(0, frame_link_on_rx(&link, 42));
+    /* Different seq -> fresh again. */
+    TEST_ASSERT_EQUAL_INT(1, frame_link_on_rx(&link, 43));
+}
+
+/* ------------------------------------------------------------------------
+ * Test runner
+ * ------------------------------------------------------------------------ */
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_crc16_known_vector_123456789);
+    RUN_TEST(test_crc16_empty_input_is_init);
+
+    RUN_TEST(test_encode_empty_payload);
+    RUN_TEST(test_encode_then_decode_roundtrip);
+    RUN_TEST(test_encode_stuffs_flag_and_esc_in_payload);
+    RUN_TEST(test_encode_stuffs_seq_when_seq_is_flag);
+
+    RUN_TEST(test_encode_null_out_buf_rejected);
+    RUN_TEST(test_encode_null_payload_with_nonzero_len_rejected);
+    RUN_TEST(test_encode_oversize_payload_rejected);
+    RUN_TEST(test_encode_bad_type_rejected);
+    RUN_TEST(test_encode_buf_too_small_rejected);
+
+    RUN_TEST(test_decoder_init_null_args);
+    RUN_TEST(test_decoder_init_oversize_buf_rejected);
+    RUN_TEST(test_decoder_feed_null_args_safe);
+    RUN_TEST(test_decoder_crc_mismatch_drops_frame_and_reports_err);
+    RUN_TEST(test_decoder_truncation_then_resync);
+    RUN_TEST(test_decoder_garbage_prefix_silently_dropped);
+    RUN_TEST(test_decoder_idle_flag_pair_ignored);
+    RUN_TEST(test_decoder_oversize_payload_dropped);
+    RUN_TEST(test_decoder_double_esc_drops_frame);
+    RUN_TEST(test_decoder_trailing_esc_before_flag_drops_frame);
+    RUN_TEST(test_decoder_bad_type_with_valid_crc_reports_err);
+    RUN_TEST(test_decoder_byte_at_a_time_feed);
+    RUN_TEST(test_decoder_max_payload_round_trip);
+    RUN_TEST(test_decoder_reset_clears_in_progress_frame);
+
+    RUN_TEST(test_link_init_null_args);
+    RUN_TEST(test_link_send_then_ack_advances_seq);
+    RUN_TEST(test_link_send_overlap_rejected);
+    RUN_TEST(test_link_send_oversize_rejected);
+    RUN_TEST(test_link_send_null_link_rejected);
+    RUN_TEST(test_link_send_write_failure_keeps_state_idle);
+    RUN_TEST(test_link_nack_triggers_retransmit);
+    RUN_TEST(test_link_tick_retransmits_after_timeout);
+    RUN_TEST(test_link_tick_idle_link_is_noop);
+    RUN_TEST(test_link_on_rx_dedups_repeated_seq);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
First half of #162 / Plan 001 Phase 1.8. The bootloader OTA receiver, app-side `ota_request` CLI command, `tools/ota_send.py`, and HIL `run_ota_test.py` will land in a follow-up PR on top of this one — the issue explicitly allowed splitting framing+OTA into two stacked PRs, and this lib is independently useful (Plan 002 §2.2 reuses it for inter-board comms).

## Summary

- `lib/framing/`: HDLC-style byte stream — `FLAG=0x7E`, `ESC=0x7D` byte-stuffing, max payload 1024 B, CRC-16-CCITT (poly `0x1021`, init `0xFFFF`, no final XOR) over the unstuffed `[SEQ][TYPE][LEN][PAYLOAD]` span.
- Three layers in one lib:
  - **`frame_encode()`** — pure encoder; computes worst-case stuffed size, rejects oversize / NULL / bad-type / too-small-out-buf inputs.
  - **`frame_decoder_t` / `frame_decoder_feed`** — stateful byte pump, fires `rx_cb` on each CRC-valid frame and `err_cb` on CRC mismatch / truncation / oversize / bad type. Resyncs on the next FLAG.
  - **`frame_link_t`** — sliding-window-of-1 stop-and-wait ARQ. Configurable timeout + retries, NACK-driven retransmit, duplicate-SEQ suppression on the receive side. Transport-agnostic via `write` / `now_ms` callbacks (so the same code drives UART today and SPI in Plan 002 later).
- 35 host unit tests in `tests/lib/framing/`. **Line coverage 95.3 %** on `lib/framing/src/framing.c`, meeting the ≥ 95 % bar Plan 002 §2.2 sets for this layer (measured locally with `gcov`).

## Test plan

- [x] `make test` — all suites pass; new framing suite contributes 35 tests.
- [x] `make all` — every existing app builds clean (no behavioural change to apps yet — the new lib is just available for the OTA receiver to link against in the follow-up PR).
- [x] `gcov` on `lib/framing/src/framing.c` reports 95.30 % of 298 lines executed.
- [x] CI `host-tests` and `firmware-build` jobs go green.

## Out of scope here (lands in PR #2 of the stack)

- Bootloader OTA receiver path (`apps/bootloader/loader/`).
- App-side `ota_request` CLI command (`apps/cli/`).
- `tools/ota_send.py` host driver.
- `scripts/run_ota_test.py` HIL flow.
- `docs/wiki/plans/001-bootloader/ota.md` and the Phase-1.8-status update on the plan page.