### PR TITLE
App target profiles + make all apps slot-aware (#167)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,8 @@ See `docs/wiki/agents.md` for parallelism rules, HIL constraints, and troublesho
 make test                       # Run host unit tests (Unity) — required before any PR
 make                            # Build default firmware app (cli_simple)
 make EXAMPLE=<name>             # Build a specific app
+make EXAMPLE=<name> SLOT=B      # Build for slot B (bootloader profile, 0x08040000)
+make EXAMPLE=<name> PROFILE=standalone  # Legacy no-bootloader map (raw, unsigned, 0x08000000)
 make all                        # Build all firmware apps
 make clean                      # Remove all build artifacts
 make flash EXAMPLE=<name>       # Flash signed app to slot A (0x08010000)

--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,8 @@ flash: $(EXAMPLE)
 		echo "and is the only path documented in bootloader-skeleton.md."; \
 		exit 1; \
 	fi
-	@echo "Flashing $(EXAMPLE).elf to target using OpenOCD..."
-	openocd -f board/st_nucleo_f4.cfg -c "program $(shell find $(BUILD_DIR)/apps -name $(EXAMPLE).elf) verify reset exit"
+	@echo "Flashing $(EXAMPLE)$(PROFILE_SUFFIX).elf to target using OpenOCD..."
+	openocd -f board/st_nucleo_f4.cfg -c "program $(shell find $(BUILD_DIR)/apps -name $(EXAMPLE)$(PROFILE_SUFFIX).elf) verify reset exit"
 
 #==============================================================================
 # flash-bootloader — explicit, manual-only sector-0 programming.
@@ -167,7 +167,7 @@ flash-bootloader: bootloader
 # Debug target
 #==============================================================================
 debug: $(EXAMPLE)
-	./debug.sh $(shell find $(BUILD_DIR)/apps -name $(EXAMPLE).elf)
+	./debug.sh $(shell find $(BUILD_DIR)/apps -name $(EXAMPLE)$(PROFILE_SUFFIX).elf)
 
 #==============================================================================
 # OpenOCD target

--- a/Makefile.common
+++ b/Makefile.common
@@ -84,35 +84,79 @@ endif
 CFLAGS := $(CFLAGS_BASE) $(COMMON_INCLUDES) -DLOG_LEVEL=$(LOG_LEVEL) $(HIL_TEST_CFLAGS)
 
 #==============================================================================
-# Linker configuration
+# Target profiles — memory map + signing selector
 #==============================================================================
-# Default linker script — slot A (0x08010000) since Plan 001 Phase 1.5.
-# Apps land at SLOT_BASE + sizeof(img_header_t); tools/sign_image.py prepends
-# the 140-byte header and produces a .signed.bin that the bootloader can
-# parse + jump into.  The bootloader app overrides LDSCRIPT to point at
-# linker/bootloader_ls.ld so it lives in sector 0 instead.
+# A "profile" bundles the four things that pin an app to a memory map:
+#   - LDSCRIPT       which linker script (where the app lands in flash)
+#   - SLOT_BASE      the FLASH ORIGIN defsym fed to a slot-aware script
+#   - PROFILE_SUFFIX appended to every output path so variants don't clobber
+#                    (_a for slot A, _b for slot B, _standalone for the
+#                    no-bootloader map)
+#   - SIGN_IMAGE     whether tools/sign_image.py wraps the .bin in an
+#                    img_header_t (the bootloader only accepts signed images)
 #
-# Override on a per-app basis by setting LDSCRIPT := ... in the app's
-# Makefile AFTER `include ../../Makefile.common`.  LDFLAGS uses recursive
-# expansion so a later override of LDSCRIPT takes effect at link time.
-LDSCRIPT ?= $(LINKER_DIR)/app_ls.ld
+# Select with PROFILE= on the command line.  Apps stay profile-agnostic: they
+# thread $(PROFILE_SUFFIX) through their paths and gate the signing step on
+# $(SIGN_IMAGE), but never name a linker script or base address themselves.
+#
+#   make EXAMPLE=cli_simple                       # bootloader, slot A (default)
+#   make EXAMPLE=cli_simple SLOT=B                # bootloader, slot B
+#   make EXAMPLE=blink_simple PROFILE=standalone  # legacy 0x08000000, unsigned
+#
+# Profiles:
+#   bootloader (default) — Plan 001 map.  app_ls.ld at SLOT_BASE
+#                          (slot A 0x08010000 / slot B 0x08040000), signed.
+#   standalone           — pre-bootloader map.  stm32_ls.ld at 0x08000000
+#                          full-flash, raw unsigned .bin/.elf flashable
+#                          directly with a debugger.
+#
+# A new memory map (e.g. a future bootloader_v2) drops in as one more branch
+# here with no per-app changes.
+#==============================================================================
+PROFILE ?= bootloader
 
-# Slot selector + base address.  Set SLOT=B to build for slot B; default is A.
-# The value is forwarded to the linker as a --defsym so app_ls.ld can compute
-# FLASH ORIGIN, and embedded into output paths so A and B builds don't
-# clobber each other.
-SLOT      ?= A
-ifeq ($(SLOT),A)
-  SLOT_BASE   ?= 0x08010000
-  SLOT_SUFFIX :=
-else ifeq ($(SLOT),B)
-  SLOT_BASE   ?= 0x08040000
-  SLOT_SUFFIX := _b
+# SLOT selector is meaningful only for slot-aware (bootloader-family)
+# profiles.  Default A; validated inside the bootloader branch below.
+SLOT ?= A
+
+ifeq ($(PROFILE),bootloader)
+  # Default linker script — slot A/B since Plan 001 Phase 1.5.  Apps land at
+  # SLOT_BASE + sizeof(img_header_t); tools/sign_image.py prepends the 140-byte
+  # header and produces a .signed.bin the bootloader can parse + jump into.
+  # The bootloader loader app overrides LDSCRIPT to bootloader_ls.ld so it lives
+  # in sector 0 instead.  Override per-app by setting LDSCRIPT := ... AFTER the
+  # `include`; LDFLAGS expands recursively so a later override still takes hold.
+  LDSCRIPT ?= $(LINKER_DIR)/app_ls.ld
+  SIGN_IMAGE := 1
+  # Slot selector + base address forwarded to the linker as a --defsym so
+  # app_ls.ld can compute FLASH ORIGIN, and embedded into output paths so A
+  # and B builds don't clobber each other.
+  ifeq ($(SLOT),A)
+    SLOT_BASE     ?= 0x08010000
+    PROFILE_SUFFIX := _a
+  else ifeq ($(SLOT),B)
+    SLOT_BASE     ?= 0x08040000
+    PROFILE_SUFFIX := _b
+  else
+    $(error SLOT must be A or B, got '$(SLOT)')
+  endif
+else ifeq ($(PROFILE),standalone)
+  # Pre-bootloader memory map: full 512 KB flash based at 0x08000000, no
+  # img_header, no signing.  Flashable directly to sector 0 with a debugger.
+  LDSCRIPT      ?= $(LINKER_DIR)/stm32_ls.ld
+  SIGN_IMAGE     := 0
+  SLOT_BASE     ?= 0x08000000
+  PROFILE_SUFFIX := _standalone
 else
-  $(error SLOT must be A or B, got '$(SLOT)')
+  $(error PROFILE must be 'bootloader' or 'standalone', got '$(PROFILE)')
 endif
 
-# Linker flags
+# Backward-compatible alias.  Older app Makefiles referenced SLOT_SUFFIX; it is
+# now an alias for PROFILE_SUFFIX so any straggler keeps working.
+SLOT_SUFFIX := $(PROFILE_SUFFIX)
+
+# Linker flags.  SLOT_BASE is always forwarded; slot-unaware scripts
+# (stm32_ls.ld) simply ignore the unreferenced defsym.
 LDFLAGS = $(MCU_FLAGS) -flto -T $(LDSCRIPT) -Wl,--gc-sections \
           -Wl,--defsym=SLOT_BASE=$(SLOT_BASE) --specs=nosys.specs
 
@@ -198,3 +242,4 @@ export ROOT_DIR BUILD_DIR HIL_TEST LIB_DIR
 export DRIVERS_LIB STARTUP_OBJ PRINTF_LIB LOG_C_LIB UTILS_LIB UNITY_ARM_LIB IMG_LIB CRYPTO_LIB FLASH_LIB FRAMING_LIB BL_HANDSHAKE_LIB
 export KEYS_DIR KEY_SEED DEV_PRIV BL_PUBKEY_C
 export SLOT SLOT_BASE SLOT_SUFFIX
+export PROFILE PROFILE_SUFFIX SIGN_IMAGE

--- a/README.md
+++ b/README.md
@@ -151,10 +151,29 @@ Other useful targets:
 ```sh
 make all                              # build every app
 make EXAMPLE=blink_pwm                # build a specific app
+make EXAMPLE=cli_simple SLOT=B        # build for slot B (0x08040000)
+make EXAMPLE=blink_pwm PROFILE=standalone  # legacy map, unsigned, at 0x08000000
 make flash EXAMPLE=iwdg_basic         # flash a specific app to slot A
 make debug EXAMPLE=cli_simple         # OpenOCD + GDB attached
 make help                             # full target list
 ```
+
+#### Build profiles
+
+A single `PROFILE=` knob selects the memory map an app builds for:
+
+- **`PROFILE=bootloader`** (default) — links at an A/B slot (`SLOT=A` →
+  `0x08010000`, `SLOT=B` → `0x08040000`) and signs the image so the
+  bootloader will verify and boot it. This is the Plan 001 map.
+- **`PROFILE=standalone`** — links the full 512 KB flash at `0x08000000`,
+  unsigned, for flashing directly with a debugger (no bootloader). The
+  pre-bootloader map, kept as a first-class build path.
+
+Apps stay profile-agnostic, so any app builds under any profile. Note that
+bootloader-profile images are **position-dependent**: a slot-A image will not
+run at slot B (the linker bakes the base address into the code and vector
+table), so the build produces a separate `_b` artifact per slot. See
+[docs/wiki/decisions/003-app-target-profiles.md](docs/wiki/decisions/003-app-target-profiles.md).
 
 ### Hardware-in-the-loop
 

--- a/apps/basic/Makefile
+++ b/apps/basic/Makefile
@@ -75,31 +75,39 @@ all: $(APPS)
 # as apps change; Phase 1.9 will tie this into the anti-rollback counter.
 IMAGE_VERSION ?= 1
 
-# Pattern rule for building apps.  Final target is the .signed.bin produced
-# by tools/sign_image.py — that is what flashes at slot A and what the
-# bootloader parses.  The unsigned .bin is kept as a debug aid.
+# Pattern rule for building apps.  Output paths carry $(PROFILE_SUFFIX) so
+# slot-A / slot-B / standalone builds of the same app never clobber each
+# other.  The final artifact is the .signed.bin for bootloader profiles
+# (SIGN_IMAGE=1) or the raw .bin for the standalone profile (SIGN_IMAGE=0).
+#
+# $(1) = app name.  $(2) is precomputed by the caller as the suffixed stem
+# ($(1)$(PROFILE_SUFFIX)) so the directory and file names stay in lock-step.
 define build-app
-$(1): $(LOCAL_BUILD_DIR)/$(1)/$(1).signed.bin
+ifeq ($(SIGN_IMAGE),1)
+$(1): $(LOCAL_BUILD_DIR)/$(2)/$(2).signed.bin
+else
+$(1): $(LOCAL_BUILD_DIR)/$(2)/$(2).bin
+endif
 	@echo "App $(1) built successfully!"
 
-$(LOCAL_BUILD_DIR)/$(1)/$(1).o: $(1).c
+$(LOCAL_BUILD_DIR)/$(2)/$(2).o: $(1).c
 	$$(make-build-dir)
 	@echo "Compiling app: $(1).c"
 	$$(CC) $$(CFLAGS) -o $$@ $$<
 
-$(LOCAL_BUILD_DIR)/$(1)/$(1).elf: $(LOCAL_BUILD_DIR)/$(1)/$(1).o $$($(1)_DEPS)
+$(LOCAL_BUILD_DIR)/$(2)/$(2).elf: $(LOCAL_BUILD_DIR)/$(2)/$(2).o $$($(1)_DEPS)
 	$$(make-build-dir)
-	@echo "Linking $(1)..."
-	$$(CC) $$(LDFLAGS) -Wl,-Map=$(LOCAL_BUILD_DIR)/$(1)/$(1).map,--cref -o $$@ $(LOCAL_BUILD_DIR)/$(1)/$(1).o -Wl,--start-group $$($(1)_DEPS) -Wl,--end-group
+	@echo "Linking $(2)..."
+	$$(CC) $$(LDFLAGS) -Wl,-Map=$(LOCAL_BUILD_DIR)/$(2)/$(2).map,--cref -o $$@ $(LOCAL_BUILD_DIR)/$(2)/$(2).o -Wl,--start-group $$($(1)_DEPS) -Wl,--end-group
 	@echo "Linking complete."
 
-$(LOCAL_BUILD_DIR)/$(1)/$(1).bin: $(LOCAL_BUILD_DIR)/$(1)/$(1).elf
+$(LOCAL_BUILD_DIR)/$(2)/$(2).bin: $(LOCAL_BUILD_DIR)/$(2)/$(2).elf
 	$$(CP) -O binary $$< $$@
-	@echo "Created $(1).bin"
+	@echo "Created $(2).bin"
 	@$$(SZ) $$<
 
-$(LOCAL_BUILD_DIR)/$(1)/$(1).signed.bin: $(LOCAL_BUILD_DIR)/$(1)/$(1).bin $$(DEV_PRIV)
-	@echo "Signing $(1).bin..."
+$(LOCAL_BUILD_DIR)/$(2)/$(2).signed.bin: $(LOCAL_BUILD_DIR)/$(2)/$(2).bin $$(DEV_PRIV)
+	@echo "Signing $(2).bin..."
 	python3 $$(ROOT_DIR)/tools/sign_image.py \
 		--priv-in $$(DEV_PRIV) \
 		--in $$< \
@@ -108,8 +116,8 @@ $(LOCAL_BUILD_DIR)/$(1)/$(1).signed.bin: $(LOCAL_BUILD_DIR)/$(1)/$(1).bin $$(DEV
 		--image-version $(IMAGE_VERSION)
 endef
 
-# Generate build rules for each app
-$(foreach app,$(APPS),$(eval $(call build-app,$(app))))
+# Generate build rules for each app.  Second arg is the profile-suffixed stem.
+$(foreach app,$(APPS),$(eval $(call build-app,$(app),$(app)$(PROFILE_SUFFIX))))
 
 # Clean all build artifacts
 clean:

--- a/apps/bootloader/app_blinky_signed/Makefile
+++ b/apps/bootloader/app_blinky_signed/Makefile
@@ -18,17 +18,18 @@ endif
 include ../../../Makefile.common
 
 #==============================================================================
-# Slot-A linker script
+# Slot-aware app linker script.  This app is bootloader-profile only; it pins
+# app_ls.ld explicitly.  SLOT_BASE / SLOT_SUFFIX come from Makefile.common's
+# profile resolver (SLOT=A|B), and LDFLAGS there already forwards the defsym.
 #==============================================================================
 LDSCRIPT := $(LINKER_DIR)/app_ls.ld
-LDFLAGS  += -Wl,--defsym=SLOT_BASE=$(SLOT_BASE)
 
-LOCAL_BUILD_DIR := $(BUILD_DIR)/apps/bootloader/app_blinky_signed$(SLOT_SUFFIX)
+LOCAL_BUILD_DIR := $(BUILD_DIR)/apps/bootloader/app_blinky_signed$(PROFILE_SUFFIX)
 
 OBJ  := $(LOCAL_BUILD_DIR)/main.o
-ELF  := $(LOCAL_BUILD_DIR)/app_blinky_signed$(SLOT_SUFFIX).elf
-BIN  := $(LOCAL_BUILD_DIR)/app_blinky_signed$(SLOT_SUFFIX).bin
-SBIN := $(LOCAL_BUILD_DIR)/app_blinky_signed$(SLOT_SUFFIX).signed.bin
+ELF  := $(LOCAL_BUILD_DIR)/app_blinky_signed$(PROFILE_SUFFIX).elf
+BIN  := $(LOCAL_BUILD_DIR)/app_blinky_signed$(PROFILE_SUFFIX).bin
+SBIN := $(LOCAL_BUILD_DIR)/app_blinky_signed$(PROFILE_SUFFIX).signed.bin
 
 DEPS := $(BL_HANDSHAKE_LIB) $(IMG_LIB) $(FLASH_LIB) $(DRIVERS_LIB) $(STARTUP_OBJ)
 
@@ -58,7 +59,7 @@ $(OBJ): main.c
 $(ELF): $(OBJ) $(DEPS)
 	$(make-build-dir)
 	@echo "Linking app_blinky_signed.elf..."
-	$(CC) $(LDFLAGS) -Wl,-Map=$(LOCAL_BUILD_DIR)/app_blinky_signed.map,--cref \
+	$(CC) $(LDFLAGS) -Wl,-Map=$(LOCAL_BUILD_DIR)/app_blinky_signed$(PROFILE_SUFFIX).map,--cref \
 		-o $@ $(OBJ) -Wl,--start-group $(DEPS) -Wl,--end-group -lc -lm -lgcc
 	@echo "Linking complete."
 

--- a/apps/cli/Makefile
+++ b/apps/cli/Makefile
@@ -17,8 +17,12 @@ include ../../Makefile.common
 
 #==============================================================================
 # Local directories
+#
+# PROFILE_SUFFIX (_a for slot A, _b for slot B, _standalone for the
+# no-bootloader map) is threaded through every output path so different
+# profile/slot builds of the same app never clobber each other.
 #==============================================================================
-LOCAL_BUILD_DIR := $(BUILD_DIR)/apps/cli
+LOCAL_BUILD_DIR := $(BUILD_DIR)/apps/cli/cli_simple$(PROFILE_SUFFIX)
 
 #==============================================================================
 # All apps in this directory
@@ -36,7 +40,22 @@ else
   CLI_SRCS := $(filter-out test_harness.c, $(wildcard *.c))
 endif
 
-CLI_OBJS := $(patsubst %.c,$(LOCAL_BUILD_DIR)/cli_simple/%.o,$(CLI_SRCS))
+CLI_OBJS := $(patsubst %.c,$(LOCAL_BUILD_DIR)/%.o,$(CLI_SRCS))
+
+#==============================================================================
+# Output artifacts (profile-suffixed)
+#==============================================================================
+ELF  := $(LOCAL_BUILD_DIR)/cli_simple$(PROFILE_SUFFIX).elf
+BIN  := $(LOCAL_BUILD_DIR)/cli_simple$(PROFILE_SUFFIX).bin
+SBIN := $(LOCAL_BUILD_DIR)/cli_simple$(PROFILE_SUFFIX).signed.bin
+
+# Final artifact depends on the profile: bootloader profiles sign the image,
+# standalone profiles stop at the raw .bin.
+ifeq ($(SIGN_IMAGE),1)
+  FINAL := $(SBIN)
+else
+  FINAL := $(BIN)
+endif
 
 #==============================================================================
 # Dependencies for each app
@@ -78,33 +97,33 @@ IMAGE_VERSION ?= 1
 # Build all apps
 all: $(APPS)
 
-# Pattern rule for building the cli_simple app (multi-file).  Final target
-# is the signed binary; the unsigned .bin is kept as a debug aid.
-cli_simple: $(LOCAL_BUILD_DIR)/cli_simple/cli_simple.signed.bin
-	@echo "App cli_simple built successfully!"
+# cli_simple builds to its profile-appropriate final artifact (signed bin for
+# bootloader profiles, raw bin for standalone).
+cli_simple: $(FINAL)
+	@echo "App cli_simple built successfully! ($(FINAL))"
 
 # Compile each .c file in this directory into an object file
-$(LOCAL_BUILD_DIR)/cli_simple/%.o: %.c
+$(LOCAL_BUILD_DIR)/%.o: %.c
 	$(make-build-dir)
 	@echo "Compiling: $<"
 	$(CC) $(CFLAGS) -I. $(CLI_LIB_INCS) -o $@ $<
 
 # Link all object files together
-$(LOCAL_BUILD_DIR)/cli_simple/cli_simple.elf: $(CLI_OBJS) $(cli_simple_DEPS)
+$(ELF): $(CLI_OBJS) $(cli_simple_DEPS)
 	$(make-build-dir)
 	@echo "Linking cli_simple..."
-	$(CC) $(LDFLAGS) -Wl,-Map=$(LOCAL_BUILD_DIR)/cli_simple/cli_simple.map,--cref -o $@ $(CLI_OBJS) -Wl,--start-group $(cli_simple_DEPS) -Wl,--end-group -lc -lm -lgcc
+	$(CC) $(LDFLAGS) -Wl,-Map=$(LOCAL_BUILD_DIR)/cli_simple$(PROFILE_SUFFIX).map,--cref -o $@ $(CLI_OBJS) -Wl,--start-group $(cli_simple_DEPS) -Wl,--end-group -lc -lm -lgcc
 	@echo "Linking complete."
 
 # Create binary from ELF
-$(LOCAL_BUILD_DIR)/cli_simple/cli_simple.bin: $(LOCAL_BUILD_DIR)/cli_simple/cli_simple.elf
+$(BIN): $(ELF)
 	$(CP) -O binary $< $@
-	@echo "Created cli_simple.bin"
+	@echo "Created $(notdir $(BIN))"
 	@$(SZ) $<
 
-# Sign the bin so the bootloader will accept it at slot A.
-$(LOCAL_BUILD_DIR)/cli_simple/cli_simple.signed.bin: $(LOCAL_BUILD_DIR)/cli_simple/cli_simple.bin $(DEV_PRIV)
-	@echo "Signing cli_simple.bin..."
+# Sign the bin so the bootloader will accept it (bootloader profiles only).
+$(SBIN): $(BIN) $(DEV_PRIV)
+	@echo "Signing $(notdir $(BIN))..."
 	python3 $(ROOT_DIR)/tools/sign_image.py \
 		--priv-in $(DEV_PRIV) \
 		--in $< \
@@ -115,4 +134,4 @@ $(LOCAL_BUILD_DIR)/cli_simple/cli_simple.signed.bin: $(LOCAL_BUILD_DIR)/cli_simp
 # Clean all build artifacts
 clean:
 	@echo "Cleaning cli apps..."
-	@rm -rf $(LOCAL_BUILD_DIR)
+	@rm -rf $(BUILD_DIR)/apps/cli

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -20,9 +20,9 @@
 stm32-bare-metal/
 ├── chip_headers/          CMSIS + STM32F4xx device register definitions (read-only reference)
 ├── linker/                Linker scripts:
-│                            - app_ls.ld         slot-A apps (default since Phase 1.5)
+│                            - app_ls.ld         slot-aware apps (PROFILE=bootloader, default)
 │                            - bootloader_ls.ld  sector-0 bootloader (16 KB)
-│                            - stm32_ls.ld       legacy 0x08000000-base (unused)
+│                            - stm32_ls.ld       full-flash 0x08000000 (PROFILE=standalone)
 ├── startup/               Vector table and startup code (stm32f411_startup.c)
 ├── drivers/               Peripheral drivers (see Drivers section below)
 │   ├── inc/               Public headers + test_output.h (HIL machine-parseable output macros)
@@ -76,7 +76,12 @@ stm32-bare-metal/
 - **Optimisation:** `-O2 -flto -ffunction-sections -fdata-sections` (dead-code elimination via `--gc-sections`)
 - **Linker:** `--specs=nosys.specs` for syscall stubs; `-lc -lm -lgcc` for libc/math/compiler-rt
 - **Hierarchical Makefiles:** Each subdirectory compiles to a static library (`.a`); the top-level Makefile links them.
-- **Per-app linker script:** Default is `linker/app_ls.ld` — slot-A aware (`SLOT_BASE = 0x08010000`). The bootloader app overrides it to `linker/bootloader_ls.ld` (sector 0, 16 KB). Override on a per-app basis by setting `LDSCRIPT := $(LINKER_DIR)/<app>_ls.ld` in the app's Makefile after `include ../../Makefile.common`. The pre-Phase-1.5 default `linker/stm32_ls.ld` is retained for reference but no longer used by the build.
+- **Target profiles:** A single `PROFILE=` knob in `Makefile.common` selects the memory map an app builds for, bundling four things — linker script, base address (`SLOT_BASE`), output-path suffix (`PROFILE_SUFFIX`), and whether to sign (`SIGN_IMAGE`). Apps stay profile-agnostic: they thread `$(PROFILE_SUFFIX)` through output paths and gate signing on `$(SIGN_IMAGE)`, never naming a script or address. Two profiles ship:
+  - `bootloader` (default) — `linker/app_ls.ld` at `SLOT_BASE` (slot A `0x08010000` / slot B `0x08040000` via `SLOT=A|B`), signed `.signed.bin`. This is the Plan 001 map.
+  - `standalone` — `linker/stm32_ls.ld` at `0x08000000` full-flash, unsigned raw `.bin`/`.elf` flashable directly with a debugger. This is the pre-bootloader map.
+
+  A new map (e.g. a future `bootloader_v2`) drops in as one more branch in the resolver with no per-app changes. Examples: `make EXAMPLE=cli_simple` (slot A), `make EXAMPLE=cli_simple SLOT=B`, `make EXAMPLE=blink_simple PROFILE=standalone`. **Bootloader-profile images are position-dependent — a slot-A image will not run at slot B and vice versa** (linker ORIGIN and the vector table bake the base address in); the build produces a separately-linked `_b` artifact per slot. See [ADR 003](decisions/003-app-target-profiles.md).
+- **Per-app linker override:** The bootloader loader app overrides `LDSCRIPT := $(LINKER_DIR)/bootloader_ls.ld` (sector 0, 16 KB) in its own Makefile after `include ../../Makefile.common`.
 - **Image signing:** Every app linked with `app_ls.ld` is post-processed by `tools/sign_image.py` into a `.signed.bin` carrying a 140-byte `img_header_t`. The bootloader parses that header before jumping. The dev keypair is regenerated from a fixed seed at the start of every build via `make keys` (outputs land under `build/keys/`, gitignored).
 - **Host tests:** Compiled with native `gcc` (no ARM toolchain needed). Unity framework from `3rd_party/unity/`.
 - **HIL tests:** `HIL_TEST=1` flag adds `-DHIL_TEST_MODE`, links `libunity_arm.a`, includes `test_harness.c`. Always `make clean` when switching.
@@ -192,3 +197,8 @@ tests/
 - SRAM: 0x20000000, 128 KB
 - Stack: top of SRAM, grows downward; overflow detection via stack canary section
 - Heap: between BSS end and stack limit (currently unused — no dynamic allocation)
+
+The exact in-flash layout depends on the build **profile** (see Build System above):
+
+- `PROFILE=bootloader` (default): bootloader in sector 0, app at slot A (`0x08010000`) or slot B (`0x08040000`) behind a 140-byte signed header. See [bootloader-skeleton.md](plans/001-bootloader/bootloader-skeleton.md) and [ab-slots.md](plans/001-bootloader/ab-slots.md) for the full partition map.
+- `PROFILE=standalone`: a single unsigned image owning the full 512 KB from `0x08000000` (`linker/stm32_ls.ld`), no bootloader.

--- a/docs/wiki/decisions/003-app-target-profiles.md
+++ b/docs/wiki/decisions/003-app-target-profiles.md
@@ -1,0 +1,126 @@
+# ADR 003 — App target profiles (memory-map selector)
+
+Status: accepted (#167)
+
+## Context
+
+After Plan 001, the project has more than one valid flash memory map:
+
+- The **bootloader map** (Plan 001): a 16 KB bootloader in sector 0, A/B
+  application slots at `0x08010000` / `0x08040000`, and every app linked with
+  `linker/app_ls.ld`, signed by `tools/sign_image.py` into a `.signed.bin` the
+  bootloader parses and verifies.
+- The **pre-bootloader map**: a single full-flash image based at `0x08000000`
+  (`linker/stm32_ls.ld`), unsigned, flashed directly with a debugger.
+
+Before this change the bootloader map was hard-wired in two places:
+
+1. `Makefile.common` set `LDSCRIPT`, `SLOT`, `SLOT_BASE`, `SLOT_SUFFIX`.
+2. Each app Makefile baked in the signing step and assumed slot A.
+
+Two app Makefiles (`apps/cli`, `apps/basic`) were not even slot-aware, so
+`make EXAMPLE=cli_simple SLOT=B` silently clobbered the slot-A artifact
+(#167). There was no supported way to build any app for the legacy map, and
+no clean place to add a future map.
+
+## Decision
+
+Introduce a single **`PROFILE=`** knob in `Makefile.common`. A profile bundles
+the four things that pin an app to a memory map:
+
+| Field | Meaning |
+|---|---|
+| `LDSCRIPT` | which linker script (where the app lands in flash) |
+| `SLOT_BASE` | the FLASH ORIGIN `--defsym` fed to a slot-aware script |
+| `PROFILE_SUFFIX` | appended to every output path so variants don't clobber |
+| `SIGN_IMAGE` | whether `sign_image.py` wraps the `.bin` in an `img_header_t` |
+
+Profiles shipped:
+
+- **`bootloader`** (default) — `app_ls.ld` at `SLOT_BASE` (slot A `0x08010000`
+  / slot B `0x08040000` via `SLOT=A|B`), `SIGN_IMAGE=1`. Identical to the
+  prior default behaviour.
+- **`standalone`** — `stm32_ls.ld` at `0x08000000` full-flash, `SIGN_IMAGE=0`,
+  raw unsigned `.bin`/`.elf` flashable directly with a debugger. Suffix
+  `_standalone`.
+
+Apps stay **profile-agnostic**: every app Makefile threads `$(PROFILE_SUFFIX)`
+through its output paths and gates the signing step on `$(SIGN_IMAGE)`, but
+never names a linker script or base address. A new map (e.g. a future
+`bootloader_v2`) is added as one more branch in the resolver with no per-app
+changes.
+
+```
+make EXAMPLE=cli_simple                       # bootloader, slot A (default)
+make EXAMPLE=cli_simple SLOT=B                # bootloader, slot B
+make EXAMPLE=blink_simple PROFILE=standalone  # legacy 0x08000000, unsigned
+```
+
+`SLOT_SUFFIX` is retained as an alias of `PROFILE_SUFFIX` for backward
+compatibility.
+
+## Consequences
+
+- #167 is closed: `apps/cli` and `apps/basic` are now slot-aware, so A and B
+  builds of the same app coexist (`build/apps/.../<app>_a/...` and
+  `.../<app>_b/...`).
+- The legacy map is a first-class, tested build path again rather than a
+  commented-out relic.
+- Every bootloader-profile slot carries a descriptive suffix (`_a` / `_b`), so
+  the slot-A artifact path moved from `build/apps/cli/cli_simple/...` to
+  `build/apps/cli/cli_simple_a/...`. The HIL / boot-smoke / OTA / verify / RDP /
+  anti-rollback scripts that hard-coded the old no-suffix slot-A path were
+  updated to the `_a` path in the same change.
+- `make flash` / `make debug` are now `PROFILE`-aware (they search for
+  `<app>$(PROFILE_SUFFIX).elf`).
+
+## Slot A/B images are position-dependent
+
+A bootloader-profile image **only runs at the slot it was linked for**. A
+slot-A image will not run at slot B and vice versa. Two mechanisms bake the
+base address in:
+
+1. **Linker ORIGIN.** `app_ls.ld` sets `FLASH ORIGIN = SLOT_BASE + 0x200`, so
+   every absolute address the linker resolves (absolute call targets in
+   `.text`, `.rodata` pointers, jump tables, the `.data` LMA via `AT> FLASH`)
+   is computed for that one base.
+2. **Vector table + VTOR.** `.isr_vector_tbl` holds absolute handler addresses
+   for the linked base, and `_app_vector_base` (written to `SCB->VTOR` by the
+   shared startup) is a link-time constant, not derived at runtime.
+
+This is why the build deliberately produces a separately-linked `_b` artifact
+with `SLOT_BASE=0x08040000`. It is correct for the current verify-in-place /
+jump-in-place bootloader design — OTA ships the binary built for the
+destination slot.
+
+### Making one image slot-agnostic (deferred; future plan)
+
+If a single OTA artifact that either slot can receive ever becomes a
+requirement, three approaches exist, in increasing order of cost:
+
+- **Option A — Position-Independent Code (the principled fix).** Build apps
+  with `-fPIE` + ROPI/RWPI, link with a PIC-aware script, and fix up the GOT
+  and `.data`/`.bss` in startup relative to the runtime load base (read from
+  `SCB->VTOR`); the vector table must be made relative or rebuilt in RAM.
+  Invasive (per-app flags, linker, startup, likely the image format) with a
+  small code-size/speed cost.
+- **Option B — runtime VTOR-only relocation.** Insufficient alone: fixes
+  interrupt dispatch but not the absolute `.text`/`.rodata` references.
+- **Option C — fixed execution region.** Link every app for one fixed address
+  and have the bootloader copy the selected slot's payload there before
+  jumping; slots become pure storage. Adds a boot-time copy and changes the
+  jump + OTA/verify flow.
+
+Decision: keep the per-slot rebuild as the default. Slot-agnostic images would
+be a separate plan phase (Option A is the principled route) and are explicitly
+out of scope here.
+
+## References
+
+- [Makefile.common](../../../Makefile.common) — the profile resolver.
+- [linker/app_ls.ld](../../../linker/app_ls.ld) — bootloader-profile script.
+- [linker/stm32_ls.ld](../../../linker/stm32_ls.ld) — standalone-profile script.
+- [bootloader-skeleton.md](../plans/001-bootloader/bootloader-skeleton.md) — the
+  memory map and boot sequence.
+- [ab-slots.md](../plans/001-bootloader/ab-slots.md) — A/B slot layout and the
+  `SLOT=A|B` knob.

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -54,6 +54,7 @@ Multi-phase project plans. Each plan's phases are sized as individual GitHub iss
 |---|---|
 | [decisions/001-ci-pipeline.md](decisions/001-ci-pipeline.md) | Why GitHub Actions with hosted runners; HIL architecture plan |
 | [decisions/002-image-format.md](decisions/002-image-format.md) | Image header format, slot metadata format, partition layout, signing algorithm — frozen for STM32F411RE |
+| [decisions/003-app-target-profiles.md](decisions/003-app-target-profiles.md) | `PROFILE=` knob selecting the memory map (bootloader slot A/B vs standalone 0x08000000); per-slot position-dependence and future PIC options |
 
 ## Log
 

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -4,6 +4,31 @@ Chronological record of significant changes. Newest entries at the top.
 Format: `## [YYYY-MM-DD] <type> | <title> (<PR/Issue>)`
 Types: `merge`, `decision`, `milestone`, `infra`
 
+## [2026-06-20] infra | App target profiles — `PROFILE=` memory-map selector (#167)
+
+Centralized the memory-map / signing choice into a single `PROFILE=` knob in
+`Makefile.common`. A profile bundles linker script, `SLOT_BASE`,
+`PROFILE_SUFFIX`, and `SIGN_IMAGE`. Two profiles ship: `bootloader` (default —
+slot A/B, signed, `app_ls.ld`) and `standalone` (full-flash `0x08000000`,
+unsigned, `stm32_ls.ld`). Apps stay profile-agnostic — they thread
+`$(PROFILE_SUFFIX)` through output paths and gate signing on `$(SIGN_IMAGE)`.
+
+- Closes #167: `apps/cli` and `apps/basic` are now slot-aware (previously
+  `SLOT=B` silently clobbered the slot-A artifact). All app Makefiles
+  (`cli`, `basic`, `app_blinky_signed`) build distinct A/B/standalone outputs.
+- `make flash` / `make debug` are now `PROFILE`-aware (search
+  `<app>$(PROFILE_SUFFIX).elf`).
+- Every bootloader-profile slot now carries a descriptive suffix (`_a` / `_b`),
+  so the slot-A path moved (`build/apps/cli/cli_simple_a/...`). The HIL /
+  boot-smoke / OTA / verify / RDP / anti-rollback scripts that hard-coded the
+  old no-suffix slot-A path were updated to the `_a` path in the same change.
+- New **ADR 003 (`decisions/003-app-target-profiles.md`)** records the profile
+  model, the per-slot position-dependence of bootloader images, and the
+  deferred options (PIC / fixed exec region) for slot-agnostic images.
+- `stm32_ls.ld` documented as the `standalone` profile script; updated
+  `architecture.md`, `bootloader-skeleton.md`, `ab-slots.md`, `README.md`,
+  `CLAUDE.md`, and `index.md`.
+
 ## [2026-06-20] milestone | Plan 001 complete — Phase 1.11 threat model + production gaps + ADR (#170)
 
 Closes Plan 001.  Phases 1.5–1.10 shipped the bootloader, signing, OTA,

--- a/docs/wiki/plans/001-bootloader/ab-slots.md
+++ b/docs/wiki/plans/001-bootloader/ab-slots.md
@@ -87,7 +87,8 @@ fallback scenarios on hardware.
 
 ## SLOT=A / SLOT=B build knob
 
-Every app linked with `linker/app_ls.ld` accepts a slot selector:
+Every app built with the default `PROFILE=bootloader` (linked with
+`linker/app_ls.ld`) accepts a slot selector:
 
 ```
 make EXAMPLE=app_blinky_signed              # SLOT=A → 0x08010000
@@ -95,17 +96,31 @@ make EXAMPLE=app_blinky_signed SLOT=B       # SLOT=B → 0x08040000
 make EXAMPLE=cli_simple SLOT=B              # any app, slot B
 ```
 
-Slot-B output paths carry a `_b` suffix so they cannot clobber the
-slot-A artefacts:
+As of #167 every app Makefile (`apps/cli`, `apps/basic`, and
+`apps/bootloader/app_blinky_signed`) is slot-aware, so the slot-A and slot-B
+builds of the same app coexist without clobbering each other. Slot-B output
+paths carry a `_b` suffix:
 
 ```
-build/apps/bootloader/app_blinky_signed/app_blinky_signed.signed.bin       (SLOT=A)
+build/apps/bootloader/app_blinky_signed_a/app_blinky_signed_a.signed.bin   (SLOT=A)
 build/apps/bootloader/app_blinky_signed_b/app_blinky_signed_b.signed.bin   (SLOT=B)
+build/apps/cli/cli_simple_a/cli_simple_a.signed.bin                        (SLOT=A)
+build/apps/cli/cli_simple_b/cli_simple_b.signed.bin                        (SLOT=B)
 ```
 
-`SLOT_BASE`, `SLOT_SUFFIX`, and `SLOT` are exported from
-`Makefile.common` for sub-make consumption. Default behaviour
-(`SLOT=A`) is bit-identical to pre-Phase-1.7 builds.
+The suffix is `PROFILE_SUFFIX` (`SLOT_SUFFIX` is kept as a backward-compatible
+alias), exported from `Makefile.common` for sub-make consumption along with
+`SLOT`, `SLOT_BASE`, `PROFILE`, and `SIGN_IMAGE`. Default behaviour (`SLOT=A`)
+is bit-identical to pre-#167 builds. See
+[ADR 003](../../decisions/003-app-target-profiles.md) for the full profile
+model.
+
+**Images are position-dependent per slot.** A slot-A image will not run at
+slot B and vice versa — `app_ls.ld` sets `FLASH ORIGIN = SLOT_BASE + 0x200`, so
+all absolute addresses and the vector table are baked in for one base. This is
+why a distinct `_b` artifact is built rather than reusing the slot-A binary;
+OTA ships the binary built for the destination slot. ADR 003 records the
+(deferred) options for making a single image slot-agnostic.
 
 ## `lib/flash` middleware
 

--- a/docs/wiki/plans/001-bootloader/bootloader-skeleton.md
+++ b/docs/wiki/plans/001-bootloader/bootloader-skeleton.md
@@ -76,7 +76,14 @@ directly with a debugger for development).
 | Script | Region | Used by |
 |---|---|---|
 | [linker/bootloader_ls.ld](../../../../linker/bootloader_ls.ld) | sector 0, 16 KB | `apps/bootloader/loader` only |
-| [linker/app_ls.ld](../../../../linker/app_ls.ld) | slot at SLOT_BASE+0x8C | every other app |
+| [linker/app_ls.ld](../../../../linker/app_ls.ld) | slot at SLOT_BASE+0x8C | every other app (`PROFILE=bootloader`, default) |
+| [linker/stm32_ls.ld](../../../../linker/stm32_ls.ld) | full flash at 0x08000000 | any app built with `PROFILE=standalone` (no bootloader) |
+
+The linker script is selected by the build **profile** (`PROFILE=`, resolved in
+[Makefile.common](../../../../Makefile.common)); see
+[ADR 003](../../decisions/003-app-target-profiles.md). The default
+`PROFILE=bootloader` uses `app_ls.ld`; `PROFILE=standalone` uses `stm32_ls.ld`
+and skips signing.
 
 `app_ls.ld` accepts `SLOT_BASE` via `--defsym` (default `0x08010000`).
 [Makefile.common](../../../../Makefile.common) injects the default; an app
@@ -97,10 +104,14 @@ the symbol weak and skips the VTOR write when it resolves to 0.
 | `cli_simple` | `app_ls.ld` | `.signed.bin` | HIL test target |
 | every other app | `app_ls.ld` | `.signed.bin` | Standalone demos |
 
-`make EXAMPLE=bootloader` builds the loader.  Every other app produces a
-`<name>.signed.bin` whose first 140 bytes are the `img_header_t` written by
-[tools/sign_image.py](../../../../tools/sign_image.py); the bootloader
-parses that header before jumping.
+`make EXAMPLE=bootloader` builds the loader.  Every other app, built with the
+default `PROFILE=bootloader`, produces a `<name>.signed.bin` whose first 140
+bytes are the `img_header_t` written by
+[tools/sign_image.py](../../../../tools/sign_image.py); the bootloader parses
+that header before jumping.  Building any app with `PROFILE=standalone`
+instead produces a raw unsigned `<name>_standalone.bin` linked at
+`0x08000000` for direct-to-debugger flashing without a bootloader (see
+[ADR 003](../../decisions/003-app-target-profiles.md)).
 
 ## Dev keypair
 
@@ -217,11 +228,17 @@ lines.  CI runs it after the cli_simple HIL job.
 ## Footguns
 
 - **Two kinds of binaries.**  `loader.bin` lives at sector 0; every other
-  `.bin` is linked at slot A.  Mixing them up (e.g. flashing the
+  bootloader-profile `.bin` is linked at a slot.  Mixing them up (e.g. flashing the
   bootloader to slot A, or vice versa) bricks the chain.  The dispatcher
   in `apps/Makefile` plus the `flash`/`flash-bootloader` split makes the
   intended path obvious; double-check by running `arm-none-eabi-objdump
   -h <name>.elf | head -5` and looking at the LMA of `.isr_vector_tbl`.
+- **Wrong profile / slot is position-dependent.**  A bootloader-profile image
+  only runs at the slot it was linked for — a slot-A image will not run at
+  slot B, and a `PROFILE=standalone` image (`0x08000000`) will not run from a
+  slot.  Re-build for the target (`SLOT=B` or `PROFILE=...`) rather than
+  re-flashing the wrong artifact.  See
+  [ADR 003](../../decisions/003-app-target-profiles.md).
 - **Stale `.signed.bin`.**  Touching `tools/sign_image.py` does not by
   default re-trigger every app's signing step.  When changing the signer
   or the on-flash format, run `make clean && make all`.

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -73,3 +73,4 @@ See [log.md](log.md) for the full history. Key milestones:
 - ✅ HIL Tier 4: SysTick hardware tests — `get_ms`, `elapsed_since`, `delay_ms` accuracy on real board (#62)
 - ✅ JUnit XML reporting for HIL tests in CI — every PR shows a HIL Tests tab in GitHub Test Summary (#123)
 - ✅ Plan 000 — Repository refactor: renamed `examples/` → `apps/`, added `lib/` (middleware) and `tools/` (host utilities), per-app linker script override (#136)
+- ✅ App target profiles: single `PROFILE=` knob (bootloader slot A/B vs standalone `0x08000000`), all app Makefiles slot-aware, ADR 003 (#167)

--- a/linker/stm32_ls.ld
+++ b/linker/stm32_ls.ld
@@ -1,4 +1,24 @@
 /* 1. Entry Point */
+/*
+ * Standalone profile linker script — STM32F411RE.
+ *
+ * This is the `PROFILE=standalone` script (Makefile.common): the pre-bootloader
+ * memory map.  The image occupies the full 512 KB flash based at 0x08000000
+ * (sector 0), carries no img_header_t, and is NOT signed — it is flashed
+ * directly with a debugger and runs from the chip's reset vector base.
+ *
+ * Because the vector table sits at 0x08000000 (the reset default for VTOR),
+ * this script deliberately does NOT export _app_vector_base.  The shared
+ * startup (startup/stm32f411_startup.c) declares that symbol weak and skips
+ * the SCB->VTOR write when it resolves to 0, leaving VTOR at the correct
+ * default.  This mirrors the bootloader_ls.ld behaviour.
+ *
+ * SLOT_BASE is forwarded by Makefile.common's LDFLAGS as an unused --defsym;
+ * this script ignores it (it is only meaningful for the slot-aware app_ls.ld).
+ *
+ * For the bootloader memory map (signed apps in A/B slots) use the default
+ * PROFILE=bootloader, which selects linker/app_ls.ld instead.
+ */
 ENTRY(Reset_Handler)
 
 /* 2. Memory definitions */

--- a/scripts/run_ab_slot_test.py
+++ b/scripts/run_ab_slot_test.py
@@ -72,7 +72,7 @@ def build_app_for_slot(project_root: Path, slot: str) -> Path:
         ["make", "EXAMPLE=app_blinky_signed", f"SLOT={slot}"],
         cwd=project_root, check=True, timeout=120,
     )
-    suffix = "" if slot == "A" else "_b"
+    suffix = "_a" if slot == "A" else "_b"
     signed = (project_root / "build" / "apps" / "bootloader"
               / f"app_blinky_signed{suffix}"
               / f"app_blinky_signed{suffix}.signed.bin")

--- a/scripts/run_anti_rollback_test.py
+++ b/scripts/run_anti_rollback_test.py
@@ -79,7 +79,7 @@ def build_cli_simple(project_root: Path, image_version: int) -> Path:
     # IMAGE_VERSION as a make variable, but the .bin itself is content-
     # only — make won't re-sign unless the .bin changes).  Touch the bin.
     bin_path = (project_root / "build" / "apps" / "cli"
-                / "cli_simple" / "cli_simple.bin")
+                / "cli_simple_a" / "cli_simple_a.bin")
     if bin_path.exists():
         bin_path.touch()
     subprocess.run(
@@ -87,12 +87,12 @@ def build_cli_simple(project_root: Path, image_version: int) -> Path:
         cwd=project_root, check=True, timeout=180,
     )
     signed = (project_root / "build" / "apps" / "cli"
-              / "cli_simple" / "cli_simple.signed.bin")
+              / "cli_simple_a" / "cli_simple_a.signed.bin")
     if not signed.exists():
         raise RuntimeError(f"expected {signed} after build")
     # Stash a copy so subsequent rebuilds with a different version don't
     # clobber it.  Caller renames the returned path freely.
-    out = signed.with_name(f"cli_simple.v{image_version}.signed.bin")
+    out = signed.with_name(f"cli_simple_a.v{image_version}.signed.bin")
     out.write_bytes(signed.read_bytes())
     return out
 
@@ -121,7 +121,7 @@ def build_blinky_a(project_root: Path, image_version: int) -> Path:
     """Build a slot-A app_blinky_signed for the force-flash downgrade pass."""
     hil.log_info(f"Building app_blinky_signed (slot A, IMAGE_VERSION={image_version})...")
     bin_path = (project_root / "build" / "apps" / "bootloader"
-                / "app_blinky_signed" / "app_blinky_signed.bin")
+                / "app_blinky_signed_a" / "app_blinky_signed_a.bin")
     if bin_path.exists():
         bin_path.touch()
     subprocess.run(
@@ -130,7 +130,7 @@ def build_blinky_a(project_root: Path, image_version: int) -> Path:
         cwd=project_root, check=True, timeout=180,
     )
     signed = (project_root / "build" / "apps" / "bootloader"
-              / "app_blinky_signed" / "app_blinky_signed.signed.bin")
+              / "app_blinky_signed_a" / "app_blinky_signed_a.signed.bin")
     if not signed.exists():
         raise RuntimeError(f"expected {signed} after build")
     out = signed.with_name(f"app_blinky_signed_a.v{image_version}.signed.bin")

--- a/scripts/run_boot_smoke_test.py
+++ b/scripts/run_boot_smoke_test.py
@@ -42,7 +42,7 @@ def build_smoke_app(project_root: Path) -> Path:
         timeout=120,
     )
     signed = (project_root / "build" / "apps" / "bootloader"
-              / "app_blinky_signed" / "app_blinky_signed.signed.bin")
+              / "app_blinky_signed_a" / "app_blinky_signed_a.signed.bin")
     if not signed.exists():
         hil.log_error(f"Expected {signed} after build")
         return None
@@ -116,7 +116,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.skip_build:
         signed = (project_root / "build" / "apps" / "bootloader"
-                  / "app_blinky_signed" / "app_blinky_signed.signed.bin")
+                  / "app_blinky_signed_a" / "app_blinky_signed_a.signed.bin")
         if not signed.exists():
             hil.log_error("No existing signed image found - build required")
             return 2

--- a/scripts/run_hil_tests.py
+++ b/scripts/run_hil_tests.py
@@ -92,7 +92,7 @@ def build_firmware(project_root: Path) -> Path:
     via `make flash-bootloader` and is never touched by CI.
 
     Returns:
-        Path to the cli_simple.signed.bin file, or None on error.
+        Path to the cli_simple_a.signed.bin file, or None on error.
     """
     log_info("Building firmware with HIL_TEST=1...")
 
@@ -114,8 +114,8 @@ def build_firmware(project_root: Path) -> Path:
             timeout=120
         )
 
-        elf_path = project_root / 'build' / 'apps' / 'cli' / 'cli_simple' / 'cli_simple.elf'
-        signed_path = project_root / 'build' / 'apps' / 'cli' / 'cli_simple' / 'cli_simple.signed.bin'
+        elf_path = project_root / 'build' / 'apps' / 'cli' / 'cli_simple_a' / 'cli_simple_a.elf'
+        signed_path = project_root / 'build' / 'apps' / 'cli' / 'cli_simple_a' / 'cli_simple_a.signed.bin'
 
         if not signed_path.exists():
             log_error("Build completed but signed binary not found")
@@ -685,8 +685,8 @@ def main():
                 return 2
         else:
             log_warning("Skipping build (--skip-build)")
-            image_path = (project_root / 'build' / 'apps' / 'cli' / 'cli_simple'
-                          / 'cli_simple.signed.bin')
+            image_path = (project_root / 'build' / 'apps' / 'cli' / 'cli_simple_a'
+                          / 'cli_simple_a.signed.bin')
             if not image_path.exists():
                 log_error("No existing signed image found - build required")
                 return 2

--- a/scripts/run_ota_test.py
+++ b/scripts/run_ota_test.py
@@ -440,7 +440,10 @@ def write_junit(
 
 # -------------------- Main --------------------
 
-BOARDS = {"ci": "066BFF554869774867234426", "dev": "066AFF504951857267161331"}
+# Reuse the canonical board→serial map from run_hil_tests so the dev/ci
+# serials never drift out of sync (a divergent local copy previously pinned
+# the wrong dev serial).
+BOARDS = hil.BOARD_REGISTRY
 
 
 def main() -> int:

--- a/scripts/run_ota_test.py
+++ b/scripts/run_ota_test.py
@@ -18,10 +18,11 @@ Drives the bootloader OTA receiver end-to-end on a real NUCLEO-F411RE.
             ota_send.py reports STATUS=verify_failed and that the next
             reset still boots slot A (cli_simple).
 
-The two slots run different apps on purpose: cli_simple's Makefile
-isn't yet SLOT-aware (a separate hygiene fix), and using two different
-apps end-to-end actually proves the OTA path more thoroughly than
-cycling the same image between slots.
+The two slots run different apps on purpose: using two different
+apps end-to-end proves the OTA path more thoroughly than cycling the
+same image between slots.  (As of #167 cli_simple's Makefile is also
+SLOT-aware, so a same-app A↔B cycle is possible too, but the
+two-app design is kept as the more demanding test.)
 
 This is the first HIL exercise of `flash_slot_commit_metadata` and
 `flash_slot_erase` running on real hardware — Phase 1.7 only validated
@@ -65,15 +66,15 @@ BLINKY_ALIVE     = "APP: blinky alive"
 
 # -------------------- Build helpers --------------------
 #
-# Slot A always carries cli_simple (slot-A only because cli_simple's Makefile
-# isn't yet SLOT-aware; that's a separate hygiene fix).  We need cli_simple
-# for the `ota_request` CLI command that triggers the bootloader OTA flow.
+# Slot A carries cli_simple: we need its `ota_request` CLI command to trigger
+# the bootloader OTA flow.  (Since #167 cli_simple is SLOT-aware too, but it
+# stays on slot A here because only it provides ota_request.)
 #
-# Slot B is the OTA target.  Any signed image that the bootloader will
-# verify works — we use app_blinky_signed because its Makefile already
-# threads $(SLOT_SUFFIX) through every output path, so `make EXAMPLE=
-# app_blinky_signed SLOT=B` produces a clean app_blinky_signed_b.signed.bin
-# without colliding with the slot-A artifact.
+# Slot B is the OTA target.  Any signed image the bootloader will verify works;
+# we use app_blinky_signed because `make EXAMPLE=app_blinky_signed SLOT=B`
+# produces a clean app_blinky_signed_b.signed.bin (every app Makefile now
+# threads $(PROFILE_SUFFIX) through its output paths) without colliding with
+# the slot-A artifact.
 
 def build_cli_simple(project_root: Path) -> Path:
     hil.log_info("Building cli_simple (slot A app — provides ota_request)...")
@@ -82,7 +83,7 @@ def build_cli_simple(project_root: Path) -> Path:
         cwd=project_root, check=True, timeout=180,
     )
     signed = (project_root / "build" / "apps" / "cli"
-              / "cli_simple" / "cli_simple.signed.bin")
+              / "cli_simple_a" / "cli_simple_a.signed.bin")
     if not signed.exists():
         raise RuntimeError(f"expected {signed} after build")
     return signed

--- a/scripts/run_rdp_test.py
+++ b/scripts/run_rdp_test.py
@@ -273,7 +273,7 @@ def step_recovery_reflash(hla_serial: str) -> tuple[Step, bool]:
     bootloader_elf = (project_root() / "build" / "apps" / "bootloader"
                       / "loader" / "loader.elf")
     app_signed = (project_root() / "build" / "apps" / "bootloader"
-                  / "app_blinky_signed" / "app_blinky_signed.signed.bin")
+                  / "app_blinky_signed_a" / "app_blinky_signed_a.signed.bin")
 
     if not bootloader_elf.exists() or not app_signed.exists():
         s.fail(

--- a/scripts/run_verify_test.py
+++ b/scripts/run_verify_test.py
@@ -80,7 +80,7 @@ def build_smoke_app(project_root: Path) -> Path | None:
         timeout=120,
     )
     signed = (project_root / "build" / "apps" / "bootloader"
-              / "app_blinky_signed" / "app_blinky_signed.signed.bin")
+              / "app_blinky_signed_a" / "app_blinky_signed_a.signed.bin")
     if not signed.exists():
         hil.log_error(f"Expected {signed} after build")
         return None
@@ -365,7 +365,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.skip_build:
         clean = (project_root / "build" / "apps" / "bootloader"
-                 / "app_blinky_signed" / "app_blinky_signed.signed.bin")
+                 / "app_blinky_signed_a" / "app_blinky_signed_a.signed.bin")
         if not clean.exists():
             hil.log_error("No existing signed image found - build required")
             sys.stdout.flush()

--- a/tools/ota_send.py
+++ b/tools/ota_send.py
@@ -15,7 +15,7 @@ Flow:
 Usage:
   python3 tools/ota_send.py \\
       --port /dev/ttyACM0 \\
-      --image build/apps/cli/cli_simple/cli_simple.signed.bin \\
+      --image build/apps/cli/cli_simple_b/cli_simple_b.signed.bin \\
       --slot B \\
       --baud 115200
 


### PR DESCRIPTION
## Summary

Centralizes the memory-map and signing choice into a single **`PROFILE=`** knob in `Makefile.common`, and makes every app Makefile slot-aware — closing #167.

A profile bundles the four things that pin an app to a memory map: linker script, `SLOT_BASE`, `PROFILE_SUFFIX`, and a new `SIGN_IMAGE` flag. Apps stay profile-agnostic — they thread `$(PROFILE_SUFFIX)` through output paths and gate signing on `$(SIGN_IMAGE)`, never naming a linker script or base address. A future memory map drops in as one more branch with no per-app changes.

Two profiles ship:
- **`bootloader`** (default) — `linker/app_ls.ld` at a slot (`SLOT=A` → `0x08010000`, `SLOT=B` → `0x08040000`), signed `.signed.bin`. The Plan 001 map.
- **`standalone`** — `linker/stm32_ls.ld` at `0x08000000` full-flash, unsigned raw `.bin`/`.elf` flashable directly with a debugger. The pre-bootloader map, now a first-class build path.

```
make EXAMPLE=cli_simple                       # bootloader, slot A (default)
make EXAMPLE=cli_simple SLOT=B                # bootloader, slot B
make EXAMPLE=blink_simple PROFILE=standalone  # legacy 0x08000000, unsigned
```

### Key changes
- **#167 fix:** `apps/cli` and `apps/basic` are now slot-aware; `SLOT=B` no longer clobbers the slot-A artifact. `app_blinky_signed` switched from `SLOT_SUFFIX` to `PROFILE_SUFFIX`.
- Every bootloader-profile slot now carries a descriptive suffix (`_a` / `_b`), so the slot-A path moved to `build/apps/.../<app>_a/...`. All HIL scripts (`run_hil_tests`, `run_ota_test`, `run_anti_rollback_test`, `run_boot_smoke_test`, `run_verify_test`, `run_rdp_test`) and `tools/ota_send.py` updated to the `_a` path.
- `make flash` / `make debug` are now `PROFILE`-aware (search `<app>$(PROFILE_SUFFIX).elf`).
- `linker/stm32_ls.ld` documented as the `standalone` profile script.

### Docs
- New **ADR 003** (`decisions/003-app-target-profiles.md`): the profile model, the per-slot position-dependence of bootloader images (a slot-A image will not run at slot B — linker ORIGIN and vector table bake the base in), and the deferred PIC / fixed-region options for slot-agnostic images.
- Updated `architecture.md`, `bootloader-skeleton.md`, `ab-slots.md`, `README.md`, `CLAUDE.md`, `index.md`, `log.md`, `roadmap.md`.

No firmware behaviour change — pure build-system hygiene + a revived legacy build path. Slot-A vector-table LMA is unchanged at `0x08010200`.

## Test plan
- [x] `make all` and `make test` green
- [x] `cli_simple`, `blink_simple`, `app_blinky_signed` built across all three profiles; verified vector-table LMAs (slot A `0x08010200`, slot B `0x08040200`, standalone `0x08000000`)
- [x] Standalone profile produces only a raw unsigned `.bin` (no `.signed.bin`)
- [x] Full HIL suite on the dev board: **149/149 passing** (clean build + flash + test)
- [x] CI `host-tests` + `firmware-build` + `hil-tests` green