### PR TITLE
Fix garbled stop_mode wake message

### DIFF
--- a/apps/cli/cli_commands.c
+++ b/apps/cli/cli_commands.c
@@ -462,13 +462,20 @@ static int cmd_stop_mode(const char *args)
 
     enter_stop_mode();
 
-    /* Woke up — HSI is now the clock source. Restore PLL to 100 MHz. */
+    /* Woke up — HSI is now the clock source and the USART/DMA are still
+     * configured for the pre-sleep 100 MHz clock.  Tear the UART down first
+     * (uart_deinit disarms the TX/RX DMA streams and stops the USART) so the
+     * re-init below starts from a known-clean state; otherwise a stale DMA
+     * stream config races the reconfigured UART and the first bytes of the
+     * wake message come out garbled. */
+    uart_deinit();
     rcc_init(RCC_CLK_SRC_HSI, 100000000U);
     uart_init();
     systick_init();
     printf_dma_init();
 
     printf("Woke from Stop mode — clock restored to 100 MHz\n");
+    printf_dma_flush();
     return 0;
 }
 


### PR DESCRIPTION
Closes #181.

## Summary

Waking from \`stop_mode\` printed a corrupted message:

\`\`\`
Entering Stop mode (low-power regulator, flash off)...C??k??from Stop mode — clock restored to 100 MHz
\`\`\`

On wake the chip resumes on HSI with the USART/DMA still configured for the pre-sleep 100 MHz clock. \`cmd_stop_mode()\` re-ran \`rcc_init\`/\`uart_init\`/\`printf_dma_init\` without tearing the UART down, so a stale TX DMA stream config raced the reconfigured UART and the first bytes of the wake message were garbled.

The fix calls \`uart_deinit()\` first (it disarms the TX/RX DMA streams and stops the USART) so the re-init starts clean, and flushes the wake message.

## Test plan

- [x] `make EXAMPLE=cli_simple` builds.
- [x] `make test` passes.
- [x] On the board: `stop_mode`, wake, confirm a clean `Woke from Stop mode — clock restored to 100 MHz` line with no garbled characters.