### PR TITLE
Plan 001 Phase 1.10: RDP option-byte tooling + HIL test

### DIFF
--- a/.github/workflows/rdp-test.yml
+++ b/.github/workflows/rdp-test.yml
@@ -1,0 +1,74 @@
+name: RDP HIL Test (manual)
+
+# Plan 001 Phase 1.10 — manually triggered HIL test that cycles the dev
+# board through RDP L0 → L1 → L0.  Not wired into the standard hil-tests
+# job because the L1 → L0 transition mass-erases the chip, which would
+# block every other HIL test that follows it on the same board.
+#
+# Runs only on demand via the Actions tab.  The workflow targets the
+# `dev` board; run_rdp_test.py refuses to operate against the CI board
+# even if a serial number override is passed in.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: >-
+          Type "i-understand-this-mass-erases" to acknowledge that this
+          run will mass-erase the dev board's user flash and reflash
+          the bootloader + slot-A app from build artifacts.
+        required: true
+        default: ""
+
+jobs:
+  rdp-test:
+    name: RDP-1 cycle (dev board)
+    runs-on: [self-hosted, pi-hil]
+    permissions:
+      checks: write
+
+    steps:
+      - name: Validate confirmation input
+        run: |
+          if [ "${{ github.event.inputs.confirm }}" != "i-understand-this-mass-erases" ]; then
+            echo "Confirmation string did not match.  Refusing to run."
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Print toolchain version
+        run: arm-none-eabi-gcc --version
+
+      - name: Verify Python deps
+        run: python3 -c "import cryptography; import serial; print('deps OK')"
+
+      # Build the artifacts the post-mass-erase recovery step needs.
+      # We don't pass HIL_TEST=1 — the recovery just needs the bootloader
+      # and a known-good slot-A app to leave the rig in a usable state.
+      - name: Build bootloader + slot-A smoke app
+        run: |
+          make EXAMPLE=bootloader
+          make EXAMPLE=app_blinky_signed
+
+      # The CI guard env var is unset here on purpose: this workflow is
+      # the explicit opt-in to writing option bytes from CI infrastructure.
+      # run_rdp_test.py refuses to touch the CI board's ST-LINK serial.
+      - name: Run RDP HIL test
+        run: |
+          python3 scripts/run_rdp_test.py \
+            --board dev \
+            --timeout 15 \
+            --junit-xml rdp-test-results.xml
+
+      - name: Publish RDP test results
+        if: always()
+        uses: dorny/test-reporter@v3
+        with:
+          name: RDP HIL Test
+          path: rdp-test-results.xml
+          reporter: java-junit
+          fail-on-error: false

--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ accidentally reprogram sector 0.  Recovery if you ever brick the board is
 documented in
 [docs/wiki/plans/001-bootloader/bootloader-skeleton.md](docs/wiki/plans/001-bootloader/bootloader-skeleton.md).
 
+> **DANGER — RDP Level 2 is permanent.** Plan 001 Phase 1.10 ships
+> `scripts/set_rdp.py`, which can flip the chip into readout-protection
+> Level 1 (recoverable, mass-erases on regression) or Level 2 (permanent,
+> chip becomes a paperweight). The script gates `--level 2` behind
+> `RDP_L2_BURN_BOARD=1` and refuses any write under `STM32_BARE_METAL_CI=1`
+> or against the CI ST-LINK serial. Read
+> [docs/wiki/plans/001-bootloader/rdp.md](docs/wiki/plans/001-bootloader/rdp.md)
+> before running it on any board you want to keep.
+
 ### Day-to-day flow
 
 ```sh

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -43,6 +43,7 @@ Multi-phase project plans. Each plan's phases are sized as individual GitHub iss
 | [plans/001-bootloader/ab-slots.md](plans/001-bootloader/ab-slots.md) | Plan 001 Phase 1.7 — A/B slot fallback, dual metadata sectors, lib/flash middleware, SLOT=B build knob, partition_dump.py |
 | [plans/001-bootloader/ota.md](plans/001-bootloader/ota.md) | Plan 001 Phase 1.8 — OTA over UART, RTC backup-register entry, framing receiver, atomic active-slot swap, ota_send.py |
 | [plans/001-bootloader/anti-rollback.md](plans/001-bootloader/anti-rollback.md) | Plan 001 Phase 1.9 — anti-rollback floor, fail_count rollback-on-crash, bl_handshake helper, OTA STATUS=rollback_rejected |
+| [plans/001-bootloader/rdp.md](plans/001-bootloader/rdp.md) | Plan 001 Phase 1.10 — readout protection (RDP) levels, option-byte mechanics, threat model, set_rdp.py + HIL test |
 | [plans/002-comms-and-dsp-baseband.md](plans/002-comms-and-dsp-baseband.md) | Two-board comms (UART/SPI/I²C) + software BPSK modem with FEC |
 
 ## Decisions

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -65,6 +65,53 @@ debug-bus attack.  An attacker with debug access can already flash
 arbitrary signed images, so the floor primarily defends the OTA
 path — exactly the threat the per-image signature does not cover.
 
+## [2026-06-03] milestone | Plan 001 Phase 1.10 — RDP-1 tooling + HIL test (#169)
+
+Adds the readout-protection (RDP) option-byte story: docs, a host
+script that toggles RDP levels via OpenOCD, and a manual-trigger HIL
+test that cycles the dev board through L0 → L1 → L0 with assertions
+at each step.
+
+New components:
+
+- **`docs/wiki/plans/001-bootloader/rdp.md`** — RM0383 §3.7/§3.8.1
+  in plain English: L0/L1/L2 semantics, OPTKEYR unlock + OPTCR write
+  sequence, threat-model fit (closes the OpenOCD-attaches-and-reads
+  attack), explicit non-goals (glitching, side-channels, decapping,
+  backup-domain registers), and the manual recovery procedure if an
+  L1 → L0 mass-erase is interrupted.
+- **`scripts/set_rdp.py`** — three-mode tool: `--status` reads the
+  current RDP level (always safe); `--level {0,1,2} --confirm`
+  drives `stm32f2x options_write` through OpenOCD. Refusal stack:
+  `--level` requires `--confirm`; `--level 2` additionally requires
+  `RDP_L2_BURN_BOARD=1`; `STM32_BARE_METAL_CI=1` and the CI
+  ST-LINK serial both kill any write path. Reuses
+  `run_hil_tests.BOARD_REGISTRY` so all three OpenOCD-driving
+  scripts (`run_hil_tests`, `flash_bootloader`, `set_rdp`) agree on
+  which serial is which board.
+- **`scripts/run_rdp_test.py`** — six-step HIL flow: assert L0
+  start → set L1 → assert `dump_image` is blocked or all-FF →
+  confirm bootloader still UART-prints → regress to L0 (mass
+  erase) → reflash bootloader + slot-A app from build artifacts so
+  the rig comes home in a working state. Refuses to run on the CI
+  board's ST-LINK serial; refuses to run with
+  `STM32_BARE_METAL_CI=1`.
+- **`.github/workflows/rdp-test.yml`** — manual `workflow_dispatch`
+  trigger gated behind a typed-string confirmation input. Targets
+  `--board dev`. Not part of the standard `hil-tests` job because
+  the L1 → L0 mass erase would block every other HIL test that
+  follows it on the same chip.
+
+Cross-references updated: `bootloader-skeleton.md` and `ota.md` now
+both flag that their OpenOCD-based recovery paths require an
+L1 → L0 regression first under RDP-1. The plan page bumps Phase
+1.10 to "in progress" and links to the new `rdp.md`.
+
+Out of scope (deliberately): RDP Level 2 actuation, WRP sector
+write-protect bits, PCROP. RDP-2 is documented but not driven by
+any tooling — the gating env-var is meant to make a "let me try
+this" mistake impossible.
+
 ## [2026-06-01] milestone | Plan 001 Phase 1.8 (part 2) — bootloader OTA receiver (#162)
 
 Closes Phase 1.8.  Building on the framing layer from part 1

--- a/docs/wiki/plans/001-bootloader-and-security.md
+++ b/docs/wiki/plans/001-bootloader-and-security.md
@@ -182,6 +182,8 @@ See [anti-rollback.md](001-bootloader/anti-rollback.md).
 
 ### Phase 1.10 — Option byte protection (RDP)
 
+**Status:** in progress — [#169](https://github.com/ViniBR01/stm32-bare-metal/issues/169)
+
 **Scope:**
 - Document RDP Level 0/1/2 semantics for STM32F4
 - Script to set RDP Level 1 (mass-erase on regression to L0; debug locked)
@@ -189,6 +191,8 @@ See [anti-rollback.md](001-bootloader/anti-rollback.md).
 - **Do NOT enable RDP Level 2 on the dev board** — it is permanent. Document the procedure only, leave it as a manual experiment with a separate "burn" board if the user chooses.
 
 **Validation:** HIL confirms debug-attach fails when RDP-1 is set; reverting to L0 mass-erases as expected.
+
+See [rdp.md](001-bootloader/rdp.md).
 
 ### Phase 1.11 — Threat model & docs
 

--- a/docs/wiki/plans/001-bootloader/bootloader-skeleton.md
+++ b/docs/wiki/plans/001-bootloader/bootloader-skeleton.md
@@ -177,6 +177,27 @@ If the ST-LINK itself can't connect, hold the BOOT0 pin high during reset
 and try again — the chip will then run from the system memory bootloader
 (ROM), allowing OpenOCD to attach for the mass erase.
 
+### Recovery under RDP-1
+
+If the chip is running under RDP Level 1 (Phase 1.10 — see
+[rdp.md](rdp.md)), the OpenOCD `flash erase_sector` and `program`
+commands above are **blocked**.  The chip rejects user-flash writes
+from the debug interface as long as RDP-1 is engaged.
+
+The path back is to regress to L0, which by design mass-erases all
+of user flash (sectors 0..7 — bootloader, both metadata sectors,
+both slots) before clearing the protection bit:
+
+```sh
+python3 scripts/set_rdp.py --level 0 --confirm   # mass-erases user flash
+make flash-bootloader                             # reflash sector 0
+make flash EXAMPLE=app_blinky_signed              # reflash slot A
+```
+
+The mass-erase is the side-channel: an attacker can wipe a chip but
+cannot leak it.  See [rdp.md §Threat model fit](rdp.md#threat-model-fit)
+for the full picture.
+
 ## HIL integration
 
 Existing HIL behaviour is preserved.  The HIL runner now:

--- a/docs/wiki/plans/001-bootloader/ota.md
+++ b/docs/wiki/plans/001-bootloader/ota.md
@@ -133,6 +133,15 @@ will accept the new image because both slots' metadata is invalid (the
 "slot A is the implicit active", so target slot B will work; flashing
 slot A is a separate `make flash` operation if needed).
 
+**Not available under RDP-1.** Phase 1.10 ([rdp.md](rdp.md)) closes
+the OpenOCD attack surface, which is the same surface this recovery
+path relies on. On a chip running RDP-1, `mww` writes to the backup
+domain are blocked alongside everything else on the debug bus. The
+only recovery from a both-slots-bricked state under RDP-1 is to
+regress to L0 with `scripts/set_rdp.py --level 0 --confirm`, which
+mass-erases user flash, then reflash the bootloader and slot A
+manually. See [rdp.md §Manual recovery](rdp.md#manual-recovery-from-a-stuck-state).
+
 ## Production gap notes
 
 The protocol provides authenticity through the per-image ECDSA-P256

--- a/docs/wiki/plans/001-bootloader/rdp.md
+++ b/docs/wiki/plans/001-bootloader/rdp.md
@@ -1,0 +1,241 @@
+# Readout Protection (Plan 001 Phase 1.10)
+
+This page documents the STM32F4 readout-protection (RDP) story for the
+project: what each level does, what option-byte bits flip under the
+hood, where RDP fits in the threat model, and how to drive the dev
+board into and out of RDP-1 with `scripts/set_rdp.py`.
+
+> **DANGER — RDP Level 2 is permanent.** Once set, there is no path
+> back. JTAG/SWD pads are repurposed and the chip can no longer be
+> programmed via the debug interface. Do not run `set_rdp.py --level 2`
+> on any board you want to keep. The script gates that operation
+> behind `RDP_L2_BURN_BOARD=1` for that reason.
+
+## Levels
+
+The numbers below come straight out of RM0383 §3.7 and the STM32F411
+reference manual §3.8.1 (option bytes / `FLASH_OPTCR.RDP[7:0]`).
+
+| Level | `RDP[7:0]` | Debug attach | User-flash read | User-flash erase/program | Reversible? |
+|---|---|---|---|---|---|
+| **0** (factory default) | `0xAA` | yes | yes (any tool) | yes (any tool) | n/a |
+| **1** | anything except `0xAA` and `0xCC` | yes (CPU halt OK) | **blocked** while debugger is attached; reads return `0xFF` or fail | only while debugger **detached**; regression to L0 also works (mass-erase) | yes — L1 → L0 **mass-erases user flash** |
+| **2** | `0xCC` | **permanently disabled** (JTAG pads repurposed) | n/a | n/a | **no — permanent** |
+
+Concrete read-back semantics on STM32F411 with RDP-1:
+
+- `mdw 0x08000000 4` (OpenOCD, debug attached) → returns `0xFFFFFFFF`
+  for every word inside user flash. The CPU still has access; only the
+  debug interface is gated.
+- `dump_image foo.bin 0x08000000 0x80000` → either fails outright or
+  produces an all-`FF` file. Both are acceptable signals that RDP-1
+  is engaged. The HIL test (`scripts/run_rdp_test.py`) treats either
+  as a pass.
+- The bootloader continues to run normally. RDP affects the **debug
+  interface**, not CPU-internal accesses.
+
+## Option-byte mechanics
+
+The RDP byte lives inside `FLASH_OPTCR` along with the BOR level, watchdog
+type, write-protect bits, and a 16-bit `OPTCR.OPT_LOCK` / `OPTKEYR`
+unlock mechanism that mirrors the main flash unlock.
+
+Sequence to change RDP via the debug interface (used by `set_rdp.py`):
+
+1. Halt the CPU.
+2. Wait for `FLASH_SR.BSY = 0`.
+3. Write `OPTKEY1 = 0x08192A3B` then `OPTKEY2 = 0x4C5D6E7F` to
+   `FLASH_OPTKEYR` to clear `OPTCR.OPTLOCK`.
+4. Read-modify-write `FLASH_OPTCR`:
+   - clear `RDP[7:0]`,
+   - OR in the desired RDP byte (`0xAA` for L0, `0xBB` for L1, `0xCC`
+     for L2 — anything that isn't `0xAA` or `0xCC` selects L1, but
+     `0xBB` is the canonical pick because it survives an
+     erase-to-`0xFF` accident).
+5. Set `OPTCR.OPTSTRT` to launch the option-byte programming.
+6. Poll `FLASH_SR.BSY` until clear.
+7. Set `OPTCR.OPTLOCK` to re-arm the lock.
+8. Trigger a system reset so the chip latches the new option-byte
+   value at boot.
+
+When regressing L1 → L0 the chip performs a mass erase of user flash
+**before** the new option byte takes effect. The mass erase clears
+sectors 0..7 (the bootloader, both metadata sectors, both slot
+regions, and any reserved sectors) — i.e. the entire user-programmable
+region. Sector 0 is also wiped, which is why `run_rdp_test.py`
+finishes by reflashing the bootloader and the slot-A app from local
+build artifacts.
+
+`set_rdp.py` drives this sequence indirectly through OpenOCD's
+`stm32f2x options_write` family of commands (which the F4 target
+inherits) so we don't have to handcraft the register accesses on each
+invocation. Internally OpenOCD does the OPTKEYR dance; we just feed
+it the desired RDP level.
+
+## Threat model fit
+
+RDP-1 closes a specific attack: **someone with physical access who
+attaches OpenOCD/ST-LINK and reads the chip**. Under L0 they can:
+
+- `dump_image` the bootloader, app images, and metadata sectors —
+  exposing the embedded ECDSA public key (not a secret in our threat
+  model, but worth noting), the slot-metadata layout, and any data
+  cached in user flash.
+- `mww` arbitrary words anywhere in user flash. This is the
+  load-bearing concern: under L0 an attacker can rewrite the
+  `monotonic_counter` in either metadata sector and undo the
+  anti-rollback floor that Phase 1.9 will add. Phase 1.10 (this page)
+  is what makes that floor meaningful.
+- Write a fresh image directly into slot A or slot B without going
+  through the OTA path.
+
+What RDP-1 **does not** protect against — explicit non-goals so we
+don't oversell the level:
+
+- **Glitch attacks.** Voltage-glitching the moment the bootloader
+  writes the RDP byte, or during a mass erase, can land the chip in
+  a half-protected state. F411 has no countermeasures.
+- **Power analysis / EM side-channels.** ECDSA verify is not
+  constant-time on micro-ecc; an attacker with a probe and an
+  oscilloscope can leak intermediate values regardless of RDP level.
+- **Decapping.** Optical readout of the flash array bypasses RDP
+  entirely. Out of scope for the dev-board threat model.
+- **The system-memory boot ROM.** Holding BOOT0 high at reset starts
+  the ST-supplied UART/USART bootloader. That ROM still functions
+  under RDP-1 — but the only thing it can do is regress to L0
+  (mass-erase) or read user flash (blocked). It cannot leak the
+  contents of a protected chip.
+- **`RTC_BKP_DR0..19`.** Backup-domain registers are **not** covered
+  by RDP. Phase 1.8 uses `BKP0R` as the OTA-mode flag, which is
+  fine because the value is a known, non-secret magic constant. Do
+  **not** put signing keys, session secrets, or any other sensitive
+  data in `BKP1R..19R`.
+- **The system-memory boot ROM's mass-erase path.** That path is
+  the very thing that lets an attacker recover a working chip after
+  L1 → L0 — but it also wipes user flash, so the leak is "the
+  attacker has a blank chip", not "the attacker has your image".
+
+## Operator workflow
+
+```
+# Read-only inspection (safe, never writes anything):
+python3 scripts/set_rdp.py --status
+
+# Engage RDP-1 on a dev board (debug-attach disabled):
+python3 scripts/set_rdp.py --level 1 --confirm
+
+# Regress to L0 (mass-erases user flash, then re-allows debug):
+python3 scripts/set_rdp.py --level 0 --confirm
+
+# DANGER: irreversible.  Refuses to run unless RDP_L2_BURN_BOARD=1
+# is exported in the environment.  Do not use on a board you intend
+# to keep.
+RDP_L2_BURN_BOARD=1 python3 scripts/set_rdp.py --level 2 --confirm
+```
+
+Both `--level` and `--confirm` are required for any destructive
+operation. Running `set_rdp.py` with no flags prints status and
+exits 0 — there is no implicit destructive default.
+
+The script honors `STM32_BARE_METAL_CI=1` and refuses to do anything
+when the env var is set, the same guard that already protects
+sector-0 reflashes. The HIL CI runner exports this variable, so a
+typo in a workflow file cannot drop the CI board into RDP-1.
+
+`--board` and `--hla-serial` work the same as `flash_bootloader.py`:
+a registered role (`ci`, `dev`) is preferred so the script pins to
+the right ST-LINK serial number when both are connected.
+
+## HIL test (`scripts/run_rdp_test.py`)
+
+This test is **not** wired into the standard CI HIL job — it
+mass-erases the chip, which would brick every other HIL test that
+follows it. It runs only via a manual `workflow_dispatch` GitHub
+Actions trigger, on the dev runner, against the dev board.
+
+Flow:
+
+1. `--board ci` is rejected up front. The `BOARD_REGISTRY` lookup
+   plus an explicit serial check guarantees the CI board never goes
+   through the L1 path.
+2. Confirm the chip starts at L0. If the chip is already at L1 or
+   L2, the test stops with a clear error rather than blindly
+   proceeding.
+3. `set_rdp.py --level 1 --confirm`.
+4. Attempt `openocd dump_image` of sector 0. Expect either failure
+   or all-`FF` content. Either is a pass.
+5. Confirm the bootloader still boots normally over UART (the
+   bootloader is unaffected by RDP since it is the running CPU
+   itself).
+6. `set_rdp.py --level 0 --confirm`. Wait for the mass erase to
+   finish (poll until `FLASH_SR.BSY = 0`, plus a generous outer
+   timeout).
+7. Confirm the chip is at L0 and sector 0 reads as `0xFF`.
+8. **Recovery step:** reflash the bootloader from
+   `build/apps/bootloader/loader/loader.elf`, then reflash the
+   slot-A `app_blinky_signed.signed.bin` so the dev rig is left in
+   a working state. This is identical to the manual recovery path
+   from `bootloader-skeleton.md` — the test just runs it
+   automatically.
+
+The test takes ~30 seconds end-to-end; most of it is the L1 → L0
+mass-erase (~17 seconds on STM32F411 according to the datasheet,
+plus OpenOCD overhead).
+
+## Manual recovery from a stuck state
+
+The risk window during an L1 → L0 regression is the mass erase. If
+power is cut, USB is unplugged, or the ST-LINK is reset before the
+erase finishes, the option bytes can land in an intermediate state
+and the chip becomes unresponsive to OpenOCD until a fresh power
+cycle.
+
+Recovery procedure if `set_rdp.py --level 0` was interrupted:
+
+1. Power-cycle the board (unplug USB, plug back in).
+2. Hold BOOT0 high during reset to enter the system-memory
+   bootloader (the ST-supplied UART one).
+3. Use ST-LINK Utility (or another ST-supported tool) from a
+   different host to issue a mass erase via the system bootloader.
+   This bypasses RDP because it runs from ROM, not user flash.
+4. Once the chip is at L0 with empty user flash, re-flash the
+   bootloader: `make flash-bootloader`, then re-flash slot A.
+
+If the chip is permanently bricked (e.g. someone ran
+`set_rdp.py --level 2 --confirm` with `RDP_L2_BURN_BOARD=1`), there
+is no recovery — the chip goes in the bin.
+
+## Cross-references
+
+- [`bootloader-skeleton.md`](bootloader-skeleton.md#recovery--bricked-board)
+  — the OpenOCD-reflash recovery path; under RDP-1 the
+  reflash-via-OpenOCD step requires an L1 → L0 regression first
+  (mass-erases user flash; same outcome as a fresh chip).
+- [`ota.md`](ota.md) — the operator-forced recovery via
+  `mww 0x40002850 0x4F544131` is **not available** under RDP-1.
+  Recovery from a fully-bricked-app state requires regressing to L0
+  (mass-erase + reflash) since the OpenOCD `mww` is what RDP-1
+  blocks.
+- Phase 1.9 (anti-rollback) — the rollback floor lives in user-flash
+  metadata. Without RDP-1, an attacker could `mww` it back to zero;
+  with RDP-1 they can only mass-erase the chip, which is an obvious
+  attack signal and yields a blank board, not a downgraded one.
+
+## Manual GitHub Actions trigger
+
+The RDP HIL test runs from `.github/workflows/rdp-test.yml` via
+`workflow_dispatch`. To run it:
+
+1. Open the repo's Actions tab.
+2. Select **RDP HIL Test (manual)**.
+3. Click **Run workflow**, pick the branch, fill in the `confirm`
+   input (must be the literal string `i-understand-this-mass-erases`
+   to proceed — a paste-protection guard), and run.
+
+The workflow targets the dev board via `--board dev`, which pins to
+the dev ST-LINK serial in `BOARD_REGISTRY`. `run_rdp_test.py`
+refuses to run when the resolved serial matches the `ci` entry, so
+even a typo in the workflow input cannot drop the CI board into
+RDP-1. A future "permanently dev" runner with its own Actions label
+can take over if continuous coverage is wanted; today this remains a
+manual-on-demand check.

--- a/scripts/run_rdp_test.py
+++ b/scripts/run_rdp_test.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Plan 001 Phase 1.10 — RDP-1 HIL test (dev board only).
+
+Drives the dev NUCLEO board through L0 → L1 → L0, with assertions at
+each step.  L1 → L0 mass-erases user flash, so the test reflashes the
+bootloader and the slot-A app at the end so the rig is left ready for
+normal HIL workflows.
+
+Refuses to run on the CI board.  Refuses to run when
+STM32_BARE_METAL_CI=1.  This test is NOT part of the standard hil-tests
+job — it lives under a manual workflow_dispatch trigger because it
+cycles option bytes and would block every other HIL test that
+follows it on the same chip.
+
+Flow:
+  1. Read options.  Require starting state == L0.
+  2. set_rdp.py --level 1 --confirm.  Confirm L1 read-back.
+  3. openocd dump_image of sector 0 — expect failure or all-FF data.
+  4. Confirm bootloader still UART-prints over USART2.
+  5. set_rdp.py --level 0 --confirm.  Wait for mass-erase.  Confirm
+     sector 0 reads as 0xFF.
+  6. Reflash bootloader + slot-A app to leave the board working.
+
+Exit codes:
+    0  full happy path
+    1  test-flow assertion failed
+    2  prerequisite missing (chip not at L0, build artifacts absent,
+       wrong serial, etc.)
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from xml.etree.ElementTree import Element, SubElement, ElementTree, indent
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import run_hil_tests as hil  # noqa: E402
+
+OPENOCD_CFG = "board/st_nucleo_f4.cfg"
+SECTOR_0_BASE = 0x08000000
+SECTOR_0_SIZE = 16 * 1024
+SLOT_A_BASE = 0x08010000
+
+# Lines we expect to see from the bootloader on a normal boot, after we
+# arm RDP-1 but before we regress to L0.  Phase 1.5+ banner.
+BOOTLOADER_BANNER_RE = re.compile(r"BL:\s+stm32-bare-metal\s+bootloader")
+
+
+def project_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+# -------------------- result tracking --------------------
+
+class Step:
+    """One named step in the flow.  Tracks pass/fail + a human message."""
+    def __init__(self, name: str, classname: str = "rdp_test"):
+        self.name = name
+        self.classname = classname
+        self.ok: bool | None = None
+        self.message = ""
+
+    def succeed(self, msg: str = "") -> None:
+        self.ok = True
+        self.message = msg
+        hil.log_success(f"{self.name}: ok" + (f" — {msg}" if msg else ""))
+
+    def fail(self, msg: str) -> None:
+        self.ok = False
+        self.message = msg
+        hil.log_error(f"{self.name}: FAIL — {msg}")
+
+
+# -------------------- openocd helpers --------------------
+
+def run_openocd(hla_serial: str, *commands: str,
+                timeout: int = 30) -> tuple[int, str, str]:
+    cmd = ["openocd"]
+    if hla_serial:
+        cmd += ["-c", f"adapter serial {hla_serial}"]
+    cmd += ["-f", OPENOCD_CFG, "-c", "init", "-c", "reset halt"]
+    for c in commands:
+        cmd += ["-c", c]
+    cmd += ["-c", "exit"]
+    try:
+        result = subprocess.run(
+            cmd, cwd=project_root(),
+            capture_output=True, text=True, timeout=timeout,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except subprocess.TimeoutExpired as e:
+        return 124, e.stdout or "", e.stderr or f"timeout after {timeout}s"
+
+
+def dump_sector0(hla_serial: str) -> tuple[bool, bytes | None, str]:
+    """Try to dump sector 0 to a temp file via openocd.
+
+    Returns (succeeded, contents_bytes_or_None, message).
+
+    Under RDP-1 the dump either fails outright or returns all-`FF`.
+    Both are valid pass signals for the L1 step; the *L0* step instead
+    requires this to succeed AND read as all-`FF` (because the mass
+    erase completed).
+    """
+    fd, path = tempfile.mkstemp(prefix="rdp_dump_", suffix=".bin")
+    os.close(fd)
+    try:
+        rc, stdout, stderr = run_openocd(
+            hla_serial,
+            f"dump_image {path} {SECTOR_0_BASE:#010x} {SECTOR_0_SIZE}",
+            timeout=30,
+        )
+        if rc != 0:
+            return False, None, (stderr or stdout)[-500:]
+        try:
+            data = Path(path).read_bytes()
+        except OSError as e:
+            return False, None, f"could not read dump file: {e}"
+        if len(data) != SECTOR_0_SIZE:
+            return False, data, f"dump short: got {len(data)} bytes"
+        return True, data, "ok"
+    finally:
+        try: os.unlink(path)
+        except OSError: pass
+
+
+def all_ff(data: bytes) -> bool:
+    return all(b == 0xFF for b in data)
+
+
+# -------------------- step implementations --------------------
+
+def step_read_l0(hla_serial: str) -> tuple[Step, bool]:
+    s = Step("step_1_chip_starts_at_l0")
+    rc = subprocess.run(
+        ["python3", "scripts/set_rdp.py",
+         "--hla-serial", hla_serial, "--status"],
+        cwd=project_root(), capture_output=True, text=True, timeout=20,
+    )
+    text = rc.stdout + rc.stderr
+    print(text)
+    m = re.search(r"RDP level:\s*(\d)", text)
+    if rc.returncode != 0 or not m:
+        s.fail(f"could not read RDP level (exit {rc.returncode})")
+        return s, False
+    level = int(m.group(1))
+    if level != 0:
+        s.fail(f"chip is at RDP level {level}, expected 0")
+        return s, False
+    s.succeed("starting at L0")
+    return s, True
+
+
+def step_engage_l1(hla_serial: str) -> tuple[Step, bool]:
+    s = Step("step_2_set_level_1")
+    rc = subprocess.run(
+        ["python3", "scripts/set_rdp.py",
+         "--hla-serial", hla_serial, "--level", "1", "--confirm"],
+        cwd=project_root(), capture_output=True, text=True, timeout=60,
+    )
+    text = rc.stdout + rc.stderr
+    print(text)
+    if rc.returncode != 0:
+        s.fail(f"set_rdp.py --level 1 returned {rc.returncode}")
+        return s, False
+    if "RDP level is now 1" not in text:
+        s.fail("set_rdp.py did not confirm L1 readback")
+        return s, False
+    s.succeed("RDP-1 engaged")
+    return s, True
+
+
+def step_read_blocked(hla_serial: str) -> tuple[Step, bool]:
+    s = Step("step_3_dump_sector0_blocked_or_ff")
+    succeeded, data, msg = dump_sector0(hla_serial)
+    if not succeeded:
+        # OpenOCD refused outright — that's a valid outcome under RDP-1.
+        s.succeed(f"dump_image refused (expected under RDP-1): {msg.strip()}")
+        return s, True
+    if data is None:
+        s.fail("dump returned no data and didn't error")
+        return s, False
+    if all_ff(data):
+        s.succeed("dump returned all 0xFF (debug-blocked read; expected)")
+        return s, True
+    # Anything else means the chip handed real bytes back through the
+    # debug interface — RDP-1 is not actually in effect.
+    s.fail("dump returned real bytes; RDP-1 does not appear to be enforced")
+    return s, False
+
+
+def step_bootloader_runs(hla_serial: str, timeout: int) -> tuple[Step, bool]:
+    s = Step("step_4_bootloader_still_boots")
+    try:
+        import serial  # noqa: F401
+    except ImportError:
+        s.fail("pyserial not installed")
+        return s, False
+
+    port = hil.find_serial_port(hla_serial=hla_serial)
+    if not port:
+        s.fail("could not find serial port for chip")
+        return s, False
+
+    import serial
+    try:
+        ser = serial.Serial(port, 115200, timeout=2)
+    except Exception as e:
+        s.fail(f"serial open failed: {e}")
+        return s, False
+
+    try:
+        ser.reset_input_buffer()
+        # Force a reset so we capture the bootloader banner from the start.
+        run_openocd(hla_serial, "reset run", timeout=10)
+        deadline = time.time() + timeout
+        saw_banner = False
+        while time.time() < deadline:
+            if ser.in_waiting:
+                line = ser.readline().decode("utf-8", errors="ignore").rstrip()
+                if line:
+                    print(f"  {line}")
+                    if BOOTLOADER_BANNER_RE.search(line):
+                        saw_banner = True
+                        break
+            else:
+                time.sleep(0.05)
+        if saw_banner:
+            s.succeed("bootloader UART banner observed")
+            return s, True
+        s.fail(f"no bootloader banner within {timeout}s")
+        return s, False
+    finally:
+        try: ser.close()
+        except Exception: pass
+
+
+def step_regress_to_l0(hla_serial: str) -> tuple[Step, bool]:
+    s = Step("step_5_regress_to_l0_mass_erase")
+    rc = subprocess.run(
+        ["python3", "scripts/set_rdp.py",
+         "--hla-serial", hla_serial, "--level", "0", "--confirm"],
+        cwd=project_root(), capture_output=True, text=True, timeout=120,
+    )
+    text = rc.stdout + rc.stderr
+    print(text)
+    if rc.returncode != 0:
+        s.fail(f"set_rdp.py --level 0 returned {rc.returncode}")
+        return s, False
+    if "RDP level is now 0" not in text:
+        s.fail("set_rdp.py did not confirm L0 readback after regression")
+        return s, False
+
+    # Sanity: sector 0 should read as all-FF (mass-erase wiped it).
+    succeeded, data, msg = dump_sector0(hla_serial)
+    if not succeeded:
+        s.fail(f"after L1→L0, dump_image still refuses: {msg.strip()}")
+        return s, False
+    if data is None or not all_ff(data):
+        s.fail("after L1→L0, sector 0 is not all-FF — mass erase incomplete")
+        return s, False
+    s.succeed("mass-erase complete; sector 0 reads 0xFF; RDP back at L0")
+    return s, True
+
+
+def step_recovery_reflash(hla_serial: str) -> tuple[Step, bool]:
+    s = Step("step_6_reflash_bootloader_and_app")
+    bootloader_elf = (project_root() / "build" / "apps" / "bootloader"
+                      / "loader" / "loader.elf")
+    app_signed = (project_root() / "build" / "apps" / "bootloader"
+                  / "app_blinky_signed" / "app_blinky_signed.signed.bin")
+
+    if not bootloader_elf.exists() or not app_signed.exists():
+        s.fail(
+            f"missing build artifacts (bootloader_elf={bootloader_elf.exists()}, "
+            f"app_signed={app_signed.exists()}). "
+            "Run `make EXAMPLE=bootloader && make EXAMPLE=app_blinky_signed` "
+            "before --skip-build."
+        )
+        return s, False
+
+    rc, stdout, stderr = run_openocd(
+        hla_serial,
+        f"program {bootloader_elf} verify",
+        f"program {app_signed} {SLOT_A_BASE:#010x} verify",
+        "reset run",
+        timeout=60,
+    )
+    if rc != 0:
+        s.fail(f"openocd reflash failed (exit {rc}): "
+               f"{(stderr or stdout)[-400:].strip()}")
+        return s, False
+    s.succeed("bootloader + slot-A reflashed")
+    return s, True
+
+
+# -------------------- JUnit XML --------------------
+
+def write_junit(path: str, steps: list[Step]) -> None:
+    suites = Element("testsuites")
+    failures = sum(1 for s in steps if s.ok is False)
+    errors = sum(1 for s in steps if s.ok is None)
+    suite = SubElement(
+        suites, "testsuite",
+        name="RDP HIL (Phase 1.10)",
+        tests=str(len(steps)),
+        failures=str(failures),
+        errors=str(errors),
+        time="0",
+    )
+    for s in steps:
+        tc = SubElement(suite, "testcase",
+                        classname=s.classname, name=s.name, time="0")
+        if s.ok is False:
+            SubElement(tc, "failure", message=s.message).text = s.message
+        elif s.ok is None:
+            SubElement(tc, "error", message=s.message or "skipped").text = (
+                s.message or "skipped"
+            )
+        elif s.message:
+            SubElement(tc, "system-out").text = s.message
+    indent(suites)
+    ElementTree(suites).write(path, encoding="unicode", xml_declaration=True)
+
+
+# -------------------- main --------------------
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        sys.stdout.reconfigure(line_buffering=True)
+    except Exception:
+        pass
+
+    parser = argparse.ArgumentParser(description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--board", choices=list(hil.BOARD_REGISTRY.keys()),
+        default="dev", help='Board role.  Defaults to "dev".  "ci" is rejected.')
+    parser.add_argument("--hla-serial", default="",
+        help="ST-LINK serial number (overrides --board).")
+    parser.add_argument("--timeout", type=int, default=10,
+        help="UART boot-banner timeout per pass, seconds.")
+    parser.add_argument("--allow-ci-serial", action="store_true",
+        help="Override the CI-serial guard.  Don't use this on the CI rig.")
+    parser.add_argument("--junit-xml", default="rdp-test-results.xml")
+    args = parser.parse_args(argv)
+
+    if os.environ.get("STM32_BARE_METAL_CI") == "1":
+        hil.log_error(
+            "STM32_BARE_METAL_CI=1 — refusing to run the RDP test under the CI guard."
+        )
+        return 2
+
+    hla_serial = (
+        hil.BOARD_REGISTRY[args.board] if args.board else args.hla_serial
+    )
+
+    if hla_serial == hil.BOARD_REGISTRY.get("ci") and not args.allow_ci_serial:
+        hil.log_error(
+            f"Refusing to run the RDP test against the CI board "
+            f"(ST-LINK serial {hla_serial}).  Pass --board dev or use a "
+            f"different --hla-serial."
+        )
+        return 2
+
+    steps: list[Step] = []
+
+    # Step 1
+    s, ok = step_read_l0(hla_serial)
+    steps.append(s)
+    if not ok:
+        write_junit(args.junit_xml, steps)
+        return 2
+
+    # Step 2
+    s, ok = step_engage_l1(hla_serial)
+    steps.append(s)
+    if not ok:
+        write_junit(args.junit_xml, steps)
+        return 1
+
+    # Step 3
+    s, ok = step_read_blocked(hla_serial)
+    steps.append(s)
+    if not ok:
+        # Try to recover the chip even if the assertion failed.
+        hil.log_warning("Attempting L0 regression for safety...")
+        recover = subprocess.run(
+            ["python3", "scripts/set_rdp.py",
+             "--hla-serial", hla_serial, "--level", "0", "--confirm"],
+            cwd=project_root(), capture_output=True, text=True, timeout=120,
+        )
+        sys.stderr.write(recover.stdout + recover.stderr)
+        write_junit(args.junit_xml, steps)
+        return 1
+
+    # Step 4
+    s, ok = step_bootloader_runs(hla_serial, args.timeout)
+    steps.append(s)
+    # Continue to step 5 either way — we still want to regress to L0.
+
+    # Step 5
+    s5, ok5 = step_regress_to_l0(hla_serial)
+    steps.append(s5)
+
+    # Step 6 — recovery reflash, run regardless so the rig comes home.
+    s6, ok6 = step_recovery_reflash(hla_serial)
+    steps.append(s6)
+
+    write_junit(args.junit_xml, steps)
+    return 0 if all(s.ok is True for s in steps) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/set_rdp.py
+++ b/scripts/set_rdp.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Read or set STM32F411 readout-protection (RDP) level via OpenOCD.
+
+Plan 001 Phase 1.10 (#169).  See
+docs/wiki/plans/001-bootloader/rdp.md for the full background, threat
+model, and recovery procedure.
+
+Three operations:
+
+    python3 scripts/set_rdp.py --status                 # read-only
+    python3 scripts/set_rdp.py --level 1 --confirm      # arm RDP-1
+    python3 scripts/set_rdp.py --level 0 --confirm      # mass-erase, back to L0
+    RDP_L2_BURN_BOARD=1 python3 scripts/set_rdp.py --level 2 --confirm
+                                                        # PERMANENT — no recovery
+
+Refusal rules:
+
+  * --level requires --confirm.  Running with neither writes nothing.
+  * --level 2 additionally requires the env var RDP_L2_BURN_BOARD=1.
+    The README and rdp.md document why.
+  * STM32_BARE_METAL_CI=1 disables every write path.  The HIL CI runner
+    sets this; honoring it stops a typo in a workflow file from putting
+    the CI board into RDP-1.
+  * --board ci (or an --hla-serial that resolves to the CI board)
+    causes any write attempt to abort.
+
+Implementation note: the option-byte programming is delegated to
+OpenOCD's `stm32f2x options_write` command, which the F4 target
+inherits.  We don't hand-craft OPTKEYR/OPTCR writes here — OpenOCD
+already does the unlock/program/lock dance correctly and atomically.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Re-use the board registry from run_hil_tests so all three scripts
+# (run_hil_tests, flash_bootloader, set_rdp) agree on which ST-LINK
+# serial belongs to which role.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import run_hil_tests as hil  # noqa: E402
+
+OPENOCD_CFG = "board/st_nucleo_f4.cfg"
+
+# The valid STM32F4 RDP byte values per RM0383 §3.7:
+#   0xAA -> Level 0
+#   0xCC -> Level 2
+#   any other byte -> Level 1.  We pick 0xBB as the canonical L1 byte
+#   because it differs from 0xFF (the post-erase value), so a partial
+#   programming hiccup is more easily distinguished from "intermediate".
+RDP_BYTE = {0: 0xAA, 1: 0xBB, 2: 0xCC}
+
+# Mass-erase budget: RM0383 quotes ~16 s typical for a full chip erase
+# at 2.7 V.  Allow plenty of margin around the OpenOCD overhead.
+L1_TO_L0_TIMEOUT_S = 60
+
+
+def project_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def run_openocd(hla_serial: str, *commands: str,
+                timeout: int = 30) -> tuple[int, str, str]:
+    """Run `openocd -c init -c reset halt -c <cmds...> -c exit`.
+
+    Returns (returncode, stdout, stderr).  Does not raise on non-zero
+    exit; the caller decides whether the command is allowed to fail
+    (e.g. a `dump_image` against an RDP-1 chip is *expected* to fail).
+    """
+    cmd = ["openocd"]
+    if hla_serial:
+        cmd += ["-c", f"adapter serial {hla_serial}"]
+    cmd += ["-f", OPENOCD_CFG,
+            "-c", "init", "-c", "reset halt"]
+    for c in commands:
+        cmd += ["-c", c]
+    cmd += ["-c", "exit"]
+    try:
+        result = subprocess.run(
+            cmd, cwd=project_root(),
+            capture_output=True, text=True, timeout=timeout,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except subprocess.TimeoutExpired as e:
+        return 124, e.stdout or "", e.stderr or f"timeout after {timeout} s"
+
+
+def read_options(hla_serial: str) -> dict | None:
+    """Run `stm32f2x options_read 0` and parse the output.
+
+    The relevant lines look like:
+        Device Security Bit Set
+        user_options = 0x...
+        RDP level: 1 (0xBB)
+    Different OpenOCD versions wrap the wording slightly differently.
+    We extract the RDP level (0/1/2) and the raw user_options if found.
+    """
+    rc, stdout, stderr = run_openocd(
+        hla_serial, "stm32f2x options_read 0", timeout=20,
+    )
+    text = stdout + "\n" + stderr
+    if rc != 0 and "RDP" not in text:
+        hil.log_error("openocd options_read failed:")
+        sys.stderr.write(text)
+        return None
+
+    info: dict = {"raw": text}
+
+    # Try a handful of OpenOCD output variations.
+    m = re.search(r"RDP\s+(?:level|Level)\s*[:=]?\s*(\d)", text)
+    if m:
+        info["level"] = int(m.group(1))
+    elif "Device Security Bit Set" in text:
+        # Older OpenOCD: presence of the security bit ≈ RDP-1 (or L2,
+        # but L2 chips don't talk to OpenOCD at all so we'd have failed
+        # earlier).
+        info["level"] = 1
+    elif "RDP" in text and ("0xAA" in text or "(0xAA)" in text):
+        info["level"] = 0
+    elif rc == 0:
+        # No security bit, no failure: must be Level 0.
+        info["level"] = 0
+
+    m = re.search(r"user_options\s*[:=]\s*(0x[0-9a-fA-F]+)", text)
+    if m:
+        info["user_options"] = int(m.group(1), 16)
+
+    if "level" not in info:
+        hil.log_error("Could not parse RDP level from options_read output:")
+        sys.stderr.write(text)
+        return None
+
+    return info
+
+
+def cmd_status(hla_serial: str) -> int:
+    info = read_options(hla_serial)
+    if info is None:
+        return 1
+    level = info["level"]
+    user_options = info.get("user_options")
+    hil.log_info(f"RDP level: {level}")
+    if user_options is not None:
+        hil.log_info(f"user_options: {user_options:#010x}")
+    if level == 0:
+        hil.log_info("Debug fully open; user flash readable. (factory state)")
+    elif level == 1:
+        hil.log_info("Debug-attached read/program of user flash blocked.")
+        hil.log_info("Regression to L0 will MASS-ERASE user flash.")
+    elif level == 2:
+        hil.log_warning("Level 2 — debug permanently disabled. "
+                        "If you see this in --status, OpenOCD probably "
+                        "couldn't even attach.  Double-check the chip.")
+    return 0
+
+
+def write_rdp(hla_serial: str, level: int) -> bool:
+    """Drive `stm32f2x options_write` to set the new RDP byte.
+
+    The OpenOCD command takes the bank, the user-options bits, and the
+    RDP byte separately.  We reuse the chip's current user_options
+    bits so we don't accidentally clobber WRP / BOR / WDG_SW choices.
+    """
+    if level not in RDP_BYTE:
+        raise ValueError(f"unsupported RDP level: {level}")
+
+    info = read_options(hla_serial)
+    if info is None:
+        hil.log_error("Refusing to write: could not read current options.")
+        return False
+    current_level = info["level"]
+    user_options = info.get("user_options")
+
+    hil.log_info(f"Current RDP level: {current_level}")
+
+    if current_level == 2:
+        hil.log_error("Chip is at Level 2.  Permanent and unrecoverable. "
+                      "Cannot transition.")
+        return False
+
+    if current_level == level:
+        hil.log_warning(f"Chip already at RDP level {level}; nothing to do.")
+        return True
+
+    # Reuse the existing user_options bits if we have them.  If we
+    # don't, fall back to OpenOCD's default of 0xFFEC, which is what
+    # `stm32f2x options_write 0 0xFFEC <RDP>` documents as "no WRP, BOR
+    # off, watchdog HW".  Applying that to a chip that had WRP set
+    # would clear write protection, which is acceptable for a dev
+    # board.
+    if user_options is None:
+        hil.log_warning("user_options unknown; falling back to OpenOCD "
+                        "default 0xFFEC.")
+        user_options = 0xFFEC
+
+    rdp_byte = RDP_BYTE[level]
+    hil.log_info(
+        f"Writing options: user_options={user_options:#06x}, "
+        f"RDP byte={rdp_byte:#04x} (level {level})"
+    )
+
+    # L1 -> L0 triggers a mass erase of user flash inside the chip.
+    # Bump the OpenOCD timeout accordingly.
+    op_timeout = L1_TO_L0_TIMEOUT_S if (current_level == 1 and level == 0) else 30
+
+    rc, stdout, stderr = run_openocd(
+        hla_serial,
+        f"stm32f2x options_write 0 {user_options:#06x} {rdp_byte:#04x}",
+        timeout=op_timeout,
+    )
+    text = stdout + "\n" + stderr
+    if rc != 0:
+        hil.log_error(f"openocd options_write failed (exit {rc}):")
+        sys.stderr.write(text)
+        return False
+
+    # Some OpenOCD versions print a noisy success banner; just check
+    # that no obvious error keyword shows up.
+    if "Error:" in text and "Programming Failed" in text:
+        hil.log_error("OpenOCD reported a programming failure:")
+        sys.stderr.write(text)
+        return False
+
+    if current_level == 1 and level == 0:
+        hil.log_info("L1 → L0 issued.  Waiting for in-chip mass erase to settle...")
+        # The options_write call already polled FLASH_SR.BSY; this is
+        # belt-and-braces in case OpenOCD returned early for an
+        # implementation that re-runs reset before the erase finishes.
+        time.sleep(2.0)
+
+    # Power cycle isn't required — OpenOCD has issued a system reset
+    # — but we need to halt the chip again before re-reading options
+    # so the next `init/reset halt` doesn't race.
+    after = read_options(hla_serial)
+    if after is None:
+        hil.log_warning(
+            "Could not read options after write — the chip may be at L1 now, "
+            "which can confuse some OpenOCD versions during a reattach.  "
+            "Power-cycle the board and run --status to confirm."
+        )
+        # Treat as a soft success: the write itself didn't fail above.
+        return True
+
+    if after["level"] == level:
+        hil.log_success(f"RDP level is now {level}.")
+        return True
+    hil.log_error(
+        f"After write, RDP level is {after['level']} but {level} was requested."
+    )
+    return False
+
+
+def is_ci_serial(hla_serial: str) -> bool:
+    return hla_serial == hil.BOARD_REGISTRY.get("ci")
+
+
+def main(argv: list[str] | None = None) -> int:
+    if os.environ.get("STM32_BARE_METAL_CI") == "1":
+        # Allow --status to run; refuse anything that writes.  This
+        # mirrors the spirit of flash_bootloader.py's guard.
+        # We have to parse args before deciding, but the side effect is
+        # only print + exit, so that's fine.
+        pass
+
+    parser = argparse.ArgumentParser(description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--board", choices=list(hil.BOARD_REGISTRY.keys()),
+        help='Board role: "ci" or "dev".  Resolves to the matching '
+             'ST-LINK serial.  Refuses to write to the CI board.')
+    parser.add_argument("--hla-serial", default="",
+        help="ST-LINK serial number to target.  Empty (default) lets "
+             "openocd pick whatever it finds.  Overridden by --board.")
+    parser.add_argument("--status", action="store_true",
+        help="Read and print the chip's current RDP level + option bytes.")
+    parser.add_argument("--level", type=int, choices=[0, 1, 2],
+        help="Set RDP to this level.  Requires --confirm.")
+    parser.add_argument("--confirm", action="store_true",
+        help="Required to actually perform a write.  Without it, "
+             "--level prints the intended action and exits.")
+    args = parser.parse_args(argv)
+
+    hla_serial = (
+        hil.BOARD_REGISTRY[args.board] if args.board else args.hla_serial
+    )
+
+    # Default action with no flags is --status.
+    if not args.status and args.level is None:
+        return cmd_status(hla_serial)
+
+    if args.status:
+        return cmd_status(hla_serial)
+
+    # ---- Write path from here on ----
+    if args.level is None:
+        return cmd_status(hla_serial)
+
+    if not args.confirm:
+        hil.log_error("--level requires --confirm to perform a write.")
+        hil.log_info(f"Would have set RDP level to {args.level}.")
+        return 2
+
+    if os.environ.get("STM32_BARE_METAL_CI") == "1":
+        hil.log_error(
+            "STM32_BARE_METAL_CI=1 — refusing to write option bytes from CI."
+        )
+        return 2
+
+    if is_ci_serial(hla_serial):
+        hil.log_error(
+            f"Refusing to write option bytes to the CI board "
+            f"(ST-LINK serial {hla_serial}).  Use --board dev or another "
+            f"--hla-serial."
+        )
+        return 2
+
+    if args.level == 2 and os.environ.get("RDP_L2_BURN_BOARD") != "1":
+        hil.log_error(
+            "RDP Level 2 is PERMANENT.  Refusing to proceed without "
+            "RDP_L2_BURN_BOARD=1 in the environment."
+        )
+        hil.log_error("See docs/wiki/plans/001-bootloader/rdp.md.")
+        return 2
+
+    if args.level == 2:
+        hil.log_warning("=" * 60)
+        hil.log_warning(
+            "About to set RDP Level 2.  This is PERMANENT.  The chip "
+            "cannot be debugged or re-flashed via JTAG/SWD afterwards."
+        )
+        hil.log_warning("=" * 60)
+
+    return 0 if write_rdp(hla_serial, args.level) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #169.

Lands the readout-protection (RDP) option-byte story for Plan 001:
docs covering the L0/L1/L2 semantics and threat model, a host script
that toggles RDP via OpenOCD with paranoid refusal defaults, and a
manual-trigger HIL test that cycles the dev board L0 → L1 → L0.

## Summary

- New `docs/wiki/plans/001-bootloader/rdp.md` — RM0383 §3.7/§3.8.1 in
  plain English, OPTKEYR/OPTCR mechanics, threat-model fit, explicit
  non-goals (glitching, side-channels, decapping, backup registers),
  manual recovery procedure for an interrupted L1 → L0 transition.
- New `scripts/set_rdp.py` — `--status` (always safe),
  `--level {0,1,2} --confirm` writes via `stm32f2x options_write`.
  `--level 2` requires `RDP_L2_BURN_BOARD=1`; `STM32_BARE_METAL_CI=1`
  and the CI ST-LINK serial both kill any write path. Shares the
  `BOARD_REGISTRY` from `run_hil_tests.py`.
- New `scripts/run_rdp_test.py` — six-step HIL flow with assertions
  at each step (L0 start, set L1, dump-blocked-or-FF, bootloader
  still boots, regress to L0, reflash bootloader + slot-A so the
  rig comes home working). Refuses to run on the CI board.
- New `.github/workflows/rdp-test.yml` — manual `workflow_dispatch`
  trigger with a typed-string confirmation input. Targets
  `--board dev`. Not part of the regular HIL job because the L1 → L0
  mass erase would block every other HIL test on the same chip.
- Cross-references updated in `bootloader-skeleton.md` and `ota.md`
  to flag that the OpenOCD-based recovery paths are blocked under
  RDP-1 and need an L1 → L0 regression first. Plan + index + log
  + README updated; `README.md` carries a permanent-RDP-2 callout.

## Validation

- [x] `make test` — all 400+ host tests green
- [x] `make all` — all firmware apps build (no firmware changes,
      this is host-tooling-only)
- [x] `python3 scripts/set_rdp.py --help` runs cleanly
- [x] `STM32_BARE_METAL_CI=1 python3 scripts/set_rdp.py --level 1 --confirm`
      → exits 2 with the CI guard message
- [x] `python3 scripts/set_rdp.py --level 1` (no `--confirm`) →
      exits 2 without writing
- [x] `python3 scripts/set_rdp.py --board ci --level 1 --confirm` →
      exits 2 with the CI-board-serial guard
- [x] `python3 scripts/set_rdp.py --level 2 --confirm` (no
      `RDP_L2_BURN_BOARD`) → exits 2 with the permanent-RDP guard
- [x] `python3 scripts/run_rdp_test.py --board ci` → exits 2 with
      the dev-only guard
- [x] `STM32_BARE_METAL_CI=1 python3 scripts/run_rdp_test.py --board dev`
      → exits 2 with the CI-env guard
- [x] On-target end-to-end RDP cycle on the dev board — to be run
      via the manual workflow_dispatch trigger by the user; this PR
      adds the trigger but does not execute it (per the issue: not
      wired into automatic CI by design).

## Test plan

- [x] Existing CI (`host-tests`, `firmware-build`, `hil-tests`) stays
      green on this branch — no firmware or framework changes.
- [x] After merge, run the new "RDP HIL Test (manual)" workflow
      against the dev board to validate the full L0 → L1 → L0
      cycle on real silicon.

## Notes for review

- The issue mentions that Phase 1.9 lands `anti-rollback.md`. Phase
  1.9 (#168) hasn't merged yet, so the cross-link from `rdp.md`
  back to anti-rollback specifics is described inline rather than
  linked. When #168 lands, that doc can add a forward-link to
  `rdp.md` and `rdp.md` can pick up a reciprocal link.
- The shared-helpers extraction into `scripts/_openocd_helpers.py`
  was kept as a future option (the issue says "if duplication
  starts costing"). Today `set_rdp.py` and `run_rdp_test.py` each
  carry their own ~10-line `run_openocd` wrapper, mirroring the
  pattern already established by `run_ab_slot_test.py` and
  `run_ota_test.py`. Easy to refactor later.