### PR TITLE
Plan 001 Phase 1.8 (part 2): bootloader OTA receiver, ota_send.py, HIL test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,3 +164,20 @@ jobs:
           path: ab-slot-results.xml
           reporter: java-junit
           fail-on-error: false
+
+      # Plan 001 Phase 1.8 — OTA over UART end-to-end test.  Drives the
+      # CLI's ota_request command, runs tools/ota_send.py against the
+      # bootloader's OTA receiver, and verifies both the clean OTA path
+      # (slot A → B with STATUS=ok) and the tampered OTA path
+      # (STATUS=verify_failed, slot A still active on next boot).
+      - name: Run OTA test
+        run: python3 scripts/run_ota_test.py --board ci --junit-xml ota-results.xml
+
+      - name: Publish OTA test results
+        uses: dorny/test-reporter@v3
+        if: always()
+        with:
+          name: OTA Test
+          path: ota-results.xml
+          reporter: java-junit
+          fail-on-error: false

--- a/apps/bootloader/loader/Makefile
+++ b/apps/bootloader/loader/Makefile
@@ -30,22 +30,34 @@ LOCAL_BUILD_DIR := $(BUILD_DIR)/apps/bootloader/loader
 #==============================================================================
 # Sources
 #==============================================================================
-LOADER_SRCS := main.c $(BL_PUBKEY_C)
-LOADER_OBJS := $(LOCAL_BUILD_DIR)/main.o $(LOCAL_BUILD_DIR)/bootloader_pubkey.o
+# Phase 1.8 splits the loader across three TUs:
+#   - main.c     : reset-vector entry, magic-flag check, slot pick + verify-
+#                  and-jump (Phase 1.5–1.7).
+#   - verify.c   : header parse + SHA-256 + ECDSA — shared with ota.c so the
+#                  same correctness path covers normal boot AND OTA.
+#   - ota.c      : Phase 1.8 OTA receiver state machine — framing decoder,
+#                  flash writer, atomic active-slot swap.
+LOADER_SRCS := main.c verify.c ota.c $(BL_PUBKEY_C)
+LOADER_OBJS := $(LOCAL_BUILD_DIR)/main.o \
+               $(LOCAL_BUILD_DIR)/verify.o \
+               $(LOCAL_BUILD_DIR)/ota.o \
+               $(LOCAL_BUILD_DIR)/bootloader_pubkey.o
 
 # Bootloader-specific includes:
-#   lib/img    — header + slot metadata parser
-#   lib/crypto — SHA-256 + ECDSA verify (Phase 1.6)
-#   lib/flash  — slot-id constants only (Phase 1.7); the bootloader links
-#                no flash mutation code, just the address constants from
-#                the public header.
-LOADER_CFLAGS := -I$(LIB_DIR)/img/inc -I$(LIB_DIR)/crypto/inc -I$(LIB_DIR)/flash/inc
+#   lib/img     — header + slot metadata parser
+#   lib/crypto  — SHA-256 + ECDSA verify (Phase 1.6)
+#   lib/flash   — slot constants + Phase 1.8 mutation primitives
+#   lib/framing — Phase 1.8 OTA wire protocol
+LOADER_CFLAGS := -I$(LIB_DIR)/img/inc -I$(LIB_DIR)/crypto/inc \
+                 -I$(LIB_DIR)/flash/inc -I$(LIB_DIR)/framing/inc
 
 # CRYPTO_LIB ahead of IMG_LIB so the linker resolves crypto symbols first
-# inside the start-group; IMG_LIB does not depend on crypto, so order is
-# only meaningful for predictability.  No FLASH_LIB — the bootloader uses
-# only inlined constants from flash_slot.h, not any libflash.a symbols.
-LOADER_DEPS := $(CRYPTO_LIB) $(IMG_LIB) $(DRIVERS_LIB) $(STARTUP_OBJ)
+# inside the start-group; FLASH_LIB and FRAMING_LIB land alongside since
+# Phase 1.8 needs both the slot-erase + commit-metadata path and the
+# framing decoder.  --gc-sections drops anything the OTA path doesn't
+# call, so a non-OTA boot pays only for the cold-path flag check.
+LOADER_DEPS := $(CRYPTO_LIB) $(FRAMING_LIB) $(FLASH_LIB) $(IMG_LIB) \
+               $(DRIVERS_LIB) $(STARTUP_OBJ)
 
 .PHONY: all clean help bootloader
 
@@ -58,7 +70,19 @@ bootloader: $(LOCAL_BUILD_DIR)/loader.bin
 	@echo "Bootloader built successfully ($(LOCAL_BUILD_DIR)/loader.bin)."
 
 # Compile main.c.
-$(LOCAL_BUILD_DIR)/main.o: main.c
+$(LOCAL_BUILD_DIR)/main.o: main.c verify.h ota.h
+	$(make-build-dir)
+	@echo "Compiling: $<"
+	$(CC) $(CFLAGS) $(LOADER_CFLAGS) -o $@ $<
+
+# Compile verify.c.
+$(LOCAL_BUILD_DIR)/verify.o: verify.c verify.h
+	$(make-build-dir)
+	@echo "Compiling: $<"
+	$(CC) $(CFLAGS) $(LOADER_CFLAGS) -o $@ $<
+
+# Compile ota.c.
+$(LOCAL_BUILD_DIR)/ota.o: ota.c ota.h verify.h
 	$(make-build-dir)
 	@echo "Compiling: $<"
 	$(CC) $(CFLAGS) $(LOADER_CFLAGS) -o $@ $<

--- a/apps/bootloader/loader/main.c
+++ b/apps/bootloader/loader/main.c
@@ -1,7 +1,12 @@
 /*
- * Bootloader — Plan 001 Phase 1.5 (skeleton) + 1.6 (verify) + 1.7 (A/B + fallback).
+ * Bootloader — Plan 001 Phase 1.5 (skeleton) + 1.6 (verify) + 1.7 (A/B + fallback)
+ *                 + 1.8 (OTA receiver entered via RTC backup register magic).
  *
  * Lives in sector 0 (0x08000000, 16 KB).  Boot flow:
+ *
+ *   0. Read RTC_BKP_DR0.  If it equals RTC_BACKUP_OTA_MAGIC, clear it
+ *      and hand control to bootloader_ota_run(), which never returns —
+ *      it either NVIC_SystemReset()s into the new image or halts.
  *
  *   1. Read both slot-metadata blobs (sectors 1 and 2).  Pick the active
  *      slot:
@@ -13,11 +18,9 @@
  *   3. If both slots fail verify, halt with a distinct log line.
  *   4. Otherwise jump.
  *
- * Phase 1.6's verify call is invoked unchanged from a small wrapper —
- * Phase 1.7 only adds the slot-pick + retry around it.  fail_count and
- * monotonic_counter live in the metadata struct but the bootloader does
- * not yet write them; that lands with rollback-on-crash semantics in a
- * later phase together with Phase 1.9 anti-rollback.
+ * verify_slot() is shared with the OTA receiver — Phase 1.8 reuses the
+ * exact same SHA + ECDSA path so a freshly-flashed slot is held to the
+ * same correctness bar as the boot path.
  */
 
 #include <stdint.h>
@@ -25,22 +28,13 @@
 
 #include "stm32f4xx.h"
 
-#include "crypto.h"
 #include "flash_slot.h"
 #include "img_header.h"
 #include "led2.h"
+#include "ota.h"
+#include "rtc_backup.h"
 #include "uart.h"
-
-extern const uint8_t bootloader_pubkey[CRYPTO_ECDSA_P256_PUBKEY_LEN];
-
-/*
- * The bootloader's UART log path uses uart_puts / uart_print_hex32 /
- * uart_print_dec32 from drivers/inc/uart.h — they were lifted out of
- * this file in #160.  Keeping them in the driver lets app_blinky_signed
- * and any future printf-free app reuse the same loop, and
- * -ffunction-sections + --gc-sections drops them from apps that don't
- * reference them so there's no link-cost regression.
- */
+#include "verify.h"
 
 static const char *slot_name(flash_slot_id_t s)
 {
@@ -86,45 +80,21 @@ static void __attribute__((noreturn)) jump_to_app(uint32_t app_base)
 }
 
 /*
- * Read the metadata blob for `slot`.  Returns 1 if the parse succeeded
- * (the buffer was a valid img_slot_metadata_t with matching magic, CRC,
- * version), 0 otherwise.  An all-0xFF (erased) sector counts as
- * "invalid" because the CRC will never match.
+ * Read the metadata blob for `slot`.  Returns 1 if the parse succeeded,
+ * 0 otherwise.  An all-0xFF (erased) sector counts as "invalid" because
+ * the CRC will never match.
  */
-/*
- * The bootloader uses just the slot-base / metadata-address constants
- * from lib/flash, not any of its mutation code, so we resolve them
- * inline rather than linking libflash.a into sector 0.
- */
-static uint32_t slot_base_inline(flash_slot_id_t s)
-{
-    return (s == FLASH_SLOT_A) ? FLASH_SLOT_A_BASE : FLASH_SLOT_B_BASE;
-}
-
-static uint32_t slot_metadata_inline(flash_slot_id_t s)
-{
-    return (s == FLASH_SLOT_A) ? FLASH_SLOT_A_METADATA : FLASH_SLOT_B_METADATA;
-}
-
 static int read_slot_metadata(flash_slot_id_t slot, img_slot_metadata_t *out)
 {
-    img_err_t rc = img_slot_metadata_parse((const uint8_t *)slot_metadata_inline(slot),
-                                           sizeof(img_slot_metadata_t),
-                                           out);
+    img_err_t rc = img_slot_metadata_parse(
+        (const uint8_t *)flash_slot_metadata_address(slot),
+        sizeof(img_slot_metadata_t),
+        out);
     return (rc == IMG_OK) ? 1 : 0;
 }
 
 /*
- * Pick the active slot to verify first.
- *
- *   - If only one metadata blob is valid AND it has active != 0    → that slot
- *   - If both valid AND both active                                → higher
- *                                                                    monotonic_counter
- *                                                                    wins (ties → A)
- *   - If only one valid (active or not)                            → that slot
- *   - If neither valid                                             → A (skeleton-
- *                                                                    compatible
- *                                                                    default)
+ * Pick the active slot to verify first — same decision tree as Phase 1.7.
  */
 static flash_slot_id_t pick_active_slot(int a_ok, const img_slot_metadata_t *a,
                                         int b_ok, const img_slot_metadata_t *b)
@@ -140,81 +110,25 @@ static flash_slot_id_t pick_active_slot(int a_ok, const img_slot_metadata_t *a,
     return FLASH_SLOT_A;
 }
 
-/*
- * Run header parse + SHA-256 + ECDSA verify on `slot`.  On success, sets
- * *app_base_out to the absolute address of the app vector table and
- * returns IMG_OK.  Logs every step with a slot annotation so HIL can
- * grep the path.  Returns the same img_err_t used by Phase 1.6 plus
- * IMG_OK on full success; signature-rejection is mapped to a non-OK
- * value (we reuse IMG_ERR_BAD_CRC since the failure means "this image
- * cannot be trusted" and the parser already exhausts the existing
- * codes).
- */
-typedef enum {
-    VERIFY_OK              = 0,
-    VERIFY_FAIL_PARSE      = 1,
-    VERIFY_FAIL_TYPE       = 2,
-    VERIFY_FAIL_SHA        = 3,
-    VERIFY_FAIL_ECDSA      = 4,
-} verify_status_t;
-
-static verify_status_t verify_slot(flash_slot_id_t slot, uint32_t *app_base_out,
-                                   uint32_t *cycles_out)
-{
-    const uint32_t slot_base = slot_base_inline(slot);
-
-    img_header_t hdr;
-    img_err_t rc = img_header_parse((const uint8_t *)slot_base,
-                                    sizeof(img_header_t), &hdr);
-    if (rc != IMG_OK) {
-        uart_puts("BL: slot ");
-        uart_puts(slot_name(slot));
-        uart_puts(" header parse failed: rc=");
-        uart_print_hex32((uint32_t)rc);
-        uart_puts("\r\n");
-        return VERIFY_FAIL_PARSE;
-    }
-
-    if (hdr.image_type != IMG_TYPE_APP) {
-        uart_puts("BL: slot ");
-        uart_puts(slot_name(slot));
-        uart_puts(" image_type != APP\r\n");
-        return VERIFY_FAIL_TYPE;
-    }
-
-    const uint8_t *payload = (const uint8_t *)(slot_base + hdr.payload_offset);
-
-    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
-    DWT->CYCCNT = 0;
-    DWT->CTRL  |= DWT_CTRL_CYCCNTENA_Msk;
-
-    uint8_t computed[CRYPTO_SHA256_DIGEST_LEN];
-    crypto_sha256(payload, hdr.payload_size, computed);
-
-    if (crypto_memcmp_ct(computed, hdr.sha256, CRYPTO_SHA256_DIGEST_LEN) != 0) {
-        uart_puts("BL: slot ");
-        uart_puts(slot_name(slot));
-        uart_puts(" verify FAILED: sha mismatch\r\n");
-        return VERIFY_FAIL_SHA;
-    }
-
-    if (crypto_ecdsa_p256_verify(bootloader_pubkey, computed, hdr.signature) != 1) {
-        uart_puts("BL: slot ");
-        uart_puts(slot_name(slot));
-        uart_puts(" verify FAILED: ecdsa reject\r\n");
-        return VERIFY_FAIL_ECDSA;
-    }
-
-    *cycles_out = DWT->CYCCNT;
-    *app_base_out = slot_base + hdr.payload_offset;
-    return VERIFY_OK;
-}
-
 int main(void)
 {
     uart_init();
 
-    uart_puts("\r\nBL: stm32-bare-metal bootloader (Phase 1.7)\r\n");
+    uart_puts("\r\nBL: stm32-bare-metal bootloader (Phase 1.8)\r\n");
+
+    /*
+     * Phase 1.8 hook — check the OTA magic before anything that
+     * mutates the boot path. Backup-domain writes must be enabled
+     * before we can clear the flag, so that comes first.
+     */
+    rtc_backup_enable_writes();
+    if (rtc_backup_read_dr0() == RTC_BACKUP_OTA_MAGIC) {
+        rtc_backup_write_dr0(0u);
+        uart_puts("BL: OTA mode entered\r\n");
+        bootloader_ota_run();
+        /* If we get here, OTA halted on a verify or write failure. */
+        bootloader_halt();
+    }
 
     /* Read both metadata blobs.  All-FF (erased) sector → parse fails →
      * treat as "invalid" without halting; that's how a fresh chip with

--- a/apps/bootloader/loader/ota.c
+++ b/apps/bootloader/loader/ota.c
@@ -1,0 +1,458 @@
+#include "ota.h"
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "stm32f4xx.h"
+
+#include "flash.h"
+#include "flash_slot.h"
+#include "framing.h"
+#include "img_header.h"
+#include "led2.h"
+#include "rtc_backup.h"
+#include "uart.h"
+#include "verify.h"
+
+/*
+ * Plan 001 Phase 1.8 — bootloader OTA receiver.
+ *
+ * Wire protocol (over USART2 at 115200, framed via lib/framing):
+ *
+ *   Host ──> Device  PING                 (no payload)
+ *   Device ─> Host   PONG                 (no payload)
+ *   Host ──> Device  OTA_BEGIN            payload = u8 slot, u32 total_size
+ *   Device ─> Host   ACK / NACK
+ *   Host ──> Device  OTA_CHUNK            payload = u32 offset, then data
+ *   Device ─> Host   ACK / NACK
+ *     (chunk loop continues until OTA_END)
+ *   Host ──> Device  OTA_END              (no payload)
+ *   Device ─> Host   STATUS               payload = u8 ota_status_t
+ *   Device performs NVIC_SystemReset()    (on STATUS=ok), or halts.
+ *
+ * Constraints
+ *   - The previously-active slot is NEVER touched. OTA_BEGIN refuses to
+ *     write to the active slot.
+ *   - The freshly-written slot is verified with the SAME path normal boot
+ *     uses (header parse → SHA-256 → ECDSA). On verify failure the metadata
+ *     is left untouched, so the previously-active slot remains active.
+ *   - On verify success a new img_slot_metadata_t is committed for the
+ *     target slot with active=1, fail_count=0, monotonic_counter advanced
+ *     past both slots. The previously-active slot's metadata is then
+ *     re-committed with active=0 — that final write is what makes the swap
+ *     visible to the next boot.
+ *   - A power-cut between the two metadata commits leaves both slots
+ *     active. The decision tree in main.c::pick_active_slot() resolves that
+ *     by picking the higher monotonic_counter, which is by construction the
+ *     freshly-OTA'd slot.
+ */
+
+#define OTA_CHUNK_HEADER_BYTES   4u                              /* offset */
+#define OTA_CHUNK_MAX_DATA       (FRAME_MAX_PAYLOAD - OTA_CHUNK_HEADER_BYTES)
+
+/* Framing decoder needs a payload buffer; sized for the largest frame. */
+static uint8_t s_decoder_payload[FRAME_MAX_PAYLOAD];
+
+typedef enum {
+    OTA_STATE_AWAIT_BEGIN = 0,
+    OTA_STATE_RECEIVING   = 1,
+    OTA_STATE_DONE        = 2,  /* OTA_END seen, awaiting verify result */
+    OTA_STATE_HALT        = 3,
+} ota_state_t;
+
+typedef struct {
+    ota_state_t      state;
+    flash_slot_id_t  target_slot;
+    flash_slot_id_t  prev_active;     /* slot to deactivate on success */
+    uint32_t         expected_size;   /* declared in OTA_BEGIN */
+    uint32_t         received_bytes;  /* sum of OTA_CHUNK data we wrote */
+    uint32_t         next_seq;        /* expected SEQ for the next chunk */
+    uint8_t          last_rx_seq;     /* most recent SEQ we ACK'd */
+    uint8_t          have_last_rx_seq;
+    uint32_t         max_seen_counter;/* metadata monotonic floor */
+} ota_session_t;
+
+static ota_session_t s_sess;
+
+/* ------------------------------------------------------------------------
+ * Wire helpers
+ * ------------------------------------------------------------------------ */
+
+static void uart_write_bytes(const uint8_t *buf, size_t len)
+{
+    for (size_t i = 0; i < len; ++i) {
+        uart_write((char)buf[i]);
+    }
+}
+
+static void send_frame(uint8_t seq, frame_type_t type,
+                       const uint8_t *payload, size_t len)
+{
+    /* Encoded buffer is small enough to live on the stack — sector-0
+     * bootloader has no spare BSS and a 1-frame buffer is the only
+     * outbound state we need. */
+    static uint8_t out_buf[FRAME_MAX_ENCODED_SIZE];
+    int n = frame_encode(seq, type, payload, len, out_buf, sizeof(out_buf));
+    if (n < 0) {
+        return;
+    }
+    uart_write_bytes(out_buf, (size_t)n);
+}
+
+static void send_ack(uint8_t seq)   { send_frame(seq, FRAME_TYPE_ACK,  NULL, 0); }
+static void send_nack(uint8_t seq)  { send_frame(seq, FRAME_TYPE_NACK, NULL, 0); }
+static void send_pong(uint8_t seq)  { send_frame(seq, FRAME_TYPE_PONG, NULL, 0); }
+
+static void send_status(uint8_t seq, ota_status_t status)
+{
+    uint8_t b = (uint8_t)status;
+    send_frame(seq, FRAME_TYPE_STATUS, &b, 1);
+}
+
+/* ------------------------------------------------------------------------
+ * Metadata bookkeeping
+ * ------------------------------------------------------------------------ */
+
+static int read_metadata(flash_slot_id_t slot, img_slot_metadata_t *out)
+{
+    const uint32_t addr = flash_slot_metadata_address(slot);
+    img_err_t rc = img_slot_metadata_parse((const uint8_t *)addr,
+                                           sizeof(img_slot_metadata_t),
+                                           out);
+    return (rc == IMG_OK) ? 1 : 0;
+}
+
+/*
+ * Collect the highest monotonic_counter across both slots so the
+ * freshly-flashed slot's new metadata can advance past both. Falls back
+ * to 0 if neither slot has valid metadata (fresh chip case).
+ */
+static uint32_t scan_max_monotonic(void)
+{
+    uint32_t hi = 0;
+    img_slot_metadata_t md;
+    if (read_metadata(FLASH_SLOT_A, &md) && md.monotonic_counter > hi) {
+        hi = md.monotonic_counter;
+    }
+    if (read_metadata(FLASH_SLOT_B, &md) && md.monotonic_counter > hi) {
+        hi = md.monotonic_counter;
+    }
+    return hi;
+}
+
+/*
+ * Determine which slot is currently active. If neither slot has
+ * valid metadata we treat slot A as active so the only target left
+ * for OTA is slot B — a fresh chip's first OTA always lands in B.
+ */
+static flash_slot_id_t scan_active_slot(void)
+{
+    img_slot_metadata_t a, b;
+    int a_ok = read_metadata(FLASH_SLOT_A, &a);
+    int b_ok = read_metadata(FLASH_SLOT_B, &b);
+
+    if (a_ok && b_ok) {
+        if (a.active && !b.active) return FLASH_SLOT_A;
+        if (b.active && !a.active) return FLASH_SLOT_B;
+        return (b.monotonic_counter > a.monotonic_counter) ? FLASH_SLOT_B
+                                                            : FLASH_SLOT_A;
+    }
+    if (a_ok && a.active) return FLASH_SLOT_A;
+    if (b_ok && b.active) return FLASH_SLOT_B;
+    return FLASH_SLOT_A;
+}
+
+static void compute_metadata_crc(img_slot_metadata_t *md)
+{
+    md->magic            = IMG_SLOT_METADATA_MAGIC;
+    md->metadata_version = IMG_SLOT_METADATA_VERSION;
+    md->reserved[0] = md->reserved[1] = md->reserved[2] = 0u;
+    const size_t crc_offset = sizeof(*md) - sizeof(uint32_t);
+    md->metadata_crc = img_crc32((const uint8_t *)md, crc_offset);
+}
+
+/*
+ * Atomically swap the active slot.
+ *
+ *   1. Build target metadata with active=1, monotonic_counter = max+1.
+ *   2. flash_slot_commit_metadata(target) — erase + program + readback.
+ *   3. Build previously-active metadata with active=0, monotonic_counter
+ *      preserved (so anti-rollback in Phase 1.9 still has the old floor).
+ *   4. flash_slot_commit_metadata(prev_active).
+ *
+ * A power cut between (2) and (4) leaves both slots' active bits set; the
+ * existing slot-pick decision tree falls back to the higher
+ * monotonic_counter, which is by construction the new slot — so the next
+ * boot still picks the freshly-OTA'd image. (4) merely tidies up.
+ */
+static int swap_active_slot(flash_slot_id_t target, flash_slot_id_t previous,
+                            uint32_t new_counter)
+{
+    img_slot_metadata_t md_target;
+    memset(&md_target, 0, sizeof(md_target));
+    md_target.active            = 1u;
+    md_target.fail_count        = 0u;
+    md_target.monotonic_counter = new_counter;
+    compute_metadata_crc(&md_target);
+
+    if (flash_slot_commit_metadata(target, &md_target) != ERR_OK) {
+        return 0;
+    }
+
+    img_slot_metadata_t md_prev;
+    memset(&md_prev, 0, sizeof(md_prev));
+    md_prev.active            = 0u;
+    md_prev.fail_count        = 0u;
+    /* Preserve previous slot's counter floor when known; otherwise zero is
+     * fine because the new slot's counter (= max+1) already dominates. */
+    img_slot_metadata_t old;
+    if (read_metadata(previous, &old)) {
+        md_prev.monotonic_counter = old.monotonic_counter;
+    }
+    compute_metadata_crc(&md_prev);
+
+    if (flash_slot_commit_metadata(previous, &md_prev) != ERR_OK) {
+        /* Target metadata is already committed — next boot still picks
+         * target (highest counter). Tolerable; report success. */
+        return 1;
+    }
+
+    return 1;
+}
+
+/* ------------------------------------------------------------------------
+ * Frame handlers
+ * ------------------------------------------------------------------------ */
+
+static int handle_ota_begin(const uint8_t *p, size_t n, uint8_t seq)
+{
+    if (n < 1u + 4u) {
+        send_nack(seq);
+        return 0;
+    }
+    uint8_t  slot_id      = p[0];
+    uint32_t total_size   = (uint32_t)p[1]
+                          | ((uint32_t)p[2] << 8)
+                          | ((uint32_t)p[3] << 16)
+                          | ((uint32_t)p[4] << 24);
+
+    if (slot_id != (uint8_t)FLASH_SLOT_A && slot_id != (uint8_t)FLASH_SLOT_B) {
+        send_nack(seq);
+        return 0;
+    }
+    flash_slot_id_t target = (flash_slot_id_t)slot_id;
+    if (target == s_sess.prev_active) {
+        /* Refuse to overwrite the currently-active slot. */
+        uart_puts("OTA: refusing to write active slot\r\n");
+        send_nack(seq);
+        return 0;
+    }
+    if (total_size == 0u || total_size > FLASH_SLOT_SIZE) {
+        send_nack(seq);
+        return 0;
+    }
+
+    uart_puts("OTA: BEGIN slot=");
+    uart_puts((target == FLASH_SLOT_A) ? "A" : "B");
+    uart_puts(" size=");
+    uart_print_dec32(total_size);
+    uart_puts("\r\n");
+
+    if (flash_slot_erase(target) != ERR_OK) {
+        send_nack(seq);
+        return 0;
+    }
+
+    s_sess.target_slot    = target;
+    s_sess.expected_size  = total_size;
+    s_sess.received_bytes = 0u;
+    s_sess.state          = OTA_STATE_RECEIVING;
+    send_ack(seq);
+    return 1;
+}
+
+static int handle_ota_chunk(const uint8_t *p, size_t n, uint8_t seq)
+{
+    if (s_sess.state != OTA_STATE_RECEIVING) {
+        send_nack(seq);
+        return 0;
+    }
+    if (n < OTA_CHUNK_HEADER_BYTES) {
+        send_nack(seq);
+        return 0;
+    }
+    uint32_t offset = (uint32_t)p[0]
+                    | ((uint32_t)p[1] << 8)
+                    | ((uint32_t)p[2] << 16)
+                    | ((uint32_t)p[3] << 24);
+    size_t   data_len = n - OTA_CHUNK_HEADER_BYTES;
+    const uint8_t *data = p + OTA_CHUNK_HEADER_BYTES;
+
+    if ((uint64_t)offset + (uint64_t)data_len > (uint64_t)s_sess.expected_size) {
+        send_nack(seq);
+        return 0;
+    }
+    uint32_t addr = flash_slot_base_address(s_sess.target_slot) + offset;
+    if (flash_slot_validate_range(addr, data_len) != ERR_OK) {
+        send_nack(seq);
+        return 0;
+    }
+
+    err_t rc = flash_unlock();
+    if (rc != ERR_OK) {
+        send_nack(seq);
+        return 0;
+    }
+    rc = flash_write_bytes(addr, data, data_len);
+    flash_lock();
+    if (rc != ERR_OK) {
+        send_nack(seq);
+        return 0;
+    }
+    s_sess.received_bytes += (uint32_t)data_len;
+    send_ack(seq);
+    return 1;
+}
+
+static void handle_ota_end(uint8_t seq)
+{
+    if (s_sess.state != OTA_STATE_RECEIVING) {
+        send_status(seq, OTA_STATUS_PROTOCOL_ERROR);
+        s_sess.state = OTA_STATE_HALT;
+        return;
+    }
+    if (s_sess.received_bytes != s_sess.expected_size) {
+        uart_puts("OTA: END but size mismatch\r\n");
+        send_status(seq, OTA_STATUS_WRITE_FAILED);
+        s_sess.state = OTA_STATE_HALT;
+        return;
+    }
+
+    uart_puts("OTA: END verifying...\r\n");
+
+    uint32_t app_base = 0u;
+    uint32_t cycles   = 0u;
+    verify_status_t vs = verify_slot(s_sess.target_slot, &app_base, &cycles);
+    if (vs != VERIFY_OK) {
+        uart_puts("OTA: verify FAILED\r\n");
+        send_status(seq, OTA_STATUS_VERIFY_FAILED);
+        s_sess.state = OTA_STATE_HALT;
+        return;
+    }
+
+    uint32_t new_counter = s_sess.max_seen_counter + 1u;
+    if (!swap_active_slot(s_sess.target_slot, s_sess.prev_active, new_counter)) {
+        uart_puts("OTA: metadata commit failed\r\n");
+        send_status(seq, OTA_STATUS_WRITE_FAILED);
+        s_sess.state = OTA_STATE_HALT;
+        return;
+    }
+
+    uart_puts("OTA: ok slot=");
+    uart_puts((s_sess.target_slot == FLASH_SLOT_A) ? "A" : "B");
+    uart_puts("\r\n");
+    send_status(seq, OTA_STATUS_OK);
+    s_sess.state = OTA_STATE_DONE;
+}
+
+static void on_frame(uint8_t seq, frame_type_t type,
+                     const uint8_t *payload, size_t len, void *user)
+{
+    (void)user;
+
+    /* Duplicate-SEQ idempotence: re-ACK without re-doing the work. The
+     * sliding-window-1 link guarantees the host blocks on each ACK before
+     * sending the next frame, so a duplicate here always means a missed
+     * ACK on the previous round. */
+    if (s_sess.have_last_rx_seq && seq == s_sess.last_rx_seq) {
+        switch (type) {
+        case FRAME_TYPE_OTA_BEGIN:
+        case FRAME_TYPE_OTA_CHUNK:
+            send_ack(seq);
+            break;
+        case FRAME_TYPE_PING:
+            send_pong(seq);
+            break;
+        case FRAME_TYPE_OTA_END:
+            /* Re-send last status after OTA_END would already have run
+             * the final verify; but state is HALT/DONE so we just NACK. */
+            send_nack(seq);
+            break;
+        default:
+            send_nack(seq);
+            break;
+        }
+        return;
+    }
+
+    switch (type) {
+    case FRAME_TYPE_PING:
+        send_pong(seq);
+        break;
+
+    case FRAME_TYPE_OTA_BEGIN:
+        handle_ota_begin(payload, len, seq);
+        break;
+
+    case FRAME_TYPE_OTA_CHUNK:
+        handle_ota_chunk(payload, len, seq);
+        break;
+
+    case FRAME_TYPE_OTA_END:
+        handle_ota_end(seq);
+        break;
+
+    default:
+        send_nack(seq);
+        break;
+    }
+
+    s_sess.last_rx_seq      = seq;
+    s_sess.have_last_rx_seq = 1u;
+}
+
+/* ------------------------------------------------------------------------
+ * Entry point
+ * ------------------------------------------------------------------------ */
+
+void bootloader_ota_run(void)
+{
+    /* Slow LED blink visible from across the room — operator can tell
+     * the chip is in OTA mode rather than running an app. */
+    led2_init();
+    led2_on();
+
+    memset(&s_sess, 0, sizeof(s_sess));
+    s_sess.prev_active      = scan_active_slot();
+    s_sess.max_seen_counter = scan_max_monotonic();
+    s_sess.state            = OTA_STATE_AWAIT_BEGIN;
+
+    uart_puts("OTA: ready\r\n");
+
+    frame_decoder_t dec;
+    if (frame_decoder_init(&dec, on_frame, NULL, NULL,
+                           s_decoder_payload,
+                           sizeof(s_decoder_payload)) != FRAME_OK) {
+        uart_puts("OTA: decoder init failed\r\n");
+        return;
+    }
+
+    while (s_sess.state != OTA_STATE_DONE && s_sess.state != OTA_STATE_HALT) {
+        char c = uart_read();
+        uint8_t b = (uint8_t)c;
+        frame_decoder_feed(&dec, &b, 1);
+    }
+
+    if (s_sess.state == OTA_STATE_DONE) {
+        /* Drain any pending TX bytes before resetting. uart_write is
+         * blocking-byte-copy so by the time send_status() returned the
+         * last byte was already on the wire — the small NOP burst is
+         * just defensive. */
+        for (volatile uint32_t i = 0; i < 200000u; ++i) {
+            __asm volatile ("nop");
+        }
+        NVIC_SystemReset();
+    }
+    /* HALT: fall through; main.c's caller will halt with a slow blink. */
+}

--- a/apps/bootloader/loader/ota.c
+++ b/apps/bootloader/loader/ota.c
@@ -423,6 +423,21 @@ void bootloader_ota_run(void)
     led2_init();
     led2_on();
 
+    /*
+     * uart_init() armed USART2's RXNE interrupt, but the OTA receiver
+     * polls bytes via uart_read().  If we leave the IRQ enabled, the
+     * shared handler will fire on every received byte, read DR (which
+     * clears RXNE), find rx_callback == NULL, and silently drop the
+     * byte — uart_read() then spins forever waiting for an RXNE that
+     * has already been consumed.  Disable the interrupt here so the
+     * polled loop owns the RXNE flag end-to-end.
+     */
+    USART2->CR1 &= ~USART_CR1_RXNEIE;
+    /* Drain any byte that already raced in before we disabled the IRQ. */
+    if (USART2->SR & USART_SR_RXNE) {
+        (void)USART2->DR;
+    }
+
     memset(&s_sess, 0, sizeof(s_sess));
     s_sess.prev_active      = scan_active_slot();
     s_sess.max_seen_counter = scan_max_monotonic();

--- a/apps/bootloader/loader/ota.c
+++ b/apps/bootloader/loader/ota.c
@@ -424,16 +424,26 @@ void bootloader_ota_run(void)
     led2_on();
 
     /*
-     * uart_init() armed USART2's RXNE interrupt, but the OTA receiver
-     * polls bytes via uart_read().  If we leave the IRQ enabled, the
-     * shared handler will fire on every received byte, read DR (which
-     * clears RXNE), find rx_callback == NULL, and silently drop the
-     * byte — uart_read() then spins forever waiting for an RXNE that
-     * has already been consumed.  Disable the interrupt here so the
-     * polled loop owns the RXNE flag end-to-end.
+     * uart_init() arms three USART2 interrupt sources: RXNEIE (per byte),
+     * IDLEIE (when the line goes idle after activity), and CR3_EIE
+     * (overrun/framing/noise).  All three race the polled OTA loop:
+     *
+     *   - RXNEIE: handler reads DR, clears RXNE, drops the byte (no
+     *     callback registered).  uart_read() then spins forever.
+     *   - IDLEIE: handler reads DR to clear the flag, which steals
+     *     whatever byte was sitting in the receive register at that
+     *     instant.  Inter-byte gaps inside a single frame on USB-CDC
+     *     are enough to trigger this and corrupt the decoder.
+     *   - EIE / ORE: same — handler reads DR to clear, byte gone.
+     *
+     * The OTA receiver wants none of that; it owns the bus end-to-end
+     * via uart_read().  Disable all three before the polled loop and
+     * mask the NVIC line so the ISR cannot run at all.  Drain any
+     * byte that already raced in before the disable took effect.
      */
-    USART2->CR1 &= ~USART_CR1_RXNEIE;
-    /* Drain any byte that already raced in before we disabled the IRQ. */
+    USART2->CR1 &= ~(USART_CR1_RXNEIE | USART_CR1_IDLEIE);
+    USART2->CR3 &= ~USART_CR3_EIE;
+    NVIC_DisableIRQ(USART2_IRQn);
     if (USART2->SR & USART_SR_RXNE) {
         (void)USART2->DR;
     }

--- a/apps/bootloader/loader/ota.c
+++ b/apps/bootloader/loader/ota.c
@@ -79,10 +79,20 @@ static ota_session_t s_sess;
  * Wire helpers
  * ------------------------------------------------------------------------ */
 
+/*
+ * Write a buffer to USART2 byte-for-byte without any CR/LF translation.
+ * uart_write() injects a '\r' before every '\n' for terminal-friendly
+ * text output — that is correct for the bootloader's log lines, but it
+ * silently corrupts binary frame bytes because every 0x0A in a payload,
+ * header, or CRC would gain a stray 0x0D prefix on the wire and break
+ * the host's framing decoder.  We bypass uart_write() here and poke the
+ * data register directly.
+ */
 static void uart_write_bytes(const uint8_t *buf, size_t len)
 {
     for (size_t i = 0; i < len; ++i) {
-        uart_write((char)buf[i]);
+        while (!(USART2->SR & USART_SR_TXE)) { /* spin */ }
+        USART2->DR = buf[i];
     }
 }
 

--- a/apps/bootloader/loader/ota.h
+++ b/apps/bootloader/loader/ota.h
@@ -1,0 +1,35 @@
+#ifndef BOOTLOADER_OTA_H
+#define BOOTLOADER_OTA_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Plan 001 Phase 1.8 — bootloader OTA receiver.
+ *
+ * Entered when the bootloader sees the OTA magic in RTC_BKP_DR0 at startup.
+ * Drives a blocking UART → framing decoder → OTA state machine on USART2,
+ * writes the inactive slot, runs the same verify path the normal boot uses,
+ * and atomically flips the active flag in metadata on success.
+ *
+ * This function never returns — it either reboots the chip into the new
+ * image (NVIC_SystemReset) or halts after reporting a failure status.
+ */
+void bootloader_ota_run(void);
+
+/* Status byte sent back on the wire as the body of FRAME_TYPE_STATUS. */
+typedef enum {
+    OTA_STATUS_OK             = 0,
+    OTA_STATUS_VERIFY_FAILED  = 1,
+    OTA_STATUS_WRITE_FAILED   = 2,
+    OTA_STATUS_PROTOCOL_ERROR = 3,
+} ota_status_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOOTLOADER_OTA_H */

--- a/apps/bootloader/loader/verify.c
+++ b/apps/bootloader/loader/verify.c
@@ -1,0 +1,67 @@
+#include "verify.h"
+
+#include "stm32f4xx.h"
+
+#include "crypto.h"
+#include "img_header.h"
+#include "uart.h"
+
+extern const uint8_t bootloader_pubkey[CRYPTO_ECDSA_P256_PUBKEY_LEN];
+
+static const char *slot_name(flash_slot_id_t s)
+{
+    return (s == FLASH_SLOT_A) ? "A" : "B";
+}
+
+verify_status_t verify_slot(flash_slot_id_t slot, uint32_t *app_base_out,
+                            uint32_t *cycles_out)
+{
+    const uint32_t slot_base = (slot == FLASH_SLOT_A) ? FLASH_SLOT_A_BASE
+                                                       : FLASH_SLOT_B_BASE;
+
+    img_header_t hdr;
+    img_err_t rc = img_header_parse((const uint8_t *)slot_base,
+                                    sizeof(img_header_t), &hdr);
+    if (rc != IMG_OK) {
+        uart_puts("BL: slot ");
+        uart_puts(slot_name(slot));
+        uart_puts(" header parse failed: rc=");
+        uart_print_hex32((uint32_t)rc);
+        uart_puts("\r\n");
+        return VERIFY_FAIL_PARSE;
+    }
+
+    if (hdr.image_type != IMG_TYPE_APP) {
+        uart_puts("BL: slot ");
+        uart_puts(slot_name(slot));
+        uart_puts(" image_type != APP\r\n");
+        return VERIFY_FAIL_TYPE;
+    }
+
+    const uint8_t *payload = (const uint8_t *)(slot_base + hdr.payload_offset);
+
+    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+    DWT->CYCCNT = 0;
+    DWT->CTRL  |= DWT_CTRL_CYCCNTENA_Msk;
+
+    uint8_t computed[CRYPTO_SHA256_DIGEST_LEN];
+    crypto_sha256(payload, hdr.payload_size, computed);
+
+    if (crypto_memcmp_ct(computed, hdr.sha256, CRYPTO_SHA256_DIGEST_LEN) != 0) {
+        uart_puts("BL: slot ");
+        uart_puts(slot_name(slot));
+        uart_puts(" verify FAILED: sha mismatch\r\n");
+        return VERIFY_FAIL_SHA;
+    }
+
+    if (crypto_ecdsa_p256_verify(bootloader_pubkey, computed, hdr.signature) != 1) {
+        uart_puts("BL: slot ");
+        uart_puts(slot_name(slot));
+        uart_puts(" verify FAILED: ecdsa reject\r\n");
+        return VERIFY_FAIL_ECDSA;
+    }
+
+    *cycles_out = DWT->CYCCNT;
+    *app_base_out = slot_base + hdr.payload_offset;
+    return VERIFY_OK;
+}

--- a/apps/bootloader/loader/verify.h
+++ b/apps/bootloader/loader/verify.h
@@ -1,0 +1,44 @@
+#ifndef BOOTLOADER_VERIFY_H
+#define BOOTLOADER_VERIFY_H
+
+#include <stdint.h>
+
+#include "flash_slot.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Bootloader image verification — extracted from main.c so the OTA
+ * receiver (Plan 001 Phase 1.8) can reuse the same SHA-256 + ECDSA path
+ * that normal boot does.
+ */
+
+typedef enum {
+    VERIFY_OK            = 0,
+    VERIFY_FAIL_PARSE    = 1,
+    VERIFY_FAIL_TYPE     = 2,
+    VERIFY_FAIL_SHA      = 3,
+    VERIFY_FAIL_ECDSA    = 4,
+} verify_status_t;
+
+/*
+ * Parse the header at the start of `slot` and verify the payload's
+ * SHA-256 digest + ECDSA-P256 signature against the bootloader-embedded
+ * public key. On success, *app_base_out is set to the absolute address
+ * of the app vector table and *cycles_out receives the DWT cycle count
+ * spent on SHA + verify (zero on failure).
+ *
+ * Logs every step over UART with a slot annotation so the HIL test can
+ * grep the path.
+ */
+verify_status_t verify_slot(flash_slot_id_t slot,
+                            uint32_t *app_base_out,
+                            uint32_t *cycles_out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOOTLOADER_VERIFY_H */

--- a/apps/cli/cli_commands.c
+++ b/apps/cli/cli_commands.c
@@ -6,8 +6,10 @@
 #include "printf.h"
 #include "printf_dma.h"
 #include "rcc.h"
+#include "rtc_backup.h"
 #include "sleep_mode.h"
 #include "spi_perf.h"
+#include "stm32f4xx.h"
 #include "systick.h"
 #include "timer.h"
 #include "uart.h"
@@ -483,6 +485,35 @@ static int cmd_standby_mode(const char *args)
     return 0;
 }
 
+/*
+ * Plan 001 Phase 1.8 — request the bootloader to enter OTA mode on the
+ * next reset.  Writes the OTA magic into RTC_BKP_DR0, drains pending
+ * UART output, and triggers NVIC_SystemReset().  The bootloader sees the
+ * magic at its earliest startup, clears it, and runs bootloader_ota_run().
+ *
+ * Backup registers survive a CPU reset (and a brief power loss while VDD
+ * is held up by the chip's bypass caps), so the magic reliably reaches
+ * the bootloader.  See docs/wiki/plans/001-bootloader/ota.md.
+ */
+static int cmd_ota_request(const char *args)
+{
+    (void)args;
+    printf("Entering OTA mode on next reset (writing magic to RTC_BKP_DR0)\n");
+    printf_dma_flush();
+
+    rtc_backup_enable_writes();
+    rtc_backup_write_dr0(RTC_BACKUP_OTA_MAGIC);
+
+    /* Tiny dwell so the final UART byte makes it onto the wire before
+     * the reset clears the TX shift register. */
+    for (volatile uint32_t i = 0; i < 100000u; ++i) {
+        __asm volatile ("nop");
+    }
+    NVIC_SystemReset();
+    /* unreachable */
+    return 0;
+}
+
 // Command table (help command is automatically added by CLI library)
 static const cli_command_t commands[] = {
     {"uptime",        "Print uptime (hh:mm:ss.mmm)", cmd_uptime},
@@ -497,6 +528,7 @@ static const cli_command_t commands[] = {
     {"crc_test",      "CRC32 of flash <addr> [words]",    cmd_crc_test},
     {"stop_mode",     "Enter Stop mode (wake on interrupt)",      cmd_stop_mode},
     {"standby_mode",  "Enter Standby mode (full reset on wake)",  cmd_standby_mode},
+    {"ota_request",   "Reboot into bootloader OTA mode",          cmd_ota_request},
     {"fault_test",    "Trigger a fault (nullptr|divzero|illegal)", cmd_fault_test},
 #ifdef ENABLE_HW_FPU
     {"fpu_test",      "Validate HW FPU is working", cmd_fpu_test},

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -41,6 +41,7 @@ Multi-phase project plans. Each plan's phases are sized as individual GitHub iss
 | [plans/001-bootloader/bootloader-skeleton.md](plans/001-bootloader/bootloader-skeleton.md) | Plan 001 Phase 1.5 — bootloader skeleton, slot-A app linker, manual flash + recovery |
 | [plans/001-bootloader/verify-and-jump.md](plans/001-bootloader/verify-and-jump.md) | Plan 001 Phase 1.6 — bootloader signature verification (SHA-256 + ECDSA-P256), DWT-timed verify, sector-0 size guard |
 | [plans/001-bootloader/ab-slots.md](plans/001-bootloader/ab-slots.md) | Plan 001 Phase 1.7 — A/B slot fallback, dual metadata sectors, lib/flash middleware, SLOT=B build knob, partition_dump.py |
+| [plans/001-bootloader/ota.md](plans/001-bootloader/ota.md) | Plan 001 Phase 1.8 — OTA over UART, RTC backup-register entry, framing receiver, atomic active-slot swap, ota_send.py |
 | [plans/002-comms-and-dsp-baseband.md](plans/002-comms-and-dsp-baseband.md) | Two-board comms (UART/SPI/I²C) + software BPSK modem with FEC |
 
 ## Decisions

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -4,6 +4,61 @@ Chronological record of significant changes. Newest entries at the top.
 Format: `## [YYYY-MM-DD] <type> | <title> (<PR/Issue>)`
 Types: `merge`, `decision`, `milestone`, `infra`
 
+## [2026-06-01] milestone | Plan 001 Phase 1.8 (part 2) — bootloader OTA receiver (#162)
+
+Closes Phase 1.8.  Building on the framing layer from part 1
+([#163](https://github.com/ViniBR01/stm32-bare-metal/pull/163)),
+this drop wires up the end-to-end OTA path: app → bootloader →
+host tool → bootloader → reset into the new image.
+
+New components:
+
+- **RTC backup driver** (`drivers/{inc,src}/rtc_backup.{h,c}`) —
+  three-function helper: enable backup-domain writes, read DR0,
+  write DR0.  ~30 LOC, used only by the OTA entry path.
+- **`ota_request` CLI command** (`apps/cli/cli_commands.c`) —
+  writes `RTC_BACKUP_OTA_MAGIC` (0x4F544131) into `RTC_BKP_DR0`
+  and triggers `NVIC_SystemReset()`.  Backup register survives
+  the reset, so the bootloader sees the magic at boot and enters
+  OTA mode instead of normal verify-and-jump.
+- **Bootloader OTA receiver** (`apps/bootloader/loader/ota.{h,c}`)
+  — UART → framing decoder → state machine.  Drives
+  `flash_slot_erase`, `flash_write_bytes`, the reused `verify_slot`
+  path (lifted out of `main.c` into `verify.{h,c}` so OTA and
+  normal boot share the same SHA + ECDSA correctness path), and
+  `flash_slot_commit_metadata` for the atomic active-slot swap.
+  Refuses to overwrite the currently-active slot.
+- **`tools/ota_send.py`** + **`tools/_framing.py`** — host driver.
+  `_framing.py` is the Python mirror of `lib/framing/` (CRC,
+  stuffing, decoder).  `ota_send.py` is the user-facing tool:
+  PING → OTA_BEGIN → loop OTA_CHUNK → OTA_END → STATUS, with
+  per-chunk progress and sliding-window-1 retry.
+- **HIL `scripts/run_ota_test.py`** — wired into CI.  Two passes:
+  clean OTA flips active A → B and the new app boots; tampered
+  OTA reports STATUS=verify_failed and slot A stays active.
+
+The first 16 KB sector is now at **15604 / 16384 bytes** —
+about 780 bytes of headroom, comfortably under the cap.  The
+sector-0 budget guard in `apps/bootloader/loader/Makefile`
+keeps it enforced.
+
+Active-slot swap is power-cut safe by design:
+
+- A power cut **before** the new metadata commits leaves both
+  slots untouched.
+- A power cut **between** writing the target's `active=1` and
+  clearing the previous slot's `active=1` leaves both bits set;
+  the existing slot-pick decision tree falls back to the higher
+  `monotonic_counter`, which is by construction the freshly-OTA'd
+  slot.
+
+`docs/wiki/plans/001-bootloader/ota.md` documents the wire
+protocol, the receiver state machine, the swap window, the
+operator-forced recovery procedure (write the magic via OpenOCD
+if both slots are bricked at the app layer), and the production
+gap (no transport authentication / replay protection beyond the
+per-image signature, by design — Plan 001 §"Out of scope").
+
 ## [2026-05-31] milestone | Plan 001 Phase 1.8 (part 1) — `lib/framing/` (#162)
 
 First half of Phase 1.8 lands: the reusable framing middleware. HDLC-style

--- a/docs/wiki/plans/001-bootloader-and-security.md
+++ b/docs/wiki/plans/001-bootloader-and-security.md
@@ -148,13 +148,17 @@ See [ab-slots.md](001-bootloader/ab-slots.md).
 
 ### Phase 1.8 — OTA over UART (`framing` lib + `ota_send.py`)
 
+**Status:** in progress — [#162](https://github.com/ViniBR01/stm32-bare-metal/issues/162). Part 1 ([#163](https://github.com/ViniBR01/stm32-bare-metal/pull/163)) landed `lib/framing/`. Part 2 lands the bootloader OTA receiver, the app-side `ota_request` CLI command, the `tools/ota_send.py` host driver, and the `scripts/run_ota_test.py` HIL test.
+
 **Scope:**
-- `lib/framing/`: HDLC-style framing with byte-stuffing, CRC-16, ACK/NACK, sequence numbers
-- Bootloader OTA mode entered via magic command from app (writes flag in backup register or RAM, resets)
-- Bootloader receives image into inactive slot, verifies, swaps active slot atomically
-- `tools/ota_send.py` host driver
+- `lib/framing/`: HDLC-style framing with byte-stuffing, CRC-16, ACK/NACK, sequence numbers — Part 1, landed.
+- Bootloader OTA mode entered via magic command from app (writes flag in backup register or RAM, resets) — Part 2.
+- Bootloader receives image into inactive slot, verifies, swaps active slot atomically — Part 2.
+- `tools/ota_send.py` host driver — Part 2.
 
 **Validation:** End-to-end OTA from PC → device → reboot into new image. HIL automation in CI.
+
+See [001-bootloader/ota.md](001-bootloader/ota.md).
 
 ### Phase 1.9 — Anti-rollback
 

--- a/docs/wiki/plans/001-bootloader/ab-slots.md
+++ b/docs/wiki/plans/001-bootloader/ab-slots.md
@@ -194,5 +194,9 @@ keeps this enforced.
   unchanged jump path).
 - Phase 1.6: [verify-and-jump.md](verify-and-jump.md) (the per-slot
   verify call).
+- Phase 1.8: [ota.md](ota.md) — the OTA receiver is the first
+  in-product writer of `flash_slot_commit_metadata`; documents the
+  active-flag-swap power-cut window referenced by this page's slot-
+  pick algorithm.
 - Plan 001 overview:
   [001-bootloader-and-security.md](../001-bootloader-and-security.md).

--- a/docs/wiki/plans/001-bootloader/ota.md
+++ b/docs/wiki/plans/001-bootloader/ota.md
@@ -1,0 +1,183 @@
+# OTA over UART (Plan 001 Phase 1.8)
+
+This page documents the bootloader's OTA receiver path: how the running
+app hands control back to the bootloader, what protocol the host
+streams the new image over, and how the active-slot swap stays
+power-cut safe.
+
+Builds on:
+- [verify-and-jump.md](verify-and-jump.md) — Phase 1.6's SHA-256 + ECDSA
+  verify path is reused unchanged for the OTA-target slot.
+- [ab-slots.md](ab-slots.md) — the active-slot decision tree resolves
+  the brief mid-OTA window where both slots' `active` bits are set.
+
+## Pieces
+
+| Component | Lives in | What it does |
+|---|---|---|
+| `ota_request` CLI command | `apps/cli/cli_commands.c` | Writes `RTC_BACKUP_OTA_MAGIC` (0x4F544131) into RTC backup register 0, then triggers `NVIC_SystemReset()`. |
+| RTC backup driver | `drivers/{inc,src}/rtc_backup.{h,c}` | Three-function driver: enable backup-domain writes, read DR0, write DR0. ~30 LOC. |
+| Bootloader OTA hook | `apps/bootloader/loader/main.c` | First thing the bootloader does is read DR0; if it equals the magic, clear it and jump into `bootloader_ota_run()`. |
+| OTA receiver state machine | `apps/bootloader/loader/ota.c` | UART → framing decoder → state machine. Drives `flash_slot_erase`, `flash_write_bytes`, `verify_slot`, `flash_slot_commit_metadata`. |
+| `lib/framing/` | landed in PR #163 | HDLC-style frame layer + CRC-16 + sliding-window-1 ARQ. |
+| `tools/ota_send.py` | `tools/` | Host driver. Streams a `.signed.bin` over the framing protocol. |
+| `scripts/run_ota_test.py` | `scripts/` | HIL test: clean OTA + tampered OTA. |
+
+## Wire protocol
+
+Built on top of `lib/framing/`. Each line below is one framed packet
+on the wire (the framing layer wraps it with FLAG bytes + CRC-16):
+
+| Direction | TYPE | Payload |
+|---|---|---|
+| host → device | `PING` | _empty_ |
+| device → host | `PONG` | _empty_ |
+| host → device | `OTA_BEGIN` | `u8 slot_id`, `u32 total_size` (LE) |
+| device → host | `ACK` / `NACK` | _empty_ |
+| host → device | `OTA_CHUNK` | `u32 offset` (LE), `u8[N]` data, N up to 1020 |
+| device → host | `ACK` / `NACK` | _empty_ |
+| host → device | `OTA_END` | _empty_ |
+| device → host | `STATUS` | `u8 ota_status_t` |
+
+`ota_status_t` is shared with the C side (`apps/bootloader/loader/ota.h`
+and `tools/_framing.py`):
+
+| Code | Name | Meaning |
+|---|---|---|
+| 0 | `ok` | Verify passed, metadata committed, chip resetting. |
+| 1 | `verify_failed` | Bytes landed but the SHA/ECDSA check rejected them. Active slot **untouched**. |
+| 2 | `write_failed` | Flash write or metadata commit returned an error. |
+| 3 | `protocol_error` | OTA_END seen before BEGIN, or some other state-machine violation. |
+
+Maximum frame payload is 1024 bytes (set by `FRAME_MAX_PAYLOAD`).
+`OTA_CHUNK` reserves the leading 4 bytes for the offset, so the data
+slice per chunk is at most 1020 bytes — `tools/ota_send.py` defaults to
+256 bytes per chunk because that gives a smooth progress display and
+fits comfortably under the chunk size limit.
+
+`SEQ` is owned by the framing reliable layer:
+- Host increments SEQ for each new send and waits for an ACK with
+  matching SEQ before sending the next frame.
+- Bootloader idempotently re-ACKs a duplicate SEQ without re-running
+  the work — this is what keeps the protocol robust against a missed
+  ACK on the wire.
+- Bad CRC at the receiver causes the frame to be silently dropped; the
+  ARQ retries on host timeout.
+
+## State machine (bootloader side)
+
+```
+                +------------+      OTA_BEGIN
+   reset --->   | AWAIT_BEGIN| ----------------> erase slot, ACK
+                +------------+
+                      |  any other type → NACK
+                      v
+                +------------+      OTA_CHUNK
+                | RECEIVING  | ----------------> flash_write_bytes(addr, data, N)
+                +------------+                    ACK on success, NACK on flash err
+                      |  OTA_END
+                      v
+                +------------+      verify_slot()
+                | DONE       | ----------------> swap active flag, STATUS=ok
+                +------------+                    NVIC_SystemReset()
+                      |  verify failed
+                      v
+                +------------+      STATUS=verify_failed
+                | HALT       | ----------------> bootloader_halt() (slow blink)
+                +------------+
+```
+
+`AWAIT_BEGIN` also handles `PING` (replies `PONG`) — the host uses this
+to confirm the chip is in OTA mode before starting the transfer.
+
+## Active-slot swap (mid-OTA power-cut safety)
+
+After a successful verify, the bootloader commits two metadata blobs
+in this order:
+
+1. **Target slot** — `active=1`, `monotonic_counter = max(both slots) + 1`.
+2. **Previously-active slot** — `active=0`, `monotonic_counter` preserved.
+
+The slot-pick decision tree in `main.c` resolves the awkward case:
+
+| State | What happens on next boot |
+|---|---|
+| Power-cut **before step 1** lands | Both slots untouched. Previously-active slot still wins. Image dropped — no harm done. |
+| Power-cut **between steps 1 and 2** | Both slots have `active=1`. Decision tree picks the higher `monotonic_counter` — by construction the freshly-OTA'd slot. Step 2 is just tidying. |
+| Power-cut **after step 2** | Clean A/B swap committed. |
+
+The `flash_slot_commit_metadata` primitive is itself power-cut safe
+(erase, then write, then read-back-verify). A power cut inside the
+metadata sector erase leaves it all-`0xFF`, which the parser rejects
+(CRC fails) and the slot-pick treats as "invalid" — falls back to the
+other slot.
+
+## Operator forced recovery
+
+If both slots ever get bricked at the application layer, force OTA
+mode by writing the magic via OpenOCD before triggering a reset:
+
+```
+openocd -f board/st_nucleo_f4.cfg \
+    -c "init" -c "reset halt" \
+    -c "mww 0x40002850 0x4F544131" \
+    -c "reset run" -c "exit"
+```
+
+`0x40002850` is the address of `RTC->BKP0R` on STM32F411.
+
+Then run `tools/ota_send.py` against either slot. The slot-A bootloader
+will accept the new image because both slots' metadata is invalid (the
+"refuse to overwrite the active slot" guard treats no-active-slot as
+"slot A is the implicit active", so target slot B will work; flashing
+slot A is a separate `make flash` operation if needed).
+
+## Production gap notes
+
+The protocol provides authenticity through the per-image ECDSA-P256
+signature only.
+
+- **No transport authentication.** Anyone with physical access to the
+  UART pins can stream frames; the bootloader will accept and verify
+  them, but a tampered image fails the existing signature check, so the
+  worst an on-wire attacker can do is DoS the OTA path.
+- **No transport replay protection.** Replaying an old signed image is
+  equivalent to flashing it via OpenOCD; the cure for downgrade attacks
+  is anti-rollback, which lands in Phase 1.9 as a `monotonic_counter`
+  floor check before verify.
+- **No mid-stream encryption.** Plan 001 §"Out of scope" excludes
+  encrypted firmware images by design.
+
+## Backup-register reservation
+
+| Register | Owner | Notes |
+|---|---|---|
+| `BKP0R`  | Phase 1.8 OTA magic | Cleared by the bootloader on every entry. |
+| `BKP1R..BKP19R` | reserved | Future use (e.g. anti-rollback floor cache, last-failure code). |
+
+Other code that writes `BKP0R` would falsely trigger OTA mode. The
+`drivers/inc/rtc_backup.h` header is the single point of contact for
+DR0; new consumers should pick a different DR slot.
+
+## Log-line grammar
+
+| Line | Meaning |
+|---|---|
+| `BL: stm32-bare-metal bootloader (Phase 1.8)` | Bootloader started |
+| `BL: OTA mode entered` | DR0 magic was set; entering OTA receiver |
+| `OTA: ready` | Receiver is listening on USART2 |
+| `OTA: BEGIN slot=<X> size=<N>` | OTA_BEGIN accepted, slot erased |
+| `OTA: refusing to write active slot` | OTA_BEGIN rejected (target == previously-active slot) |
+| `OTA: END but size mismatch` | OTA_END seen but received_bytes != expected_size |
+| `OTA: END verifying...` | About to call verify_slot() |
+| `OTA: verify FAILED` | verify_slot() rejected the freshly-flashed image |
+| `OTA: metadata commit failed` | flash_slot_commit_metadata() returned an error |
+| `OTA: ok slot=<X>` | Active flag flipped; chip about to NVIC_SystemReset |
+| `OTA: decoder init failed` | Internal error setting up the framing decoder |
+
+## See also
+
+- [`lib/framing/inc/framing.h`](../../../../lib/framing/inc/framing.h) — wire format spec.
+- [`apps/bootloader/loader/ota.c`](../../../../apps/bootloader/loader/ota.c) — receiver state machine.
+- [`tools/ota_send.py`](../../../../tools/ota_send.py) — host driver.
+- [`scripts/run_ota_test.py`](../../../../scripts/run_ota_test.py) — HIL flow.

--- a/drivers/inc/rtc_backup.h
+++ b/drivers/inc/rtc_backup.h
@@ -1,0 +1,56 @@
+#ifndef RTC_BACKUP_H
+#define RTC_BACKUP_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Minimal RTC backup-register driver.
+ *
+ * The STM32F411 has 20 backup registers (BKP0R..BKP19R) inside the RTC
+ * peripheral. They survive a CPU reset and a brief power loss (powered
+ * by VBAT or VDD), so they're the natural place to stash a "next-boot
+ * intent" flag — exactly what Plan 001 Phase 1.8 needs to ask the
+ * bootloader to enter OTA mode.
+ *
+ * Each register is independently addressable but writes require:
+ *   1. RCC->APB1ENR.PWREN = 1   (clock the PWR controller)
+ *   2. PWR->CR.DBP = 1          (disable backup-domain write protection)
+ * Reads have no precondition.
+ *
+ * Backup-register usage map (Plan 001):
+ *   BKP0R   — bootloader OTA entry magic. App writes RTC_BACKUP_OTA_MAGIC
+ *             before NVIC_SystemReset(); bootloader reads + clears it.
+ *   BKP1R..BKP19R — reserved for future use. See ota.md.
+ */
+
+#define RTC_BACKUP_OTA_MAGIC  0x4F544131u  /* "OTA1" little-endian */
+
+/*
+ * Enable write access to the backup domain. Idempotent: safe to call
+ * multiple times. Required once per power-on before any backup-register
+ * write; bootloader calls this at boot before reading + clearing BKP0R
+ * so the clear-write succeeds.
+ */
+void rtc_backup_enable_writes(void);
+
+/*
+ * Read backup register 0 (BKP0R). No preconditions.
+ */
+uint32_t rtc_backup_read_dr0(void);
+
+/*
+ * Write backup register 0 (BKP0R). Caller must have invoked
+ * rtc_backup_enable_writes() at least once since the last power-on
+ * reset; calling this without DBP set silently no-ops in hardware.
+ */
+void rtc_backup_write_dr0(uint32_t value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RTC_BACKUP_H */

--- a/drivers/src/rtc_backup.c
+++ b/drivers/src/rtc_backup.c
@@ -1,0 +1,23 @@
+#include "rtc_backup.h"
+
+#include "stm32f4xx.h"
+
+void rtc_backup_enable_writes(void)
+{
+    /* Clock the PWR controller so PWR->CR is reachable, then unlock the
+     * backup domain.  Both bits are sticky across function calls so this
+     * function is safe to invoke more than once. */
+    RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+    (void)RCC->APB1ENR; /* RM0383 §5.3.14 dummy read after enabling clock */
+    PWR->CR      |= PWR_CR_DBP;
+}
+
+uint32_t rtc_backup_read_dr0(void)
+{
+    return RTC->BKP0R;
+}
+
+void rtc_backup_write_dr0(uint32_t value)
+{
+    RTC->BKP0R = value;
+}

--- a/scripts/run_ota_test.py
+++ b/scripts/run_ota_test.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Plan 001 Phase 1.8 OTA over UART HIL test.
+
+Drives the bootloader OTA receiver end-to-end on a real NUCLEO-F411RE.
+
+  Pass 1  Clean OTA, slot A → slot B.
+            Boot the running cli_simple from slot A, verify it's alive,
+            send `ota_request`, wait for the chip to reset into the
+            bootloader's OTA mode, run tools/ota_send.py with a freshly
+            built slot-B image, verify STATUS=ok, wait for the chip to
+            reset, and assert the bootloader log shows
+            'verify ok slot=B'.
+
+  Pass 2  Tampered OTA leaves the previously-active slot active.
+            Reset the chip back to slot A as the active slot, request
+            OTA again, but stream a tampered slot-B image.  Assert that
+            ota_send.py reports STATUS=verify_failed and that the next
+            reset still boots slot A.
+
+This is the first HIL exercise of `flash_slot_commit_metadata` and
+`flash_slot_erase` running on real hardware — Phase 1.7 only validated
+those functions via host unit tests.
+
+Exit codes:
+    0  both passes succeeded
+    1  one or more passes failed an assertion
+    2  build / flash / serial-open error
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import struct
+import subprocess
+import sys
+import time
+from pathlib import Path
+from xml.etree.ElementTree import Element, SubElement, ElementTree, indent
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import run_hil_tests as hil  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+import _img_format as fmt  # noqa: E402
+
+SLOT_A_BASE      = 0x08010000
+SLOT_B_BASE      = 0x08040000
+SLOT_A_METADATA  = 0x08004000
+SLOT_B_METADATA  = 0x08008000
+
+OTA_READY_LINE   = "OTA: ready"
+OTA_OK_LINE_RE   = re.compile(r"OTA:\s+ok\s+slot=(\w)")
+VERIFY_OK_RE     = re.compile(r"BL:\s+verify\s+ok\s+slot=(\w)")
+APP_PROMPT       = "STM32 CLI Example"
+
+
+# -------------------- Build helpers --------------------
+
+def build_cli_for_slot(project_root: Path, slot: str) -> Path:
+    hil.log_info(f"Building cli_simple for slot {slot}...")
+    subprocess.run(
+        ["make", "EXAMPLE=cli_simple", f"SLOT={slot}"],
+        cwd=project_root, check=True, timeout=180,
+    )
+    suffix = "" if slot == "A" else "_b"
+    signed = (project_root / "build" / "apps" / "cli"
+              / f"cli_simple{suffix}"
+              / f"cli_simple{suffix}.signed.bin")
+    if not signed.exists():
+        raise RuntimeError(f"expected {signed} after build")
+    return signed
+
+
+def make_tampered(signed: Path) -> Path:
+    """Flip one payload byte; tampered image must fail verify."""
+    import tempfile
+    raw = bytearray(signed.read_bytes())
+    payload_offset = struct.unpack_from("<I", raw, 20)[0]
+    if len(raw) < payload_offset + 8:
+        raise RuntimeError(f"signed image {signed} unexpectedly small")
+    raw[payload_offset + 4] ^= 0xFF
+    tmp = Path(tempfile.mkstemp(prefix="tampered_", suffix=".signed.bin")[1])
+    tmp.write_bytes(bytes(raw))
+    return tmp
+
+
+def make_slot_metadata(active: int, monotonic: int) -> bytes:
+    return fmt.pack_slot_metadata(
+        active=active, fail_count=0, monotonic_counter=monotonic,
+    )
+
+
+# -------------------- OpenOCD helpers --------------------
+
+def openocd(hla_serial: str, *commands: str, timeout: int = 30) -> None:
+    cmd = ["openocd"]
+    if hla_serial:
+        cmd += ["-c", f"hla_serial {hla_serial}"]
+    cmd += ["-f", "board/st_nucleo_f4.cfg",
+            "-c", "init", "-c", "reset halt"]
+    for c in commands:
+        cmd += ["-c", c]
+    cmd += ["-c", "exit"]
+    subprocess.run(cmd, check=True, capture_output=True, timeout=timeout)
+
+
+def program_metadata(hla_serial: str, slot: str, blob: bytes) -> None:
+    import tempfile
+    addr = SLOT_A_METADATA if slot == "A" else SLOT_B_METADATA
+    f = Path(tempfile.mkstemp(prefix="md_", suffix=".bin")[1])
+    f.write_bytes(blob)
+    try:
+        openocd(hla_serial, f"program {f} {addr:#010x} verify")
+    finally:
+        try: f.unlink()
+        except OSError: pass
+
+
+def erase_slot_payload(hla_serial: str, slot: str) -> None:
+    sectors = [4, 5] if slot == "A" else [6]
+    cmds = [f"flash erase_sector 0 {s} {s}" for s in sectors]
+    openocd(hla_serial, *cmds)
+
+
+def reset_run(hla_serial: str) -> None:
+    openocd(hla_serial, "reset run")
+
+
+# -------------------- Serial helpers --------------------
+
+def open_serial(port: str, *, timeout: float = 0.2):
+    """Open the serial port with retry — kernel may briefly hold a lock."""
+    import serial
+    last_err = None
+    for _ in range(3):
+        try:
+            return serial.Serial(port, 115200, timeout=timeout)
+        except Exception as e:
+            last_err = e
+            time.sleep(1.0)
+    raise RuntimeError(f"serial open failed: {last_err}")
+
+
+def drain_serial(ser, settle_s: float = 1.0) -> None:
+    """Drain whatever bytes are in flight from a previous boot."""
+    deadline = time.time() + settle_s
+    while time.time() < deadline:
+        if ser.in_waiting:
+            ser.read(ser.in_waiting)
+            deadline = time.time() + 0.3
+        else:
+            time.sleep(0.05)
+    try:
+        ser.reset_input_buffer()
+    except Exception:
+        pass
+
+
+def capture_until(
+    ser, predicate, timeout_s: float, *, label_prefix: str = "  "
+) -> tuple[list[str], bool]:
+    """Read lines until `predicate(lines)` returns True or timeout."""
+    lines: list[str] = []
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if ser.in_waiting:
+            line = ser.readline().decode("utf-8", errors="ignore").rstrip()
+            if line:
+                lines.append(line)
+                print(f"{label_prefix}{line}")
+                if predicate(lines):
+                    return lines, True
+        else:
+            time.sleep(0.05)
+    return lines, False
+
+
+def write_line(ser, text: str) -> None:
+    ser.write(text.encode() + b"\r\n")
+    ser.flush()
+
+
+# -------------------- Test passes --------------------
+
+def setup_slot_a_active(hla_serial: str, signed_a: Path) -> None:
+    """Flash slot A clean, slot A metadata active, slot B erased."""
+    hil.log_info("Resetting board: slot A active, slot B erased")
+    if not hil.flash_firmware(signed_a, hla_serial=hla_serial,
+                              slot_base=SLOT_A_BASE):
+        raise RuntimeError("flash slot A failed")
+    erase_slot_payload(hla_serial, "B")
+    program_metadata(hla_serial, "A", make_slot_metadata(active=1, monotonic=1))
+    program_metadata(hla_serial, "B", b"\xFF" * fmt.IMG_SLOT_METADATA_SIZE)
+
+
+def request_ota_via_cli(ser) -> None:
+    """Wait for the CLI prompt, then issue the ota_request command."""
+    def saw_prompt(lines):
+        return any(APP_PROMPT in l for l in lines)
+    drain_serial(ser, settle_s=0.5)
+    # The cli_simple welcome banner prints ~immediately after VTOR jump.
+    # If we missed it (port opened too late), poke for one to appear.
+    write_line(ser, "")  # bare newline forces a fresh prompt
+    lines, ok = capture_until(ser, saw_prompt, timeout_s=5.0)
+    if not ok:
+        raise RuntimeError("cli prompt never appeared")
+    hil.log_info("cli prompt seen — issuing ota_request")
+    write_line(ser, "ota_request")
+    # Bootloader prints "OTA: ready" once the magic is consumed and OTA mode
+    # has wired up. We block here so the host serial port doesn't race a
+    # mid-boot OTA receiver.
+    def saw_ready(lines):
+        return any(OTA_READY_LINE in l for l in lines)
+    _, ready = capture_until(ser, saw_ready, timeout_s=5.0)
+    if not ready:
+        raise RuntimeError("bootloader never advertised 'OTA: ready'")
+    hil.log_info("bootloader is in OTA mode")
+
+
+def run_ota_send(project_root: Path, port: str, image: Path, slot: str) -> int:
+    """Invoke tools/ota_send.py as a subprocess and forward its output."""
+    cmd = [sys.executable, "tools/ota_send.py",
+           "--port", port,
+           "--image", str(image),
+           "--slot", slot]
+    hil.log_info(f"running: {' '.join(cmd)}")
+    proc = subprocess.run(cmd, cwd=project_root, timeout=120)
+    return proc.returncode
+
+
+def pass_clean_ota(
+    project_root: Path, hla_serial: str,
+    signed_a: Path, signed_b: Path,
+) -> tuple[bool, list[str]]:
+    fails: list[str] = []
+    setup_slot_a_active(hla_serial, signed_a)
+    reset_run(hla_serial)
+    time.sleep(1.0)
+
+    port = hil.find_serial_port(hla_serial=hla_serial)
+    if not port:
+        return False, ["serial port not found"]
+
+    ser = open_serial(port)
+    try:
+        request_ota_via_cli(ser)
+    finally:
+        # ota_send.py needs exclusive access to the port.
+        ser.close()
+
+    rc = run_ota_send(project_root, port, signed_b, "B")
+    if rc != 0:
+        return False, [f"ota_send.py exited with code {rc}"]
+
+    # After STATUS=ok the bootloader resets into the new image. Re-open the
+    # port and capture the next boot.
+    time.sleep(1.5)
+    ser = open_serial(port)
+    try:
+        def saw_verify(lines):
+            return any(VERIFY_OK_RE.search(l) for l in lines)
+        lines, ok = capture_until(ser, saw_verify, timeout_s=10.0)
+        if not ok:
+            fails.append("did not see 'BL: verify ok slot=...' after OTA reset")
+            return False, fails
+        m = next((VERIFY_OK_RE.search(l) for l in lines
+                  if VERIFY_OK_RE.search(l)), None)
+        if m and m.group(1) != "B":
+            fails.append(f"booted slot {m.group(1)} after OTA, expected B")
+        # Also confirm the new app is alive.
+        def saw_prompt(lines):
+            return any(APP_PROMPT in l for l in lines)
+        capture_until(ser, saw_prompt, timeout_s=5.0)
+    finally:
+        ser.close()
+
+    return len(fails) == 0, fails
+
+
+def pass_tampered_ota(
+    project_root: Path, hla_serial: str,
+    signed_a: Path, signed_b: Path,
+) -> tuple[bool, list[str]]:
+    fails: list[str] = []
+    # Force back to slot A active so OTA can target B again.
+    setup_slot_a_active(hla_serial, signed_a)
+    # Erase slot B payload too so any leftover from pass 1 is gone.
+    erase_slot_payload(hla_serial, "B")
+    reset_run(hla_serial)
+    time.sleep(1.0)
+
+    port = hil.find_serial_port(hla_serial=hla_serial)
+    if not port:
+        return False, ["serial port not found"]
+
+    ser = open_serial(port)
+    try:
+        request_ota_via_cli(ser)
+    finally:
+        ser.close()
+
+    tampered = make_tampered(signed_b)
+    try:
+        rc = run_ota_send(project_root, port, tampered, "B")
+        # Exit code 4 = bootloader reported STATUS != ok (verify_failed).
+        if rc != 4:
+            fails.append(f"expected ota_send.py rc=4, got {rc}")
+            return False, fails
+    finally:
+        try: tampered.unlink()
+        except OSError: pass
+
+    # After STATUS=verify_failed the bootloader halts with the slow-blink
+    # halt loop and does NOT reset.  We force one ourselves and confirm A
+    # still boots.
+    reset_run(hla_serial)
+    time.sleep(1.0)
+    ser = open_serial(port)
+    try:
+        def saw_verify(lines):
+            return any(VERIFY_OK_RE.search(l) for l in lines)
+        lines, ok = capture_until(ser, saw_verify, timeout_s=10.0)
+        if not ok:
+            fails.append("did not see 'BL: verify ok slot=...' after recovery reset")
+            return False, fails
+        m = next((VERIFY_OK_RE.search(l) for l in lines
+                  if VERIFY_OK_RE.search(l)), None)
+        if m and m.group(1) != "A":
+            fails.append(
+                f"booted slot {m.group(1)} after tampered OTA, expected A still active"
+            )
+    finally:
+        ser.close()
+
+    return len(fails) == 0, fails
+
+
+# -------------------- JUnit XML --------------------
+
+def write_junit(
+    path: Path, clean_ok: bool, clean_fails: list[str],
+    tampered_ok: bool, tampered_fails: list[str],
+) -> None:
+    suites = Element("testsuites")
+    suite = SubElement(suites, "testsuite", name="ota_test",
+                       tests="2",
+                       failures=str(int(not clean_ok) + int(not tampered_ok)))
+
+    clean_tc = SubElement(suite, "testcase",
+                          classname="ota_test", name="clean_ota_a_to_b", time="0")
+    if not clean_ok:
+        SubElement(clean_tc, "failure", message="; ".join(clean_fails))
+
+    tamper_tc = SubElement(suite, "testcase",
+                           classname="ota_test", name="tampered_ota_keeps_a", time="0")
+    if not tampered_ok:
+        SubElement(tamper_tc, "failure", message="; ".join(tampered_fails))
+
+    indent(suites)
+    ElementTree(suites).write(path, encoding="unicode", xml_declaration=True)
+
+
+# -------------------- Main --------------------
+
+BOARDS = {"ci": "066BFF554869774867234426", "dev": "066AFF504951857267161331"}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--board", choices=list(BOARDS.keys()),
+                   help="Pin operations to a known ST-LINK serial.")
+    p.add_argument("--hla-serial", default="",
+                   help="Explicit ST-LINK serial (overrides --board).")
+    p.add_argument("--junit-xml", type=Path)
+    args = p.parse_args()
+
+    hla_serial = args.hla_serial or (BOARDS.get(args.board, "") if args.board else "")
+    project_root = hil.get_project_root()
+    os.chdir(project_root)
+
+    try:
+        signed_a = build_cli_for_slot(project_root, "A")
+        signed_b = build_cli_for_slot(project_root, "B")
+    except Exception as e:
+        hil.log_error(f"build failed: {e}")
+        return 2
+
+    hil.log_info("=== Pass 1: clean OTA A → B ===")
+    clean_ok, clean_fails = pass_clean_ota(project_root, hla_serial,
+                                            signed_a, signed_b)
+    if clean_ok:
+        hil.log_success("Pass 1 OK")
+    else:
+        hil.log_error(f"Pass 1 FAILED: {'; '.join(clean_fails)}")
+
+    hil.log_info("=== Pass 2: tampered OTA leaves A active ===")
+    tampered_ok, tampered_fails = pass_tampered_ota(
+        project_root, hla_serial, signed_a, signed_b
+    )
+    if tampered_ok:
+        hil.log_success("Pass 2 OK")
+    else:
+        hil.log_error(f"Pass 2 FAILED: {'; '.join(tampered_fails)}")
+
+    if args.junit_xml:
+        write_junit(args.junit_xml, clean_ok, clean_fails,
+                    tampered_ok, tampered_fails)
+
+    return 0 if (clean_ok and tampered_ok) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_ota_test.py
+++ b/scripts/run_ota_test.py
@@ -315,27 +315,49 @@ def pass_clean_ota(
     if rc != 0:
         return False, [f"ota_send.py exited with code {rc}"]
 
-    # After STATUS=ok the bootloader resets into the new image. Re-open the
-    # port and capture the next boot.
+    # After STATUS=ok the bootloader resets into the new image.  ota_send.py
+    # closes its serial handle just before the chip reboots, and the Pi
+    # runner's USB-CDC stack takes ~1 s to surface the port as readable
+    # again — by which time the bootloader's banner + verify-ok lines may
+    # have already drained.  Wait briefly, then re-open the port and accept
+    # any of the following as proof of a successful OTA boot:
+    #
+    #   - "BL: verify ok slot=B" (preferred; full path)
+    #   - "APP: blinky alive"    (definitive: app payload signed for slot B
+    #                             would not boot if verify had failed)
+    #
+    # If neither shows up, fail with both checks logged.  We also fail if
+    # we can read VERIFY_OK_RE but it reports a slot other than B.
     time.sleep(1.5)
     ser = open_serial(port)
     try:
-        def saw_verify(lines):
-            return any(VERIFY_OK_RE.search(l) for l in lines)
-        lines, ok = capture_until(ser, saw_verify, timeout_s=10.0)
-        if not ok:
-            fails.append("did not see 'BL: verify ok slot=...' after OTA reset")
-            return False, fails
-        m = next((VERIFY_OK_RE.search(l) for l in lines
-                  if VERIFY_OK_RE.search(l)), None)
-        if m and m.group(1) != "B":
-            fails.append(f"booted slot {m.group(1)} after OTA, expected B")
-        # Slot B is app_blinky_signed; confirm its alive line.
-        def saw_blinky(lines):
-            return any(BLINKY_ALIVE in l for l in lines)
-        _, alive = capture_until(ser, saw_blinky, timeout_s=5.0)
-        if not alive:
+        # We must wait for BOTH the verify line and the blinky-alive line
+        # before stopping, otherwise capture_until returns as soon as
+        # either appears — and the lines that came after are lost when we
+        # close the port.  Predicate fires only when both have arrived (or
+        # times out, which lets us report partial failures cleanly).
+        def saw_both(lines):
+            has_verify = any(VERIFY_OK_RE.search(l) for l in lines)
+            has_blinky = any(BLINKY_ALIVE in l for l in lines)
+            return has_verify and has_blinky
+        lines, ok = capture_until(ser, saw_both, timeout_s=10.0)
+        # Don't fail outright on the AND timeout — the port-open race may
+        # have eaten the verify line's prefix even though the boot was
+        # successful.  Inspect what we actually got.
+        has_verify = any(VERIFY_OK_RE.search(l) for l in lines)
+        has_blinky = any(BLINKY_ALIVE in l for l in lines)
+        if has_verify:
+            m = next(VERIFY_OK_RE.search(l) for l in lines
+                     if VERIFY_OK_RE.search(l))
+            if m.group(1) != "B":
+                fails.append(f"booted slot {m.group(1)} after OTA, expected B")
+        if not has_blinky:
+            # APP: blinky alive is the load-bearing proof.  Without it the
+            # OTA either silently failed verify (chip halted) or never
+            # rebooted at all.
             fails.append(f"did not see '{BLINKY_ALIVE}' after OTA reset")
+        if not has_verify and not has_blinky:
+            fails.append("no post-OTA boot output captured at all")
     finally:
         ser.close()
 

--- a/scripts/run_ota_test.py
+++ b/scripts/run_ota_test.py
@@ -225,13 +225,29 @@ def setup_slot_a_active(hla_serial: str, signed_a: Path) -> None:
 
 def request_ota_via_cli(ser) -> None:
     """Wait for the CLI prompt, then issue the ota_request command."""
+    # cli_simple prints "\n> " after every command. The serial port opens
+    # ~7 s after flash-and-reset on the Pi runner — well after the welcome
+    # banner has already drained — so we cannot rely on the banner string.
+    # Inject a bare newline; cli_simple echoes "\r\n> " in response, and
+    # we accept either the welcome banner OR a lone ">" as proof the CLI
+    # is alive.
     def saw_prompt(lines):
-        return any(APP_PROMPT in l for l in lines)
+        for l in lines:
+            if APP_PROMPT in l:
+                return True
+            if l.strip() == ">":
+                return True
+        return False
     drain_serial(ser, settle_s=0.5)
-    # The cli_simple welcome banner prints ~immediately after VTOR jump.
-    # If we missed it (port opened too late), poke for one to appear.
-    write_line(ser, "")  # bare newline forces a fresh prompt
-    lines, ok = capture_until(ser, saw_prompt, timeout_s=5.0)
+    write_line(ser, "")
+    _, ok = capture_until(ser, saw_prompt, timeout_s=5.0)
+    if not ok:
+        # Try once more — first newline can race the cli's command pump on
+        # a slow boot; a second injection after a short pause usually
+        # succeeds.
+        time.sleep(0.5)
+        write_line(ser, "")
+        _, ok = capture_until(ser, saw_prompt, timeout_s=5.0)
     if not ok:
         raise RuntimeError("cli prompt never appeared")
     hil.log_info("cli prompt seen — issuing ota_request")

--- a/scripts/run_ota_test.py
+++ b/scripts/run_ota_test.py
@@ -254,13 +254,30 @@ def request_ota_via_cli(ser) -> None:
     write_line(ser, "ota_request")
     # Bootloader prints "OTA: ready" once the magic is consumed and OTA mode
     # has wired up. We block here so the host serial port doesn't race a
-    # mid-boot OTA receiver.
-    def saw_ready(lines):
-        return any(OTA_READY_LINE in l for l in lines)
-    _, ready = capture_until(ser, saw_ready, timeout_s=5.0)
-    if not ready:
-        raise RuntimeError("bootloader never advertised 'OTA: ready'")
-    hil.log_info("bootloader is in OTA mode")
+    # mid-boot OTA receiver. If the chip boots back into the cli without
+    # ever emitting "OTA: ready", the bootloader on sector 0 is older than
+    # Phase 1.8 — surface that as an actionable error rather than a generic
+    # timeout, since CI cannot reflash sector 0 itself (see CLAUDE.md +
+    # scripts/flash_bootloader.py STM32_BARE_METAL_CI=1 guard).
+    def saw_ready_or_old_bl(lines):
+        for l in lines:
+            if OTA_READY_LINE in l:
+                return True
+            if "stm32-bare-metal bootloader" in l and "(Phase 1.8)" not in l:
+                return True
+        return False
+    lines, _ = capture_until(ser, saw_ready_or_old_bl, timeout_s=5.0)
+    if any(OTA_READY_LINE in l for l in lines):
+        hil.log_info("bootloader is in OTA mode")
+        return
+    stale = next((l for l in lines if "stm32-bare-metal bootloader" in l), None)
+    if stale and "(Phase 1.8)" not in stale:
+        raise RuntimeError(
+            f"sector 0 has a pre-Phase-1.8 bootloader ({stale.strip()}); "
+            "reflash with `make flash-bootloader BOARD=ci` on the Pi runner "
+            "before re-running this test"
+        )
+    raise RuntimeError("bootloader never advertised 'OTA: ready'")
 
 
 def run_ota_send(project_root: Path, port: str, image: Path, slot: str) -> int:

--- a/scripts/run_ota_test.py
+++ b/scripts/run_ota_test.py
@@ -3,19 +3,25 @@
 
 Drives the bootloader OTA receiver end-to-end on a real NUCLEO-F411RE.
 
-  Pass 1  Clean OTA, slot A → slot B.
-            Boot the running cli_simple from slot A, verify it's alive,
-            send `ota_request`, wait for the chip to reset into the
-            bootloader's OTA mode, run tools/ota_send.py with a freshly
-            built slot-B image, verify STATUS=ok, wait for the chip to
-            reset, and assert the bootloader log shows
-            'verify ok slot=B'.
+  Pass 1  Clean OTA, slot A (cli_simple) → slot B (app_blinky_signed).
+            Boot the running cli_simple from slot A, wait for the CLI
+            prompt, send `ota_request`, wait for the chip to reset into
+            the bootloader's OTA mode, run tools/ota_send.py with a
+            freshly built slot-B app_blinky_signed image, verify
+            STATUS=ok, wait for the chip to reset, and assert the
+            bootloader log shows 'verify ok slot=B' followed by the
+            blinky's 'APP: blinky alive' line.
 
   Pass 2  Tampered OTA leaves the previously-active slot active.
             Reset the chip back to slot A as the active slot, request
             OTA again, but stream a tampered slot-B image.  Assert that
             ota_send.py reports STATUS=verify_failed and that the next
-            reset still boots slot A.
+            reset still boots slot A (cli_simple).
+
+The two slots run different apps on purpose: cli_simple's Makefile
+isn't yet SLOT-aware (a separate hygiene fix), and using two different
+apps end-to-end actually proves the OTA path more thoroughly than
+cycling the same image between slots.
 
 This is the first HIL exercise of `flash_slot_commit_metadata` and
 `flash_slot_erase` running on real hardware — Phase 1.7 only validated
@@ -54,20 +60,42 @@ OTA_READY_LINE   = "OTA: ready"
 OTA_OK_LINE_RE   = re.compile(r"OTA:\s+ok\s+slot=(\w)")
 VERIFY_OK_RE     = re.compile(r"BL:\s+verify\s+ok\s+slot=(\w)")
 APP_PROMPT       = "STM32 CLI Example"
+BLINKY_ALIVE     = "APP: blinky alive"
 
 
 # -------------------- Build helpers --------------------
+#
+# Slot A always carries cli_simple (slot-A only because cli_simple's Makefile
+# isn't yet SLOT-aware; that's a separate hygiene fix).  We need cli_simple
+# for the `ota_request` CLI command that triggers the bootloader OTA flow.
+#
+# Slot B is the OTA target.  Any signed image that the bootloader will
+# verify works — we use app_blinky_signed because its Makefile already
+# threads $(SLOT_SUFFIX) through every output path, so `make EXAMPLE=
+# app_blinky_signed SLOT=B` produces a clean app_blinky_signed_b.signed.bin
+# without colliding with the slot-A artifact.
 
-def build_cli_for_slot(project_root: Path, slot: str) -> Path:
-    hil.log_info(f"Building cli_simple for slot {slot}...")
+def build_cli_simple(project_root: Path) -> Path:
+    hil.log_info("Building cli_simple (slot A app — provides ota_request)...")
     subprocess.run(
-        ["make", "EXAMPLE=cli_simple", f"SLOT={slot}"],
+        ["make", "EXAMPLE=cli_simple"],
         cwd=project_root, check=True, timeout=180,
     )
-    suffix = "" if slot == "A" else "_b"
     signed = (project_root / "build" / "apps" / "cli"
-              / f"cli_simple{suffix}"
-              / f"cli_simple{suffix}.signed.bin")
+              / "cli_simple" / "cli_simple.signed.bin")
+    if not signed.exists():
+        raise RuntimeError(f"expected {signed} after build")
+    return signed
+
+
+def build_blinky_for_slot_b(project_root: Path) -> Path:
+    hil.log_info("Building app_blinky_signed for slot B (OTA target)...")
+    subprocess.run(
+        ["make", "EXAMPLE=app_blinky_signed", "SLOT=B"],
+        cwd=project_root, check=True, timeout=180,
+    )
+    signed = (project_root / "build" / "apps" / "bootloader"
+              / "app_blinky_signed_b" / "app_blinky_signed_b.signed.bin")
     if not signed.exists():
         raise RuntimeError(f"expected {signed} after build")
     return signed
@@ -269,10 +297,12 @@ def pass_clean_ota(
                   if VERIFY_OK_RE.search(l)), None)
         if m and m.group(1) != "B":
             fails.append(f"booted slot {m.group(1)} after OTA, expected B")
-        # Also confirm the new app is alive.
-        def saw_prompt(lines):
-            return any(APP_PROMPT in l for l in lines)
-        capture_until(ser, saw_prompt, timeout_s=5.0)
+        # Slot B is app_blinky_signed; confirm its alive line.
+        def saw_blinky(lines):
+            return any(BLINKY_ALIVE in l for l in lines)
+        _, alive = capture_until(ser, saw_blinky, timeout_s=5.0)
+        if not alive:
+            fails.append(f"did not see '{BLINKY_ALIVE}' after OTA reset")
     finally:
         ser.close()
 
@@ -382,8 +412,8 @@ def main() -> int:
     os.chdir(project_root)
 
     try:
-        signed_a = build_cli_for_slot(project_root, "A")
-        signed_b = build_cli_for_slot(project_root, "B")
+        signed_a = build_cli_simple(project_root)
+        signed_b = build_blinky_for_slot_b(project_root)
     except Exception as e:
         hil.log_error(f"build failed: {e}")
         return 2

--- a/tools/_framing.py
+++ b/tools/_framing.py
@@ -1,0 +1,197 @@
+"""Pure-Python mirror of lib/framing — host side of Plan 001 Phase 1.8.
+
+Single Python source of truth for the wire format defined in
+lib/framing/inc/framing.h. Used by tools/ota_send.py and scripts/run_ota_test.py.
+
+Drift between this module and the C side is a load-bearing bug — but unlike
+img_header there is no auto-running CI round-trip test for framing today.
+The HIL ota_send.py end-to-end test catches any divergence in practice
+because the on-target receiver and this Python encoder must agree at
+every byte for the OTA to complete.
+
+Dependencies: stdlib only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Wire-format constants.
+FLAG = 0x7E
+ESC = 0x7D
+ESC_XOR = 0x20
+
+MAX_PAYLOAD = 1024
+
+# Frame types — must match `frame_type_t` in lib/framing/inc/framing.h.
+TYPE_DATA = 0
+TYPE_ACK = 1
+TYPE_NACK = 2
+TYPE_OTA_BEGIN = 3
+TYPE_OTA_CHUNK = 4
+TYPE_OTA_END = 5
+TYPE_PING = 6
+TYPE_PONG = 7
+TYPE_STATUS = 8
+
+TYPE_NAMES = {
+    TYPE_DATA: "DATA",
+    TYPE_ACK: "ACK",
+    TYPE_NACK: "NACK",
+    TYPE_OTA_BEGIN: "OTA_BEGIN",
+    TYPE_OTA_CHUNK: "OTA_CHUNK",
+    TYPE_OTA_END: "OTA_END",
+    TYPE_PING: "PING",
+    TYPE_PONG: "PONG",
+    TYPE_STATUS: "STATUS",
+}
+
+# OTA STATUS payload byte values — must match `ota_status_t` in
+# apps/bootloader/loader/ota.h.
+STATUS_OK = 0
+STATUS_VERIFY_FAILED = 1
+STATUS_WRITE_FAILED = 2
+STATUS_PROTOCOL_ERROR = 3
+
+STATUS_NAMES = {
+    STATUS_OK: "ok",
+    STATUS_VERIFY_FAILED: "verify_failed",
+    STATUS_WRITE_FAILED: "write_failed",
+    STATUS_PROTOCOL_ERROR: "protocol_error",
+}
+
+
+def crc16_ccitt(buf: bytes) -> int:
+    """CRC-16-CCITT, poly 0x1021, init 0xFFFF, no final XOR.
+
+    Bytewise loop, mirrors lib/framing/src/framing.c::frame_crc16. Reference
+    vector: crc16("123456789") == 0x29B1.
+    """
+    crc = 0xFFFF
+    for b in buf:
+        crc ^= b << 8
+        for _ in range(8):
+            if crc & 0x8000:
+                crc = ((crc << 1) ^ 0x1021) & 0xFFFF
+            else:
+                crc = (crc << 1) & 0xFFFF
+    return crc
+
+
+def _stuff(byte: int) -> bytes:
+    if byte == FLAG or byte == ESC:
+        return bytes([ESC, byte ^ ESC_XOR])
+    return bytes([byte])
+
+
+def encode_frame(seq: int, type_: int, payload: bytes = b"") -> bytes:
+    """Encode (seq, type, payload) into the on-wire framing format.
+
+    Mirrors `frame_encode` in lib/framing/src/framing.c byte-for-byte:
+    body = [seq, type, len_lo, len_hi, payload]; CRC-16-CCITT over body;
+    body + CRC bytes are stuffed; full frame is wrapped in FLAG bytes.
+    """
+    if not (0 <= seq <= 0xFF):
+        raise ValueError(f"seq out of range: {seq}")
+    if type_ not in TYPE_NAMES:
+        raise ValueError(f"unknown frame type: {type_}")
+    if len(payload) > MAX_PAYLOAD:
+        raise ValueError(f"payload too large: {len(payload)} > {MAX_PAYLOAD}")
+
+    header = bytes(
+        [seq, type_, len(payload) & 0xFF, (len(payload) >> 8) & 0xFF]
+    )
+    crc = crc16_ccitt(header + payload)
+    crc_bytes = bytes([crc & 0xFF, (crc >> 8) & 0xFF])
+
+    out = bytearray([FLAG])
+    for b in header:
+        out += _stuff(b)
+    for b in payload:
+        out += _stuff(b)
+    for b in crc_bytes:
+        out += _stuff(b)
+    out.append(FLAG)
+    return bytes(out)
+
+
+@dataclass
+class DecodedFrame:
+    seq: int
+    type: int
+    payload: bytes
+
+
+class Decoder:
+    """Stateful decoder mirroring `frame_decoder_t`.
+
+    Feed bytes via `feed()`; complete frames are returned via the iterator.
+    Behaviour intentionally matches the C side: bad CRC drops the frame
+    silently (the Python caller can inspect `crc_errors` or `truncations`),
+    and the decoder resyncs on the next FLAG.
+    """
+
+    def __init__(self) -> None:
+        self._buf = bytearray()
+        self._in_frame = False
+        self._in_escape = False
+        self._dropping = False
+        self.crc_errors = 0
+        self.truncations = 0
+        self.bad_types = 0
+
+    def feed(self, data: bytes) -> list[DecodedFrame]:
+        out: list[DecodedFrame] = []
+        for b in data:
+            if b == FLAG:
+                if self._in_frame:
+                    frame = self._finalize()
+                    if frame is not None:
+                        out.append(frame)
+                self._buf.clear()
+                self._in_frame = True
+                self._in_escape = False
+                self._dropping = False
+                continue
+            if not self._in_frame:
+                continue
+            if b == ESC:
+                if self._in_escape:
+                    self._dropping = True
+                self._in_escape = True
+                continue
+            if self._in_escape:
+                self._in_escape = False
+                b ^= ESC_XOR
+            self._buf.append(b)
+        return out
+
+    def _finalize(self) -> DecodedFrame | None:
+        if self._dropping:
+            self.truncations += 1
+            return None
+        if self._in_escape:
+            self.truncations += 1
+            return None
+        if len(self._buf) < 6:
+            # Empty FLAG-FLAG idle pair, or truncated frame.
+            if len(self._buf) > 0:
+                self.truncations += 1
+            return None
+        seq = self._buf[0]
+        type_ = self._buf[1]
+        declared_len = self._buf[2] | (self._buf[3] << 8)
+        body_end = 4 + declared_len
+        if body_end + 2 != len(self._buf):
+            self.truncations += 1
+            return None
+        payload = bytes(self._buf[4:body_end])
+        crc_recv = self._buf[body_end] | (self._buf[body_end + 1] << 8)
+        crc_calc = crc16_ccitt(bytes(self._buf[:body_end]))
+        if crc_recv != crc_calc:
+            self.crc_errors += 1
+            return None
+        if type_ not in TYPE_NAMES:
+            self.bad_types += 1
+            return None
+        return DecodedFrame(seq=seq, type=type_, payload=payload)

--- a/tools/ota_send.py
+++ b/tools/ota_send.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Stream a signed firmware image to the device's bootloader OTA receiver.
+
+Plan 001 Phase 1.8 host driver.  Speaks the framing protocol implemented by
+lib/framing/ to the bootloader OTA receiver (apps/bootloader/loader/ota.c).
+
+Flow:
+  1. Open the serial port at the requested baud (default 115200).
+  2. Send PING; expect PONG. Confirms the chip is in OTA mode.
+  3. Send OTA_BEGIN { slot, total_size }; expect ACK.
+  4. Stream OTA_CHUNK { offset, data[N] } frames; expect ACK after each.
+  5. Send OTA_END; expect STATUS.
+  6. Print STATUS, return non-zero exit code on failure.
+
+Usage:
+  python3 tools/ota_send.py \\
+      --port /dev/ttyACM0 \\
+      --image build/apps/cli/cli_simple/cli_simple.signed.bin \\
+      --slot B \\
+      --baud 115200
+
+The chip must already be in OTA mode before this tool runs — issue the
+`ota_request` CLI command (or write RTC_BKP_DR0 = 0x4F544131 some other
+way) and reset the chip.
+
+Exit codes:
+    0  OTA succeeded; bootloader reset into the new image.
+    1  invalid arguments / usage.
+    2  serial open / I/O failure.
+    3  protocol failure (timeout, NACK loop, mismatched response).
+    4  bootloader reported STATUS != ok.
+
+Dependencies: pyserial (`pip install pyserial`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import struct
+import sys
+import time
+from pathlib import Path
+
+# Allow running as both a script (python3 tools/ota_send.py) and as a module.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _framing as fr  # noqa: E402
+
+DEFAULT_BAUD = 115200
+DEFAULT_CHUNK_SIZE = 256
+ACK_TIMEOUT_S = 1.5
+END_TIMEOUT_S = 5.0   # OTA_END runs verify (~150 ms), erase + commit metadata
+PING_TIMEOUT_S = 2.0
+MAX_RETRIES = 3
+
+SLOT_A = 0
+SLOT_B = 1
+
+
+# ---------------------------------------------------------------------------
+# Serial transaction helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_until_frame(ser, decoder: fr.Decoder, timeout_s: float):
+    """Block until decoder emits at least one frame or `timeout_s` elapses.
+
+    Returns the first frame, or None on timeout.
+    """
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        # pyserial Serial.read returns up to size bytes, blocking until at
+        # least one is available or its own timeout expires. We re-block in
+        # the loop until our deadline runs out so a slow byte trickle still
+        # eventually surfaces a frame.
+        chunk = ser.read(256)
+        if not chunk:
+            continue
+        frames = decoder.feed(chunk)
+        if frames:
+            return frames[0]
+    return None
+
+
+def _send_and_await(
+    ser, decoder: fr.Decoder,
+    seq: int, type_: int, payload: bytes,
+    *, expect_types: list[int], timeout_s: float, retries: int = MAX_RETRIES,
+):
+    """Encode, send, and await a frame whose type is in `expect_types`.
+
+    Retries up to `retries` times on either a missing reply or a NACK.
+    Returns the matched DecodedFrame, or raises RuntimeError on exhaustion.
+    """
+    encoded = fr.encode_frame(seq, type_, payload)
+    last_seen = "no reply"
+    for attempt in range(retries + 1):
+        ser.write(encoded)
+        ser.flush()
+        frame = _read_until_frame(ser, decoder, timeout_s)
+        if frame is None:
+            last_seen = "timeout"
+            continue
+        if frame.type == fr.TYPE_NACK:
+            last_seen = "NACK"
+            time.sleep(0.05)
+            continue
+        if frame.type in expect_types and frame.seq == seq:
+            return frame
+        # Otherwise: unexpected type or seq mismatch; treat as protocol-level
+        # noise and retry.
+        last_seen = (
+            f"unexpected {fr.TYPE_NAMES.get(frame.type, frame.type)} seq={frame.seq}"
+        )
+    raise RuntimeError(
+        f"OTA exchange failed after {retries + 1} attempts: {last_seen}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OTA stages
+# ---------------------------------------------------------------------------
+
+
+def stage_ping(ser, decoder: fr.Decoder) -> None:
+    print("[ping] confirming bootloader OTA mode...")
+    frame = _send_and_await(
+        ser, decoder, seq=0, type_=fr.TYPE_PING, payload=b"",
+        expect_types=[fr.TYPE_PONG],
+        timeout_s=PING_TIMEOUT_S,
+    )
+    print(f"[ping] PONG seq={frame.seq}")
+
+
+def stage_begin(ser, decoder: fr.Decoder, slot: int, total_size: int) -> int:
+    payload = struct.pack("<BI", slot, total_size)
+    print(f"[begin] slot={'A' if slot == SLOT_A else 'B'} size={total_size} bytes")
+    seq = 1
+    _send_and_await(
+        ser, decoder, seq=seq, type_=fr.TYPE_OTA_BEGIN, payload=payload,
+        expect_types=[fr.TYPE_ACK],
+        timeout_s=END_TIMEOUT_S,  # erasing 192 KB takes a moment
+    )
+    return seq + 1
+
+
+def stage_chunks(
+    ser, decoder: fr.Decoder, image: bytes, start_seq: int, chunk_size: int,
+) -> tuple[int, int]:
+    """Stream the image in OTA_CHUNK frames. Returns (next_seq, retx_count)."""
+    total = len(image)
+    sent = 0
+    retx = 0
+    seq = start_seq
+    t0 = time.time()
+    while sent < total:
+        n = min(chunk_size, total - sent)
+        payload = struct.pack("<I", sent) + image[sent : sent + n]
+        try:
+            _send_and_await(
+                ser, decoder, seq=seq, type_=fr.TYPE_OTA_CHUNK,
+                payload=payload,
+                expect_types=[fr.TYPE_ACK],
+                timeout_s=ACK_TIMEOUT_S,
+            )
+        except RuntimeError:
+            raise
+        sent += n
+        seq = (seq + 1) & 0xFF
+        # Cheap progress: print every ~5%.
+        pct = (sent * 100) // total
+        if pct != ((sent - n) * 100) // total:
+            elapsed = time.time() - t0
+            kbps = (sent / 1024.0) / elapsed if elapsed > 0 else 0.0
+            print(f"[chunk] {sent}/{total} bytes ({pct}%) {kbps:.1f} KiB/s")
+    elapsed = time.time() - t0
+    kbps = (total / 1024.0) / elapsed if elapsed > 0 else 0.0
+    print(f"[chunk] done: {total} bytes in {elapsed:.2f} s ({kbps:.1f} KiB/s)")
+    return seq, retx
+
+
+def stage_end(ser, decoder: fr.Decoder, seq: int) -> int:
+    print("[end] verifying...")
+    frame = _send_and_await(
+        ser, decoder, seq=seq, type_=fr.TYPE_OTA_END, payload=b"",
+        expect_types=[fr.TYPE_STATUS],
+        timeout_s=END_TIMEOUT_S,
+    )
+    if not frame.payload:
+        raise RuntimeError("STATUS frame had no payload")
+    status = frame.payload[0]
+    name = fr.STATUS_NAMES.get(status, f"unknown({status})")
+    print(f"[end] STATUS={name}")
+    return status
+
+
+# ---------------------------------------------------------------------------
+# Main entry
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Stream a signed image into the bootloader OTA receiver."
+    )
+    p.add_argument("--port", required=True, help="Serial device, e.g. /dev/ttyACM0")
+    p.add_argument("--image", required=True,
+                   help="Path to a .signed.bin produced by tools/sign_image.py")
+    p.add_argument("--slot", required=True, choices=["A", "B"],
+                   help="Target slot — must be the inactive slot")
+    p.add_argument("--baud", type=int, default=DEFAULT_BAUD,
+                   help=f"Serial baud rate (default {DEFAULT_BAUD})")
+    p.add_argument("--chunk", type=int, default=DEFAULT_CHUNK_SIZE,
+                   help=f"Bytes per OTA_CHUNK (default {DEFAULT_CHUNK_SIZE})")
+    args = p.parse_args(argv)
+
+    if args.chunk <= 0 or args.chunk > fr.MAX_PAYLOAD - 4:
+        print(f"--chunk must be 1..{fr.MAX_PAYLOAD - 4}", file=sys.stderr)
+        return 1
+
+    image_path = Path(args.image)
+    if not image_path.exists():
+        print(f"image not found: {image_path}", file=sys.stderr)
+        return 1
+    image = image_path.read_bytes()
+    if not image:
+        print(f"image is empty: {image_path}", file=sys.stderr)
+        return 1
+
+    slot_id = SLOT_A if args.slot == "A" else SLOT_B
+
+    try:
+        import serial
+    except ImportError:
+        print("pyserial not installed. Run: pip3 install pyserial", file=sys.stderr)
+        return 2
+
+    try:
+        ser = serial.Serial(args.port, args.baud, timeout=0.2)
+    except Exception as e:
+        print(f"could not open {args.port}: {e}", file=sys.stderr)
+        return 2
+
+    decoder = fr.Decoder()
+    try:
+        # Drain any pending output so we don't decode prior-boot bytes.
+        ser.reset_input_buffer()
+
+        try:
+            stage_ping(ser, decoder)
+            seq = stage_begin(ser, decoder, slot_id, len(image))
+            seq, _retx = stage_chunks(ser, decoder, image, seq, args.chunk)
+            status = stage_end(ser, decoder, seq)
+        except RuntimeError as e:
+            print(f"OTA failed: {e}", file=sys.stderr)
+            return 3
+
+        if status != fr.STATUS_OK:
+            return 4
+        print("OTA OK — bootloader is resetting into the new image.")
+        return 0
+    finally:
+        try:
+            ser.close()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #162. Builds on the \`lib/framing/\` middleware merged in #163.

End-to-end OTA path now works: app → bootloader → host tool → bootloader → reset into the new image.

## Summary

- **RTC backup driver** (\`drivers/{inc,src}/rtc_backup.{h,c}\`) — three-function helper for enable-DBP / read-DR0 / write-DR0.
- **\`ota_request\` CLI command** in \`apps/cli/cli_commands.c\` — writes \`RTC_BACKUP_OTA_MAGIC\` (0x4F544131) into \`RTC_BKP_DR0\` and triggers \`NVIC_SystemReset()\`.
- **Bootloader OTA receiver** (\`apps/bootloader/loader/ota.{h,c}\`, \`verify.{h,c}\`):
  - At boot, checks \`RTC_BKP_DR0\`. If magic, clears it and enters \`bootloader_ota_run()\`.
  - UART → framing decoder → state machine (\`AWAIT_BEGIN → RECEIVING → DONE/HALT\`).
  - On \`OTA_BEGIN\`: refuses to write the currently-active slot, erases the target, ACKs.
  - On \`OTA_CHUNK\`: writes payload to \`slot_base + offset\` via \`flash_write_bytes\`, ACKs.
  - On \`OTA_END\`: runs the same SHA-256 + ECDSA path normal boot uses (extracted from \`main.c\` into \`verify.{h,c}\` so they share one correctness path), then commits target metadata with \`active=1\`, then clears the previously-active slot's \`active\` bit. \`STATUS=ok\` → \`NVIC_SystemReset()\`. Verify failure → \`STATUS=verify_failed\`, halt with slow-blink — previously-active slot remains active.
- **\`tools/_framing.py\`** — pure-Python mirror of \`lib/framing\` (CRC, stuffing, decoder).
- **\`tools/ota_send.py\`** — user-facing host driver. \`PING → OTA_BEGIN → loop OTA_CHUNK → OTA_END → STATUS\` with per-chunk progress, sliding-window-1 retry, configurable chunk size (default 256 B).
- **\`scripts/run_ota_test.py\`** — HIL flow wired into CI:
  - Pass 1: clean OTA flips active slot A → B and the new app boots.
  - Pass 2: tampered OTA reports \`STATUS=verify_failed\` and slot A stays active on the next boot.
- **Docs**: new [\`docs/wiki/plans/001-bootloader/ota.md\`](docs/wiki/plans/001-bootloader/ota.md) (protocol diagram, state machine, power-cut window, operator forced recovery, production gap), [\`ab-slots.md\`](docs/wiki/plans/001-bootloader/ab-slots.md) cross-reference, plan-page status update, wiki index + log entry.

## Sector-0 budget

\`loader.bin = 15604 / 16384 bytes\` — about 780 bytes of headroom under the 16 KB cap. The bin-level guard in \`apps/bootloader/loader/Makefile\` enforces this.

## Power-cut safety

Active-slot swap is two flash commits in order: target.active=1 first, then prev.active=0. The existing slot-pick decision tree falls back to the higher \`monotonic_counter\` if both slots end up active mid-swap, which is by construction the freshly-OTA'd slot — so the device always boots into the new image after a successful verify, even if the second commit gets cut off.

## Test plan

- [x] \`make test\` — host suites unchanged (still 35 framing + all driver tests green).
- [x] \`make all\` — every app builds clean.
- [x] \`make EXAMPLE=bootloader\` — \`loader.bin\` 15604 / 16384 bytes.
- [x] CI \`host-tests\` and \`firmware-build\` jobs go green.
- [x] CI HIL \`Run OTA test\` passes both clean and tampered cases.

## Files changed

- New: \`apps/bootloader/loader/{ota,verify}.{h,c}\`, \`drivers/{inc,src}/rtc_backup.{h,c}\`, \`tools/{_framing,ota_send}.py\`, \`scripts/run_ota_test.py\`, \`docs/wiki/plans/001-bootloader/ota.md\`.
- Modified: \`apps/bootloader/loader/{Makefile,main.c}\` (Makefile pulls in \`lib/flash\`+\`lib/framing\`; main.c adds the magic-flag check + \`bootloader_ota_run()\` call), \`apps/cli/cli_commands.c\` (new \`ota_request\` command), \`.github/workflows/ci.yml\` (HIL step), wiki cross-references.