### PR TITLE
Add 'make sanitize-board' target to recover from rollback-floor lockout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ APP_TARGETS := $(ALL_APPS) $(filter-out $(ALL_APPS),$(EXAMPLE))
 #==============================================================================
 # Phony targets
 #==============================================================================
-.PHONY: all clean test keys flash-bootloader $(SUBDIRS) flash debug openocd serial help $(APP_TARGETS)
+.PHONY: all clean test keys flash-bootloader sanitize-board $(SUBDIRS) flash debug openocd serial help $(APP_TARGETS)
 
 #==============================================================================
 # Build all apps
@@ -218,6 +218,25 @@ flash-bootloader: bootloader
 		$(if $(BOARD),--board $(BOARD)) \
 		$(if $(HLA_SERIAL),--hla-serial $(HLA_SERIAL)) \
 		$(BOOTLOADER_FLASH_ARGS)
+
+#==============================================================================
+# sanitize-board — erase the slot metadata sectors to reset the rollback floor.
+#
+# The Phase 1.9 bootloader derives a rollback floor from the highest
+# monotonic_counter committed across both metadata sectors.  After an
+# anti-rollback or OTA HIL run the floor is left elevated (e.g. 2), so a plain
+# `make flash` (which signs at the default IMAGE_VERSION=1) is then rejected on
+# every slot — the board logs `rollback ver=1 < floor=N` and stops at
+# `both slots failed verify`.  Erasing the metadata sectors resets floor=0 so
+# the next boot accepts a freshly flashed image.
+#
+# Delegates to scripts/sanitize_board.py (the same step CI runs at the start of
+# each HIL job); honors the shared BOARD / HLA_SERIAL knobs.
+#==============================================================================
+sanitize-board:
+	@python3 scripts/sanitize_board.py \
+		$(if $(BOARD),--board $(BOARD)) \
+		$(if $(HLA_SERIAL),--hla-serial $(HLA_SERIAL))
 #==============================================================================
 # Debug target
 #
@@ -279,6 +298,7 @@ help:
 	@echo "  make openocd            - Start OpenOCD server"
 	@echo "  make serial             - Connect to serial port (115200 baud)"
 	@echo "  make serial BAUD_RATE=9600 - Connect with custom baud rate"
+	@echo "  make sanitize-board     - Erase slot metadata (reset rollback floor)"
 	@echo ""
 	@echo "Board / slot / profile knobs (flash, serial, debug):"
 	@echo "  BOARD=dev|ci            - Target a registered board (default: dev)"

--- a/README.md
+++ b/README.md
@@ -174,6 +174,31 @@ make debug EXAMPLE=cli_simple         # OpenOCD + GDB attached (pinned to BOARD)
 make help                             # full target list
 ```
 
+#### Recovering from a rejected image (rollback floor)
+
+If the board boots only to the bootloader and logs something like:
+
+```
+BL: rollback ver=1 < floor=2
+BL: both slots failed verify
+```
+
+the board is not bricked — the **anti-rollback floor** is rejecting your image.
+The Phase 1.9 bootloader derives a floor from the highest `monotonic_counter`
+ever committed, and an anti-rollback or OTA HIL run leaves that floor elevated.
+A plain `make flash` signs images at the default `IMAGE_VERSION=1`, which is
+then below the floor. Reset the floor by erasing the slot metadata, then
+re-flash:
+
+```sh
+make sanitize-board        # erase metadata sectors (floor -> 0) on the dev board
+make flash
+make serial
+```
+
+(`make sanitize-board` honors `BOARD=`/`HLA_SERIAL=` like the other targets and
+is the same step CI runs at the start of every HIL job.)
+
 #### Build profiles
 
 A single `PROFILE=` knob selects the memory map an app builds for:


### PR DESCRIPTION
Closes #179.

## Summary

After an anti-rollback or OTA HIL run, the dev board's rollback floor is left elevated (e.g. floor=2). A plain `make flash` signs images at the default `IMAGE_VERSION=1`, so the bootloader rejects every slot (`rollback ver=1 < floor=2`) and stops at `both slots failed verify` — the board looks bricked but just needs its metadata erased.

`scripts/sanitize_board.py` already does this (and CI runs it before every HIL job), but it had no Makefile entry point. This adds one and documents the recovery.

- New `make sanitize-board` target wrapping `scripts/sanitize_board.py`, honoring the shared `BOARD`/`HLA_SERIAL` knobs (default `dev`).
- Listed in `make help`.
- README day-to-day flow gains a "Recovering from a rejected image (rollback floor)" note with the `ver < floor` log signature.

No firmware behavior change.

## Test plan

- [x] `make -n sanitize-board` resolves to `scripts/sanitize_board.py --board dev`; `BOARD=ci` switches roles.
- [x] `make help` lists the target.
- [x] `make test` passes.
- [x] On the Pi: `make sanitize-board` followed by `make flash` recovers a floor-locked board.