### PR TITLE
Fix stop_mode wake leaving CLI unresponsive; restore UART callbacks (#190)

### DIFF
--- a/apps/cli/cli_commands.c
+++ b/apps/cli/cli_commands.c
@@ -474,6 +474,11 @@ static int cmd_stop_mode(const char *args)
     systick_init();
     printf_dma_init();
 
+    /* uart_deinit() cleared the driver's callback pointers; uart_init() does
+     * not restore them.  Re-attach the app's RX / TX-complete callbacks here
+     * or the CLI silently stops receiving input after wake (see #190). */
+    cli_app_attach_uart_callbacks();
+
     printf("Woke from Stop mode — clock restored to 100 MHz\n");
     printf_dma_flush();
     return 0;

--- a/apps/cli/cli_commands.h
+++ b/apps/cli/cli_commands.h
@@ -14,6 +14,17 @@
  */
 const cli_command_t* cli_commands_get_table(size_t* num_commands);
 
+/**
+ * @brief (Re)register the application's UART RX / TX-complete callbacks.
+ *
+ * The UART driver clears its callback pointers in uart_deinit().  Any code
+ * path that tears the UART down and re-inits it (e.g. the stop_mode wake
+ * sequence) must call this afterwards so the CLI keeps receiving input and
+ * printf_dma keeps resetting its buffers.  Defined in cli_simple.c, where the
+ * concrete callbacks live; declared here so cli_commands.c can reuse it.
+ */
+void cli_app_attach_uart_callbacks(void);
+
 #ifdef HIL_TEST_MODE
 /**
  * @brief Run all Unity tests on the target hardware

--- a/apps/cli/cli_simple.c
+++ b/apps/cli/cli_simple.c
@@ -59,6 +59,15 @@ static void process_pending_command(void) {
     }
 }
 
+// (Re)register UART callbacks.  Kept in one place so every UART (re)init
+// path — main() at boot and the stop_mode wake sequence — wires the same
+// callbacks and they can never drift apart.  uart_deinit() clears these, so
+// any teardown/re-init must call this again.
+void cli_app_attach_uart_callbacks(void) {
+    uart_register_rx_callback(on_char_received);
+    uart_register_tx_complete_callback(printf_dma_tx_complete_callback);
+}
+
 int main(void) {
     // Initialize hardware
     led2_init();
@@ -91,8 +100,7 @@ int main(void) {
     (void)bl_handshake_clear_fail_count(boot_slot);
 
     // Register UART callbacks
-    uart_register_rx_callback(on_char_received);
-    uart_register_tx_complete_callback(printf_dma_tx_complete_callback);
+    cli_app_attach_uart_callbacks();
     
     // Initialize CLI with application commands
     size_t num_commands;

--- a/tests/uart/test_uart.c
+++ b/tests/uart/test_uart.c
@@ -509,6 +509,68 @@ void test_null_rx_callback_does_not_crash(void)
 }
 
 /* ======================================================================== */
+/* Callback lifecycle across deinit/init (regression for #190)              */
+/*                                                                          */
+/* The stop_mode wake path tears the UART down (uart_deinit) and re-inits   */
+/* it (uart_init).  uart_deinit() must clear the driver callbacks, and      */
+/* uart_init() must NOT silently resurrect them — the application owns      */
+/* re-registration.  These tests pin that contract so a future re-init      */
+/* path that forgets to re-register is caught at `make test` time.          */
+/* ======================================================================== */
+
+void test_uart_deinit_clears_rx_callback(void)
+{
+    uart_init();
+    uart_register_rx_callback(test_rx_cb);
+
+    uart_deinit();
+
+    /* After deinit the callback must be gone: an RXNE interrupt must not
+     * dispatch to the previously-registered callback. */
+    fake_USART2.SR = SR_RXNE;
+    fake_USART2.DR = 'Z';
+    USART2_IRQHandler();
+    TEST_ASSERT_EQUAL(0, rx_cb_count);
+}
+
+void test_uart_init_does_not_restore_rx_callback_after_deinit(void)
+{
+    /* Simulate the stop_mode wake sequence at the driver level:
+     * register -> deinit -> re-init.  The driver must NOT auto-restore the
+     * old callback; the app is responsible for re-registering.  If a future
+     * change made uart_init() resurrect a stale pointer this test would
+     * fail and force a deliberate decision. */
+    uart_init();
+    uart_register_rx_callback(test_rx_cb);
+    uart_deinit();
+    uart_init();
+
+    fake_USART2.SR = SR_RXNE;
+    fake_USART2.DR = 'W';
+    USART2_IRQHandler();
+    TEST_ASSERT_EQUAL(0, rx_cb_count);
+}
+
+void test_uart_rx_callback_works_after_deinit_init_reregister(void)
+{
+    /* The full, correct wake sequence: register -> deinit -> re-init ->
+     * RE-REGISTER.  After re-registering, RX dispatch must work again.
+     * This is exactly what cli_app_attach_uart_callbacks() restores in the
+     * stop_mode wake path. */
+    uart_init();
+    uart_register_rx_callback(test_rx_cb);
+    uart_deinit();
+    uart_init();
+    uart_register_rx_callback(test_rx_cb);  /* app re-registers after wake */
+
+    fake_USART2.SR = SR_RXNE;
+    fake_USART2.DR = 'K';
+    USART2_IRQHandler();
+    TEST_ASSERT_EQUAL(1, rx_cb_count);
+    TEST_ASSERT_EQUAL('K', rx_cb_char);
+}
+
+/* ======================================================================== */
 /* Critical section                                                           */
 /* ======================================================================== */
 
@@ -826,6 +888,11 @@ int main(void)
     RUN_TEST(test_rx_callback_not_called_when_dma_rx_active);
     RUN_TEST(test_rx_callback_receives_correct_character);
     RUN_TEST(test_null_rx_callback_does_not_crash);
+
+    /* Callback lifecycle across deinit/init (regression for #190) */
+    RUN_TEST(test_uart_deinit_clears_rx_callback);
+    RUN_TEST(test_uart_init_does_not_restore_rx_callback_after_deinit);
+    RUN_TEST(test_uart_rx_callback_works_after_deinit_init_reregister);
 
     /* Critical section */
     RUN_TEST(test_critical_section_enter_sets_basepri);


### PR DESCRIPTION
## Summary

- Fixes #190: after running the `stop_mode` CLI command, the CLI hung at the `> ` prompt — keystrokes were no longer processed.
- Root cause: PR #181 added `uart_deinit()` to the `stop_mode` wake sequence (to fix a garbled wake message). `uart_deinit()` clears the driver's `rx_callback` / `tx_complete_callback`, and the wake path then called `uart_init()` without re-registering them. `uart_init()` re-arms RXNEIE + the NVIC IRQ, so the RX ISR still fired on each keystroke — but with `rx_callback == NULL` every character was dropped, so the CLI looked hung. The TX-complete callback was also lost, wedging `printf_dma` after the next buffer.
- Centralizes callback registration in `cli_app_attach_uart_callbacks()` (defined in `cli_simple.c`, declared in `cli_commands.h`) so `main()` at boot and the `stop_mode` wake path wire the same callbacks and cannot drift. Calls it after `uart_init()` in `cmd_stop_mode()`.

## Regression test

Adds three host unit tests in `tests/uart/test_uart.c` that pin the deinit/init callback lifecycle:
- `test_uart_deinit_clears_rx_callback` — `uart_deinit()` clears the RX callback.
- `test_uart_init_does_not_restore_rx_callback_after_deinit` — `uart_init()` does not silently resurrect a stale callback (the app owns re-registration).
- `test_uart_rx_callback_works_after_deinit_init_reregister` — RX dispatch works again once the app re-registers (the corrected wake sequence).

## Test plan

- [x] `make test` — all host suites pass (79 uart tests, incl. 3 new).
- [x] `make all` — all firmware apps build.
- [x] HIL on the **CI** NUCLEO: flashed cli_simple, ran `stop_mode`, confirmed `uptime`/`help` respond **after** wake (was the failing case).
- [x] CI: `host-tests` and `firmware-build` green.

## Notes

The original report involved the **dev** NUCLEO board printing nothing at all over serial; that turned out to be a separate hardware/VCP issue on that board (a known-good firmware build produced no output, and a direct debugger write to `USART2->DR` did not transmit). This PR addresses the firmware regression surfaced on the CI board.