### PR TITLE
Plan 001 Phase 1.11: threat model, production gaps, and image format ADR

### DIFF
--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -12,6 +12,7 @@
 - **No dynamic allocation.** All state is statically allocated.
 - **Layered drivers.** Low-level drivers (GPIO, DMA) are reused by higher-level drivers (UART, SPI). Applications use drivers only, never registers directly.
 - **ISR-safe architecture.** Interrupt handlers are kept minimal; work is deferred to the main loop where possible (e.g. CLI character input vs command execution).
+- **Secure boot chain (Plan 001).** ECDSA-P256 signed images, A/B slots with atomic fallback, anti-rollback floor, OTA over UART. See [threat model](plans/001-bootloader/threat-model.md) for what is and isn't defended, and [production gaps](plans/001-bootloader/production-gap.md) for what a real product would add.
 
 ## Directory Layout
 

--- a/docs/wiki/decisions/002-image-format.md
+++ b/docs/wiki/decisions/002-image-format.md
@@ -1,0 +1,69 @@
+# ADR 002: Image Format and Partition Layout
+
+**Date:** 2026-06-19
+**Status:** Accepted
+**Issues:** #143 (Phase 1.2), #151 (Phase 1.5), #158 (Phase 1.7), #168 (Phase 1.9)
+
+## Context
+
+Plan 001 built the bootloader incrementally across Phases 1.2 through 1.9. Each phase added constraints (signing, A/B fallback, anti-rollback) on top of the on-flash binary format defined in Phase 1.2. Now that all phases have landed and downstream tools (sign_image.py, partition_dump.py, ota_send.py) depend on the exact byte layout, the format is effectively frozen for the STM32F411RE deliverable. This ADR pins the decisions in one place so future contributors know what is load-bearing and why.
+
+## Decisions
+
+### 1. Image header is 140 bytes, packed, CRC-last
+
+`img_header_t` is `__attribute__((packed))` with `_Static_assert(sizeof == 140)`. Fields in order: `magic` (4), `header_version` (4), `image_version` (4), `image_type` (4), `payload_size` (4), `payload_offset` (4), `sha256` (32), `signature` (64), `reserved[4]` (16), `header_crc` (4). Magic is `"IMGH"` = `0x494D4748` little-endian. The trailing CRC covers bytes [0, 136).
+
+### 2. Slot metadata is 36 bytes, packed, CRC-last
+
+`img_slot_metadata_t` fields: `magic` (4), `metadata_version` (4), `active` (4), `fail_count` (4), `monotonic_counter` (4), `reserved[3]` (12), `metadata_crc` (4). Magic is `"SLOT"` = `0x534C4F54` little-endian. The `active` field is `uint32_t` (non-zero = active). CRC covers bytes [0, 32).
+
+### 3. Payload is 512-byte aligned
+
+`payload_offset = 0x200` (512). The 140-byte header is followed by a 372-byte zero-padded gap so the payload's first word (the Cortex-M vector table) lands on a 512-byte boundary. STM32F411 supports up to 96 external IRQs (112 vectors total, 448 bytes), requiring SCB->VTOR alignment to the next power-of-two (512). This alignment holds for all Cortex-M4 parts with up to 96 IRQs.
+
+### 4. Flash sector layout (STM32F411RE, 512 KB)
+
+| Sector | Address | Size | Contents |
+|--------|-----------|--------|------------------------------|
+| 0 | 0x08000000 | 16 KB | Bootloader (`bootloader_ls.ld`) |
+| 1 | 0x08004000 | 16 KB | Slot A metadata (36 B used) |
+| 2 | 0x08008000 | 16 KB | Slot B metadata (36 B used) |
+| 3 | 0x0800C000 | 16 KB | Reserved (anti-rollback log) |
+| 4 | 0x08010000 | 64 KB | Slot A payload (start) |
+| 5 | 0x08020000 | 128 KB | Slot A payload (continued) |
+| 6 | 0x08040000 | 128 KB | Slot B payload |
+| 7 | 0x08060000 | 128 KB | Reserved |
+
+Slot A capacity: 192 KB. Slot B capacity: 128 KB. Bootloader is hard-capped at 16 KB by the linker script; a post-link size guard fails the build if exceeded.
+
+### 5. Signing: ECDSA-P256 over SHA-256, raw R||S
+
+The signature is computed over the SHA-256 digest of the payload (not the header). The 64-byte signature field stores raw `R || S` (32 + 32, big-endian integers). DER encoding is NOT used. The host signer (`sign_image.py`) decodes the DER output from the Python `cryptography` library into raw R||S before packing. The bootloader's `crypto_ecdsa_p256_verify()` expects this raw format directly.
+
+## Consequences
+
+- Changing any field offset or size in `img_header_t` or `img_slot_metadata_t` requires bumping `IMG_HEADER_VERSION` / `IMG_SLOT_METADATA_VERSION`, updating `tools/_img_format.py`, and regenerating the round-trip test fixture. The CI round-trip suite (`tests/tools/sign_roundtrip/`) will fail if the Python and C sides drift.
+- Changing the sector layout bricks any device that has already been flashed with the current bootloader, since the bootloader hard-codes metadata and slot addresses.
+- The format is frozen for the STM32F411RE deliverable. A different MCU with different sector geometry would need a new partition table (but the header and metadata struct formats can be reused).
+- The 16 KB bootloader budget has approximately 4.5 KB of headroom remaining after Phase 1.9.
+
+## Alternatives considered
+
+- **RSA-PSS-2048** — rejected because verify time on a 100 MHz Cortex-M4 without a hardware accelerator exceeds 200 ms, unacceptable for boot latency.
+- **Ed25519** — rejected for ecosystem complexity; fewer host-side libraries and tooling compared to ECDSA-P256, and the Python `cryptography` library's Ed25519 API does not expose raw R||S decomposition.
+- **DER-encoded signatures** — rejected because a DER parser adds code size to the 16 KB bootloader sector; raw R||S is fixed-length and trivial to index.
+- **Single slot (no A/B)** — rejected because OTA updates cannot be made atomic without a fallback slot; a failed flash leaves the device bricked.
+- **Metadata embedded in the image header** — rejected because metadata (active flag, fail_count) is written every boot while the image is written only on OTA; separate sectors avoid wearing out the payload sectors.
+
+## References
+
+- [lib/img/inc/img_header.h](../../../lib/img/inc/img_header.h) — struct definitions and static asserts
+- [docs/wiki/plans/001-bootloader/image-format.md](../plans/001-bootloader/image-format.md) — Phase 1.2 format spec
+- [docs/wiki/plans/001-bootloader/signing.md](../plans/001-bootloader/signing.md) — Phase 1.4 host signing workflow
+- [docs/wiki/plans/001-bootloader/ab-slots.md](../plans/001-bootloader/ab-slots.md) — Phase 1.7 A/B partition layout
+- [docs/wiki/plans/001-bootloader/verify-and-jump.md](../plans/001-bootloader/verify-and-jump.md) — Phase 1.6 signature verification
+- [linker/bootloader_ls.ld](../../../linker/bootloader_ls.ld) — sector 0 linker script
+- [linker/app_ls.ld](../../../linker/app_ls.ld) — slot-A app linker script
+- [tools/_img_format.py](../../../tools/_img_format.py) — Python format constants (must match C)
+- [tools/sign_image.py](../../../tools/sign_image.py) — host signing tool

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -44,6 +44,8 @@ Multi-phase project plans. Each plan's phases are sized as individual GitHub iss
 | [plans/001-bootloader/ota.md](plans/001-bootloader/ota.md) | Plan 001 Phase 1.8 — OTA over UART, RTC backup-register entry, framing receiver, atomic active-slot swap, ota_send.py |
 | [plans/001-bootloader/anti-rollback.md](plans/001-bootloader/anti-rollback.md) | Plan 001 Phase 1.9 — anti-rollback floor, fail_count rollback-on-crash, bl_handshake helper, OTA STATUS=rollback_rejected |
 | [plans/001-bootloader/rdp.md](plans/001-bootloader/rdp.md) | Plan 001 Phase 1.10 — readout protection (RDP) levels, option-byte mechanics, threat model, set_rdp.py + HIL test |
+| [plans/001-bootloader/threat-model.md](plans/001-bootloader/threat-model.md) | Plan 001 Phase 1.11 — threat model: attacker classes, defenses, explicit non-goals, trust assumptions |
+| [plans/001-bootloader/production-gap.md](plans/001-bootloader/production-gap.md) | Plan 001 Phase 1.11 — production gaps: 8 changes needed to ship (key custody, secure ROM, TrustZone, etc.) |
 | [plans/002-comms-and-dsp-baseband.md](plans/002-comms-and-dsp-baseband.md) | Two-board comms (UART/SPI/I²C) + software BPSK modem with FEC |
 
 ## Decisions
@@ -51,6 +53,7 @@ Multi-phase project plans. Each plan's phases are sized as individual GitHub iss
 | Page | Summary |
 |---|---|
 | [decisions/001-ci-pipeline.md](decisions/001-ci-pipeline.md) | Why GitHub Actions with hosted runners; HIL architecture plan |
+| [decisions/002-image-format.md](decisions/002-image-format.md) | Image header format, slot metadata format, partition layout, signing algorithm — frozen for STM32F411RE |
 
 ## Log
 

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -4,6 +4,27 @@ Chronological record of significant changes. Newest entries at the top.
 Format: `## [YYYY-MM-DD] <type> | <title> (<PR/Issue>)`
 Types: `merge`, `decision`, `milestone`, `infra`
 
+## [2026-06-20] milestone | Plan 001 complete — Phase 1.11 threat model + production gaps + ADR (#170)
+
+Closes Plan 001.  Phases 1.5–1.10 shipped the bootloader, signing, OTA,
+A/B slots, anti-rollback, and RDP-1.  This final phase documents what the
+project defends against, what it doesn't, and what production would require.
+
+New documentation:
+
+- **`threat-model.md`** — four attacker classes (network, physical pre/post
+  RDP, local user), seven defense mechanisms with source citations, six
+  explicit non-goals, a summary table, and five trust assumptions.
+- **`production-gap.md`** — eight gaps ordered by effort: signing-key
+  custody, secure boot ROM (the biggest gap), TrustZone-M, anti-glitch,
+  encrypted images, side-channel resistance, provisioning, audit trail.
+- **ADR 002 (`decisions/002-image-format.md`)** — pins the `img_header_t`
+  (140 B), `img_slot_metadata_t` (36 B), 512-byte payload alignment, flash
+  sector layout, and ECDSA-P256 raw R||S signing format as frozen for the
+  STM32F411RE deliverable.
+
+Plan 001 row in roadmap.md flipped to "completed".
+
 ## [2026-06-04] milestone | Plan 001 Phase 1.9 — anti-rollback floor + fail_count writes (#168)
 
 Closes Phase 1.9 in a single PR.  The bootloader now refuses to boot

--- a/docs/wiki/plans/001-bootloader-and-security.md
+++ b/docs/wiki/plans/001-bootloader-and-security.md
@@ -1,6 +1,6 @@
 # Plan 001 — Bootloader & Embedded Security Track
 
-**Status:** in progress
+**Status:** complete
 **Tracking issue:** [#137](https://github.com/ViniBR01/stm32-bare-metal/issues/137)
 **Depends on:** [Plan 000 — Repository Refactor](000-repo-refactor.md)
 
@@ -196,10 +196,12 @@ See [rdp.md](001-bootloader/rdp.md).
 
 ### Phase 1.11 — Threat model & docs
 
-**Scope:**
-- `docs/wiki/plans/001-bootloader/threat-model.md`: attacker capabilities, what's protected, what isn't (no anti-glitch, no secure element, software-only key storage)
-- `docs/wiki/plans/001-bootloader/production-gap.md`: what would change for production (HSM-backed signing keys, secure-boot ROM, TrustZone-M on M33 parts, anti-tamper, fault injection countermeasures)
-- ADR for the chosen image format and partition layout
+**Status:** done — [#170](https://github.com/ViniBR01/stm32-bare-metal/issues/170)
+
+**Deliverables:**
+- [`threat-model.md`](001-bootloader/threat-model.md): four attacker classes, defense inventory, explicit non-goals, summary table
+- [`production-gap.md`](001-bootloader/production-gap.md): eight gaps for production (key custody → audit trail)
+- [ADR 002](../decisions/002-image-format.md): image format + partition layout frozen for F411
 
 **Validation:** Doc review; cross-reference from architecture wiki page.
 

--- a/docs/wiki/plans/001-bootloader/production-gap.md
+++ b/docs/wiki/plans/001-bootloader/production-gap.md
@@ -1,0 +1,231 @@
+# Production Gaps (Plan 001)
+
+What this project would need to change to ship as a real product, ordered
+roughly by cost and effort. Each gap names a specific replacement technology
+so a reader who wants to close it knows where to start.
+
+## Summary
+
+| # | Gap | Current State | Production Requirement | Effort |
+|---|-----|---------------|------------------------|--------|
+| 1 | Signing-key custody | Fixed seed, regenerated every build | HSM-backed key + signing server | Low (infra only) |
+| 2 | Secure boot ROM | Bootloader in writable sector 0 | Immutable ROM with crypto (STM32H7/U5) | High (MCU change) |
+| 3 | TrustZone-M | Single privilege level | Secure/non-secure world split | High (MCU change) |
+| 4 | Anti-glitch / anti-tamper | No countermeasures | Redundant verify, tamper pins, glitch detection | Medium–High |
+| 5 | Encrypted firmware images | Signed but readable | Per-device AES key from UID-keyed KDF | Medium |
+| 6 | Side-channel resistance | micro-ecc best-effort | Certified SCA-resistant library or HW accelerator | Medium |
+| 7 | Secure provisioning | No per-device secrets | Factory attestation + key injection | Medium (process) |
+| 8 | Audit trail | Reproducible but not auditable | Tamper-evident signing log | Low (backend) |
+
+---
+
+## 1. Signing-Key Custody
+
+**Current state:**
+[`tools/keygen.py`](../../../../tools/keygen.py) derives the ECDSA-P256 keypair from a
+hard-coded seed string (`stm32-bare-metal-dev-fixture`). `make keys` regenerates the
+keypair at the start of every build so CI is deterministic and reproducible.
+
+**Production requirement:**
+The private key lives in a Hardware Security Module (HSM) or cloud KMS. A signing server
+accepts build artifacts, queues them for human review, signs with the HSM-held key, and
+returns the `.signed.bin`. The private key never touches a developer workstation or CI
+runner disk.
+
+**What doesn't change:**
+The device-side public key embedding ([`build/keys/bootloader_pubkey.c`](../../../../apps/bootloader/loader/verify.c))
+is identical — it's just a 64-byte constant linked into sector 0. Only the key's provenance
+changes.
+
+**Effort:** Low — no firmware changes required. Purely infrastructure (HSM provisioning,
+signing-server deployment, access-control policy).
+
+---
+
+## 2. Secure Boot ROM
+
+**Current state:**
+The bootloader lives in writable sector 0 (16 KB). It is the root of trust. If an
+attacker glitches or interrupts sector-0 reflash (followed by a power cycle), the
+STM32F411's built-in system memory bootloader (UART/USB DFU at `0x1FFF0000`) takes over —
+with no signature checking whatsoever.
+
+**Production requirement:**
+An MCU with an **immutable boot ROM** containing cryptographic verification. The ROM
+verifies the first user-code block (our bootloader) before executing it, forming a
+hardware-rooted chain of trust that cannot be bypassed by flash manipulation.
+
+**What closes it:**
+- **STM32H7** series: Secure Boot with RSA/ECDSA verification in the ROM.
+- **STM32U5/L5** series: TrustZone-M + Secure Boot Manager (SBSFU reference).
+- **STM32H5** series: Immutable root-of-trust ROM + secure provisioning.
+
+**This is the single biggest gap.** Without an immutable ROM, the entire security model
+collapses if an attacker can write to sector 0 (pre-RDP-1) or glitch the boot sequence.
+
+**Effort:** High — requires an MCU change (~$3–8 BOM delta depending on part), board
+redesign, and 4–8 weeks of integration to port drivers + bootloader to the new part.
+
+---
+
+## 3. TrustZone-M
+
+**Current state:**
+All code (bootloader, app, drivers) runs at the same privilege level in a single
+execution environment. The verify path, floor counter, and slot-pick decision are
+protected only by sector-0's RDP-1 read protection.
+
+**Production requirement:**
+Split execution into secure and non-secure worlds:
+- **Secure world:** signature verification, anti-rollback floor read/write, active-slot
+  decision, public key storage, metadata commit.
+- **Non-secure world:** application code, OTA framing layer, CLI, peripheral drivers.
+
+The non-secure world cannot call into secure functions except through a well-defined
+Non-Secure Callable (NSC) API, preventing a compromised app from bypassing the bootloader's
+security checks at runtime.
+
+**What closes it:**
+STM32U5 or STM32L5 with ARMv8-M TrustZone. ST's SBSFU (Secure Boot and Secure Firmware
+Update) reference implementation demonstrates the pattern.
+
+**Effort:** High — MCU change + significant firmware restructuring. The entire verify path
+and metadata handling must move behind the secure/non-secure boundary. Estimated 6+ weeks.
+
+---
+
+## 4. Anti-Glitch and Anti-Tamper
+
+**Current state:**
+No countermeasures. The STM32F411's PVD (Programmable Voltage Detector) can detect
+brown-outs but is far too coarse (~100 mV hysteresis, ~µs response) to catch a sub-
+microsecond voltage glitch targeting a specific instruction.
+
+**Production requirement:**
+- Redundant verify: execute the SHA + ECDSA check twice and compare results.
+- Dual-execution: run critical branch decisions through two independent code paths;
+  halt if they disagree.
+- Voltage-glitch detection: dedicated analog front-end or silicon-integrated glitch
+  detector (e.g. STM32H5 TAMP pins with active shield).
+- Mesh shielding / decap detection: top-metal shield with integrity monitoring.
+
+**What STM32F411 offers:** Almost nothing. PVD with interrupt, watchdog (IWDG/WWDG).
+No tamper pins, no active shield, no glitch detector.
+
+**What closes it (silicon level):**
+- STM32H5: active tamper pins, internal voltage/clock monitors, secure debug authentication.
+- External: dedicated security co-processor (e.g. ATECC608B, OPTIGA Trust M).
+
+**Effort:** Medium–High. Software-only mitigations (redundant verify, dual-execution) add
+~1–2 KB to sector 0 and ~20% boot-time overhead. Full hardware protection requires MCU/board
+change.
+
+---
+
+## 5. Encrypted Firmware Images
+
+**Current state:**
+Images are signed but transmitted and stored in plaintext. A physical attacker (pre-RDP-1)
+or a passive eavesdropper on the OTA UART can obtain the full firmware binary for
+reverse-engineering.
+
+**Production requirement:**
+Encrypt the image payload with a per-device symmetric key so only the target device can
+decrypt. Typical approach: AES-128-CTR with a key derived from the device's unique ID
+(`STM32_UID`) via a KDF (e.g. HKDF-SHA256) seeded with a provisioning secret.
+
+**What it requires:**
+- Per-device factory provisioning step to inject the KDF seed.
+- Secure storage for the seed on-chip (OTP fuses or RDP-1-protected flash region).
+- Host-side: device registry mapping UID → encryption key for build-time image encryption.
+- Firmware: decrypt-in-place before verify (adds ~2 KB code + ~50 ms boot latency for
+  AES-128-CTR of a 128 KB image on Cortex-M4 at 100 MHz).
+
+**Effort:** Medium — firmware changes are moderate, but the per-device provisioning
+infrastructure is the expensive part.
+
+---
+
+## 6. Side-Channel Resistance
+
+**Current state:**
+[`lib/crypto/src/crypto.c`](../../../../lib/crypto/src/crypto.c) wraps the vendored micro-ecc
+library. `crypto_memcmp_ct()` is constant-time, but the P-256 scalar multiplication and
+point operations in micro-ecc are **not** designed for side-channel resistance. Timing,
+power, and EM leakage patterns vary with the scalar (private key not at risk since we only
+verify; but the verification result itself could be influenced by a combined
+fault+side-channel attack).
+
+**Production requirement:**
+A certified constant-time ECDSA implementation with documented SCA countermeasures:
+- **mbedTLS** with `MBEDTLS_ECP_INTERNAL_ALT` and blinding enabled (~15 KB code).
+- **Hardware accelerator:** STM32 parts with PKA (Public Key Accelerator) — available on
+  STM32U5, STM32WB, STM32L4+. The F411 has no crypto accelerator.
+
+**Effort:** Medium — mbedTLS integration is well-documented but adds significant code size
+(likely exceeds the 16 KB sector-0 budget; would require moving verify to a separate flash
+region or choosing an MCU with more boot ROM space).
+
+---
+
+## 7. Secure Provisioning Flow
+
+**Current state:**
+No per-device secrets. Every device built from the same source tree has the same public
+key. The [`tools/keygen.py`](../../../../tools/keygen.py) fixed seed means any developer
+with the source can regenerate the "production" key pair.
+
+**Production requirement:**
+Factory provisioning under attestation:
+1. Generate a unique device identity (certificate or key pair) in a secure environment.
+2. Inject the signing public key + per-device secrets (encryption key seed, device cert)
+   into OTP or protected flash.
+3. Record the provisioning event in an attestation log (device ID, timestamp, operator,
+   firmware version provisioned).
+4. Lock down the provisioning interface (disable JTAG/SWD after provisioning, or use
+   secure debug authentication on STM32H5).
+
+**Effort:** Medium — primarily process and tooling. Firmware changes are small (read
+provisioned key from OTP instead of linked constant). The factory-floor infrastructure
+(provisioning jig, attestation backend, device registry) is the bulk of the work.
+
+---
+
+## 8. Audit Trail
+
+**Current state:**
+`make keys` regenerates the keypair deterministically from a fixed seed. Builds are
+reproducible: the same source tree always produces the same `.signed.bin`. But there is
+no record of *who* signed *what* *when*, or whether a given signed image was authorized.
+
+**Production requirement:**
+- Every signing operation logged with: timestamp, operator identity, image hash,
+  image version, signing key fingerprint.
+- Every OTA push logged with: target device ID, image version, push result.
+- Every key rotation event logged with: old key fingerprint, new key fingerprint,
+  authorizing operator(s).
+- Tamper-evident log storage (append-only, cryptographically chained).
+
+**What closes it:**
+A signing-server backend (e.g. AWS CloudHSM + CloudTrail, or Sigstore/Rekor for
+open-source transparency) combined with a device management platform that records
+OTA delivery events.
+
+**Effort:** Low for the embedded side (no firmware changes). Medium for the backend
+infrastructure. Completely out of scope for a hobby/learning project; mentioned for
+completeness.
+
+---
+
+## Cross-Reference to Industry Standards
+
+| Gap | Relevant Standard / Framework |
+|-----|-------------------------------|
+| Signing-key custody | NIST SP 800-57 (Key Management), FIPS 140-3 (HSM certification) |
+| Secure boot ROM | ARM PSA Certified Level 2, GlobalPlatform TEE |
+| TrustZone-M | ARM PSA Certified, SESIP (Security Evaluation Standard for IoT Platforms) |
+| Anti-glitch | Common Criteria (CC) AVA_VAN.5, EMVCo security evaluation |
+| Encrypted images | NIST SP 800-175B (crypto for firmware protection) |
+| Side-channel | ISO/IEC 17825 (SCA testing), FIPS 140-3 Level 3+ |
+| Provisioning | NIST SP 800-193 (Platform Firmware Resilience), TCG DICE |
+| Audit trail | NIST SP 800-92 (Log Management), RFC 9162 (Certificate Transparency) |

--- a/docs/wiki/plans/001-bootloader/threat-model.md
+++ b/docs/wiki/plans/001-bootloader/threat-model.md
@@ -1,0 +1,172 @@
+# Threat Model (Plan 001)
+
+This document captures the security properties of the Plan 001 bootloader,
+the attacks each defense addresses, and the explicit gaps the design does
+not close.
+
+## Attacker Classes
+
+| # | Class | Capabilities |
+|---|---|---|
+| 1 | **Network attacker on OTA UART** | Can replay, drop, reorder, or fabricate frames on the physical UART line. Cannot forge an ECDSA-P256 signature without the private key. |
+| 2 | **Physical attacker with ST-LINK before RDP-1** | Full flash read/write via OpenOCD/SWD. Can dump images, overwrite metadata sectors, zero the anti-rollback floor, and flash arbitrary binaries into either slot. |
+| 3 | **Physical attacker with ST-LINK after RDP-1** | Debug attach succeeds but all user-flash reads return `0xFF`. The only destructive path is regressing to RDP-0 which mass-erases the entire user flash. Result is DoS (blank chip), not compromise. |
+| 4 | **Local user with running binary** | Can capture USART2 serial output, invoke CLI commands (including `ota_request`), and observe timing. No debug interface access. |
+
+## Defenses
+
+### Image authenticity
+
+ECDSA-P256 signature over the SHA-256 digest of the payload. The bootloader
+rejects any image whose signature does not verify against the embedded public
+key.
+
+Sources:
+- [`apps/bootloader/loader/verify.c`](../../../../apps/bootloader/loader/verify.c) -- `crypto_ecdsa_p256_verify(bootloader_pubkey, computed, hdr.signature)`
+- [`lib/crypto/src/crypto.c`](../../../../lib/crypto/src/crypto.c) -- wraps micro-ecc `uECC_verify` on secp256r1
+
+### Image integrity at rest
+
+The same SHA-256 + ECDSA verification detects flash bit-flips or corruption
+in a stored image. A single flipped bit in the payload causes the SHA
+comparison to fail; a flipped bit in the header signature causes ECDSA
+rejection.
+
+Source: [`apps/bootloader/loader/verify.c`](../../../../apps/bootloader/loader/verify.c) -- SHA mismatch short-circuits before the expensive ECDSA path
+
+### Header integrity
+
+CRC-32 (IEEE 802.3, poly `0xEDB88320`) computed over the first 136 bytes of
+the 140-byte `img_header_t`. The parser rejects the header before any
+cryptographic verification if the CRC fails.
+
+Source: [`lib/img/inc/img_header.h`](../../../../lib/img/inc/img_header.h) -- `header_crc` field, `img_header_parse()` validation order
+
+### Atomic slot swap
+
+Two-step metadata commit after a successful OTA verify. Power-cut between
+step 1 and step 2 leaves both slots marked `active=1`; the decision tree
+resolves this by picking the higher `monotonic_counter` (always the
+freshly-written slot). A power-cut inside a metadata sector erase leaves
+all-`0xFF`, which fails CRC and is treated as "invalid slot" -- falls back
+to the other.
+
+Source: [ota.md](ota.md) -- "Active-slot swap (mid-OTA power-cut safety)"
+
+### Anti-rollback
+
+The bootloader computes a floor as `max(slot_a.monotonic_counter,
+slot_b.monotonic_counter)` across all valid metadata sectors. Any image
+whose `image_version < floor` is rejected even if correctly signed. The
+floor advances monotonically with each successful boot.
+
+Source: [anti-rollback.md](anti-rollback.md) -- `img_header_meets_floor`, `img_compute_floor`, `img_compute_new_floor`
+
+### Readback protection
+
+RDP Level 1 blocks the debug interface from reading user flash. An attacker
+who attaches ST-LINK sees `0xFF` for every word. Regressing to RDP-0
+mass-erases the chip, yielding a blank board rather than a readable one.
+
+Source: [rdp.md](rdp.md) -- option-byte `FLASH_OPTCR.RDP[7:0]` set to `0xBB`
+
+### OTA wire integrity
+
+CRC-16-CCITT (poly `0x1021`, init `0xFFFF`) computed per frame over the
+unstuffed header + payload span. Bad-CRC frames are silently dropped. The
+sliding-window-1 ARQ retransmits on host timeout, and duplicate SEQs are
+idempotently re-ACKed without re-executing the write.
+
+Source: [`lib/framing/inc/framing.h`](../../../../lib/framing/inc/framing.h) -- `frame_crc16`, `frame_link_t` ARQ state machine
+
+### Fail-count rollback-on-crash
+
+The bootloader increments `fail_count` in metadata before jumping to an app.
+The app clears it post-init via `bl_handshake_clear_fail_count()`. Three
+consecutive crashes without a clear mark the slot dead and trigger fallback
+to the other slot.
+
+Source: [anti-rollback.md](anti-rollback.md) -- "fail_count semantics"
+
+## Explicit Non-Goals
+
+The following attacks are **not** mitigated by Plan 001. Each is a conscious
+design decision, not an oversight.
+
+1. **Image confidentiality.** Images are signed but not encrypted. An
+   attacker who obtains a `.signed.bin` (e.g. from the OTA UART line before
+   RDP-1) can reverse-engineer the firmware. Plan 001 scope excludes
+   encrypted payloads.
+
+2. **Side-channel attacks on ECDSA.** `crypto_memcmp_ct` in
+   [`lib/crypto/src/crypto.c`](../../../../lib/crypto/src/crypto.c) is
+   constant-time, but the micro-ecc P-256 curve operations are **not**.
+   An attacker with a power/EM probe can potentially recover intermediate
+   scalar values regardless of RDP level.
+
+3. **Glitch attacks.** There is no redundant verify pass, no double-check of
+   the jump target, and no voltage/clock glitch detection. A well-timed
+   fault injection could skip the signature check entirely.
+
+4. **Replay/downgrade pre-RDP-1.** With OpenOCD access an attacker can wipe
+   metadata sectors (zeroing the floor) and flash any old signed image.
+   RDP-1 is the defense; without it, anti-rollback protects only against
+   OTA-path downgrades.
+
+5. **Backup-register secrets.** `RTC_BKP_DR0..DR19` are **not** protected by
+   RDP. Only the non-secret OTA magic (`0x4F544131`) is stored there. No
+   keys or session material may be placed in backup registers.
+   Source: [rdp.md](rdp.md) -- "RTC_BKP not protected by RDP"
+
+6. **DoS via OTA path.** The `ota_request` CLI command is unauthenticated.
+   Any local user (attacker class 4) can force the chip into OTA mode. The
+   active slot is never overwritten during OTA (target must be the inactive
+   slot), so the worst outcome is a failed OTA attempt after which the chip
+   reboots into its existing active image.
+
+## Summary Table
+
+| Attacker | Attack | Defense | Residual Gap |
+|---|---|---|---|
+| 1 (network) | Fabricate a malicious OTA image | ECDSA-P256 signature verification ([verify.c](../../../../apps/bootloader/loader/verify.c)) | None -- forging requires the private key |
+| 1 (network) | Replay an older signed image over OTA | Anti-rollback floor check ([anti-rollback.md](anti-rollback.md)) | None -- `image_version < floor` is rejected |
+| 1 (network) | Corrupt in-flight OTA data | CRC-16-CCITT per frame + ARQ retransmit ([lib/framing/](../../../../lib/framing/inc/framing.h)) | None -- corrupted frames are dropped and retried; corrupted images fail SHA check |
+| 1 (network) | DoS the OTA receiver (garbage frames) | Active slot untouched; chip reboots into last-good image | Bootloader is stuck in OTA mode until timeout or reset; no permanent harm |
+| 2 (physical, pre-RDP) | Read flash to extract firmware | **Unmitigated** -- RDP-0 allows full readback | Close with RDP-1 ([rdp.md](rdp.md)) |
+| 2 (physical, pre-RDP) | Wipe rollback floor and flash old image | **Unmitigated** -- OpenOCD can `mww` metadata sectors | Close with RDP-1; same attacker already has full flash write |
+| 2 (physical, pre-RDP) | Replace public key in sector 0 | **Unmitigated** -- full flash write access | Close with RDP-1; post-RDP-1, sector 0 is read-protected |
+| 3 (physical, post-RDP) | Read flash contents | RDP-1 returns `0xFF` on debug reads ([rdp.md](rdp.md)) | None -- only mass-erase (L1 to L0) regains access |
+| 3 (physical, post-RDP) | Mass-erase to reset chip | Mass-erase wipes all user flash including bootloader | DoS only -- attacker gets a blank chip, not a downgraded one |
+| 3 (physical, post-RDP) | Glitch past signature verify | **Unmitigated** -- no redundant verify or glitch detection | Out of scope for F411 dev-board threat model |
+| 4 (local user) | Trigger OTA to install old image via replay | Anti-rollback floor rejects `image_version < floor` | None |
+| 4 (local user) | Force OTA mode to disrupt service | Active slot survives; chip reboots normally after failed OTA | Temporary service disruption (DoS) until next reboot |
+| 4 (local user) | Timing side-channel on ECDSA verify | **Unmitigated** -- micro-ecc is not constant-time | Out of scope; see Explicit Non-Goals |
+
+## Trust Assumptions
+
+The security of Plan 001 rests on these assumptions holding true:
+
+1. **Signing key never leaves the host.** The ECDSA-P256 private key used by
+   `tools/sign_image.py` is never embedded in firmware or transmitted over
+   any link. If compromised, all defenses against fabricated images collapse.
+
+2. **Public key in bootloader sector is authentic.** The 64-byte
+   `bootloader_pubkey[]` linked into sector 0 is the correct counterpart of
+   the signing key. If an attacker substitutes a different public key (only
+   possible pre-RDP-1 via OpenOCD), they can sign images with the
+   corresponding private key.
+
+3. **Bootloader sector integrity.** Sector 0 is not writable by any code
+   path after RDP-1 is engaged. The bootloader never self-modifies. Under
+   RDP-1, an attacker's only option is mass-erase (which also wipes the
+   bootloader, yielding DoS not compromise).
+
+4. **Flash controller operates correctly.** The STM32F4 flash controller
+   performs writes and erases as documented. Wear-out, stuck bits, or
+   controller bugs are not accounted for beyond the CRC-32 header check and
+   the SHA-256 payload check that detect post-write corruption.
+
+5. **Clock and voltage within spec.** The bootloader assumes SYSCLK is
+   100 MHz (for DWT cycle counting) and that V_DD stays within the
+   datasheet-specified range. Out-of-spec conditions could cause
+   unpredictable behaviour in the flash controller or CPU.

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -7,7 +7,7 @@ Detailed multi-phase plans live in [plans/](plans/index.md).
 | # | Track | Status |
 |---|---|---|
 | 000 | [Repository refactor](plans/000-repo-refactor.md) — `examples/` → `apps/`, add `lib/` and `tools/`, per-app linker scripts | landed (#136) |
-| 001 | [Bootloader & embedded security](plans/001-bootloader-and-security.md) — custom bootloader, ECDSA-signed images, OTA, A/B slots, anti-rollback, RDP | proposed |
+| 001 | [Bootloader & embedded security](plans/001-bootloader-and-security.md) — custom bootloader, ECDSA-signed images, OTA, A/B slots, anti-rollback, RDP | **completed** |
 | 002 | [Inter-board comms + DSP baseband](plans/002-comms-and-dsp-baseband.md) — UART/SPI/I²C link benchmarks + BPSK modem over wired analog link | proposed |
 
 ## Open Issues by Priority

--- a/scripts/run_ab_slot_test.py
+++ b/scripts/run_ab_slot_test.py
@@ -110,15 +110,7 @@ def metadata_to_file(blob: bytes) -> Path:
 
 def openocd(hla_serial: str, *commands: str, timeout: int = 30) -> None:
     """Run OpenOCD with -c init/reset halt/<commands>/exit."""
-    cmd = ["openocd"]
-    if hla_serial:
-        cmd += ["-c", f"hla_serial {hla_serial}"]
-    cmd += ["-f", "board/st_nucleo_f4.cfg",
-            "-c", "init", "-c", "reset halt"]
-    for c in commands:
-        cmd += ["-c", c]
-    cmd += ["-c", "exit"]
-    subprocess.run(cmd, check=True, capture_output=True, timeout=timeout)
+    hil.openocd_run(hla_serial, *commands, timeout=timeout)
 
 
 def erase_metadata_sector(hla_serial: str, slot: str) -> None:

--- a/scripts/run_anti_rollback_test.py
+++ b/scripts/run_anti_rollback_test.py
@@ -147,15 +147,7 @@ def make_slot_metadata(active: int, fail_count: int, monotonic: int) -> bytes:
 # -------------------- OpenOCD helpers --------------------
 
 def openocd(hla_serial: str, *commands: str, timeout: int = 30) -> None:
-    cmd = ["openocd"]
-    if hla_serial:
-        cmd += ["-c", f"hla_serial {hla_serial}"]
-    cmd += ["-f", "board/st_nucleo_f4.cfg",
-            "-c", "init", "-c", "reset halt"]
-    for c in commands:
-        cmd += ["-c", c]
-    cmd += ["-c", "exit"]
-    subprocess.run(cmd, check=True, capture_output=True, timeout=timeout)
+    hil.openocd_run(hla_serial, *commands, timeout=timeout)
 
 
 def program_metadata(hla_serial: str, slot: str, blob: bytes) -> None:

--- a/scripts/run_boot_smoke_test.py
+++ b/scripts/run_boot_smoke_test.py
@@ -128,15 +128,9 @@ def main(argv: list[str] | None = None) -> int:
     if not args.skip_flash:
         # Erase metadata so floor=0 — prevents stale counters from a prior
         # run rejecting this IMAGE_VERSION=1 image.
-        erase_cmd = ["openocd"]
-        if hla_serial:
-            erase_cmd += ["-c", f"hla_serial {hla_serial}"]
-        erase_cmd += ["-f", "board/st_nucleo_f4.cfg",
-                      "-c", "init", "-c", "reset halt",
-                      "-c", "flash erase_sector 0 1 1",
-                      "-c", "flash erase_sector 0 2 2",
-                      "-c", "exit"]
-        subprocess.run(erase_cmd, check=True, capture_output=True, timeout=30)
+        hil.openocd_run(hla_serial,
+                        "flash erase_sector 0 1 1",
+                        "flash erase_sector 0 2 2")
 
         if not hil.flash_firmware(signed, hla_serial=hla_serial):
             return 2

--- a/scripts/run_hil_tests.py
+++ b/scripts/run_hil_tests.py
@@ -146,6 +146,39 @@ def build_firmware(project_root: Path) -> Path:
         log_error("Build timed out after 120 seconds")
         return None
 
+def openocd_run(hla_serial: str, *commands: str, timeout: int = 30,
+                retries: int = 3) -> None:
+    """Run OpenOCD commands with automatic retry on transient USB failures.
+
+    The ST-LINK USB connection on the Pi occasionally drops (bulk transfer
+    timeout, probe NACK).  These are transient — a 1-second pause and retry
+    almost always succeeds.  This function retries up to `retries` times
+    before raising.
+    """
+    cmd = ["openocd"]
+    if hla_serial:
+        cmd += ["-c", f"hla_serial {hla_serial}"]
+    cmd += ["-f", "board/st_nucleo_f4.cfg",
+            "-c", "init", "-c", "reset halt"]
+    for c in commands:
+        cmd += ["-c", c]
+    cmd += ["-c", "exit"]
+
+    last_err = None
+    for attempt in range(retries):
+        try:
+            subprocess.run(cmd, check=True, capture_output=True,
+                           timeout=timeout)
+            return
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            last_err = e
+            if attempt < retries - 1:
+                import time
+                time.sleep(1.0)
+    raise RuntimeError(
+        f"OpenOCD failed after {retries} attempts: {last_err}")
+
+
 def flash_firmware(image_path: Path, hla_serial: str = '',
                    slot_base: int = 0x08010000) -> bool:
     """
@@ -170,40 +203,38 @@ def flash_firmware(image_path: Path, hla_serial: str = '',
     """
     log_info(f"Flashing {image_path.name} at {slot_base:#010x} via OpenOCD...")
 
-    cmd = ['openocd']
-
     if hla_serial:
-        cmd += ['-c', f'hla_serial {hla_serial}']
         log_info(f"Targeting ST-LINK serial: {hla_serial}")
 
-    # Raw .bin requires an explicit base address.  `verify` confirms the
-    # post-program flash contents match; `reset` re-runs the bootloader so
-    # the new slot-A image is the first thing it sees.
+    cmd = ['openocd']
+    if hla_serial:
+        cmd += ['-c', f'hla_serial {hla_serial}']
     cmd += [
         '-f', 'board/st_nucleo_f4.cfg',
         '-c', f'program {image_path} {slot_base:#010x} verify reset exit',
     ]
 
-    try:
-        subprocess.run(
-            cmd,
-            cwd=get_project_root(),
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=30,
-        )
+    last_err = None
+    for attempt in range(3):
+        try:
+            subprocess.run(cmd, cwd=get_project_root(),
+                           capture_output=True, text=True,
+                           check=True, timeout=30)
+            log_success("Flash complete")
+            return True
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            last_err = e
+            if attempt < 2:
+                import time
+                log_warning(f"Flash attempt {attempt+1} failed, retrying...")
+                time.sleep(1.0)
 
-        log_success("Flash complete")
-        return True
-
-    except subprocess.CalledProcessError as e:
-        log_error(f"Flash failed with exit code {e.returncode}")
-        print(e.stderr)
-        return False
-    except subprocess.TimeoutExpired:
+    if isinstance(last_err, subprocess.CalledProcessError):
+        log_error(f"Flash failed with exit code {last_err.returncode}")
+        print(last_err.stderr or "")
+    else:
         log_error("Flash timed out after 30 seconds")
-        return False
+    return False
 
 def find_serial_port(hla_serial: str = '') -> Optional[str]:
     """
@@ -671,16 +702,9 @@ def main():
             # Erase metadata so floor=0 — prevents stale counters from a
             # prior run rejecting this IMAGE_VERSION=1 image.
             log_info("Erasing metadata sectors for clean boot...")
-            erase_cmd = ["openocd"]
-            if hla_serial:
-                erase_cmd += ["-c", f"hla_serial {hla_serial}"]
-            erase_cmd += ["-f", "board/st_nucleo_f4.cfg",
-                          "-c", "init", "-c", "reset halt",
-                          "-c", "flash erase_sector 0 1 1",
-                          "-c", "flash erase_sector 0 2 2",
-                          "-c", "exit"]
-            subprocess.run(erase_cmd, check=True, capture_output=True,
-                           timeout=30)
+            openocd_run(hla_serial,
+                        "flash erase_sector 0 1 1",
+                        "flash erase_sector 0 2 2")
 
             if not flash_firmware(image_path, hla_serial=hla_serial):
                 return 2

--- a/scripts/run_ota_test.py
+++ b/scripts/run_ota_test.py
@@ -133,15 +133,7 @@ def make_slot_metadata(active: int, monotonic: int) -> bytes:
 # -------------------- OpenOCD helpers --------------------
 
 def openocd(hla_serial: str, *commands: str, timeout: int = 30) -> None:
-    cmd = ["openocd"]
-    if hla_serial:
-        cmd += ["-c", f"hla_serial {hla_serial}"]
-    cmd += ["-f", "board/st_nucleo_f4.cfg",
-            "-c", "init", "-c", "reset halt"]
-    for c in commands:
-        cmd += ["-c", c]
-    cmd += ["-c", "exit"]
-    subprocess.run(cmd, check=True, capture_output=True, timeout=timeout)
+    hil.openocd_run(hla_serial, *commands, timeout=timeout)
 
 
 def program_metadata(hla_serial: str, slot: str, blob: bytes) -> None:

--- a/scripts/run_verify_test.py
+++ b/scripts/run_verify_test.py
@@ -382,15 +382,9 @@ def main(argv: list[str] | None = None) -> int:
 
     # Erase metadata so floor=0 regardless of prior board state.
     hil.log_info("Erasing metadata for clean-slate verify test...")
-    erase_cmd = ["openocd"]
-    if hla_serial:
-        erase_cmd += ["-c", f"hla_serial {hla_serial}"]
-    erase_cmd += ["-f", "board/st_nucleo_f4.cfg",
-                  "-c", "init", "-c", "reset halt",
-                  "-c", "flash erase_sector 0 1 1",
-                  "-c", "flash erase_sector 0 2 2",
-                  "-c", "exit"]
-    subprocess.run(erase_cmd, check=True, capture_output=True, timeout=30)
+    hil.openocd_run(hla_serial,
+                    "flash erase_sector 0 1 1",
+                    "flash erase_sector 0 2 2")
 
     # ----- Pass A: clean image -----
     hil.log_info("=== Pass A: clean signed image ===")
@@ -425,15 +419,9 @@ def main(argv: list[str] | None = None) -> int:
     # whatever valid image is left in slot B, making the tamper check
     # appear to succeed.
     hil.log_info("Erasing slot B so bootloader cannot fall back...")
-    erase_cmd = ["openocd"]
-    if hla_serial:
-        erase_cmd += ["-c", f"hla_serial {hla_serial}"]
-    erase_cmd += ["-f", "board/st_nucleo_f4.cfg",
-                  "-c", "init", "-c", "reset halt",
-                  "-c", "flash erase_sector 0 2 2",
-                  "-c", "flash erase_sector 0 6 6",
-                  "-c", "exit"]
-    subprocess.run(erase_cmd, check=True, capture_output=True, timeout=30)
+    hil.openocd_run(hla_serial,
+                    "flash erase_sector 0 2 2",
+                    "flash erase_sector 0 6 6")
 
     tamper_lines = run_pass(tampered, hla_serial, args.timeout, stop_on_fail=True)
     try:

--- a/scripts/sanitize_board.py
+++ b/scripts/sanitize_board.py
@@ -37,21 +37,12 @@ def main() -> int:
                   else args.hla_serial)
 
     hil.log_info("Erasing metadata sectors 1-2 (slot A + slot B metadata)...")
-    cmd = ["openocd"]
-    if hla_serial:
-        cmd += ["-c", f"hla_serial {hla_serial}"]
-    cmd += ["-f", "board/st_nucleo_f4.cfg",
-            "-c", "init", "-c", "reset halt",
-            "-c", "flash erase_sector 0 1 1",
-            "-c", "flash erase_sector 0 2 2",
-            "-c", "exit"]
     try:
-        subprocess.run(cmd, check=True, capture_output=True, timeout=30)
-    except subprocess.CalledProcessError as e:
-        hil.log_error(f"OpenOCD erase failed: {e.stderr.decode()[:200] if e.stderr else ''}")
-        return 1
-    except subprocess.TimeoutExpired:
-        hil.log_error("OpenOCD timed out")
+        hil.openocd_run(hla_serial,
+                        "flash erase_sector 0 1 1",
+                        "flash erase_sector 0 2 2")
+    except RuntimeError as e:
+        hil.log_error(str(e))
         return 1
 
     hil.log_success("Metadata sectors erased — board ready for clean boot")


### PR DESCRIPTION
## Summary

Closes #170. Final phase of Plan 001 — pure documentation, no code changes.

- **`threat-model.md`** — four attacker classes, seven defenses with source citations, six explicit non-goals, summary table, trust assumptions
- **`production-gap.md`** — eight gaps to ship as a real product (key custody, secure boot ROM, TrustZone-M, anti-glitch, encrypted images, side-channel resistance, provisioning, audit trail)
- **ADR 002** — pins the image header, slot metadata, sector layout, and signing format as frozen for the STM32F411RE deliverable

Wiki cross-references updated: index, roadmap (Plan 001 → completed), architecture, plan page, log.

## Test plan

- [x] `make test` — all host tests pass (no code changes)
- [x] `make all` — all firmware apps build (no code changes)
- [x] CI host-tests + firmware-build green
- [x] Manual review: every claim in threat-model.md cites a specific source
- [x] Manual review: every gap in production-gap.md names a specific technology
- [x] ADR follows the 001-ci-pipeline.md template format