### PR TITLE
Plan 002 B0.1+B0.2 — self-contained software BPSK modem (q15) + AWGN BER-vs-SNR

### DIFF
--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -47,6 +47,7 @@ Multi-phase project plans. Each plan's phases are sized as individual GitHub iss
 | [plans/001-bootloader/threat-model.md](plans/001-bootloader/threat-model.md) | Plan 001 Phase 1.11 — threat model: attacker classes, defenses, explicit non-goals, trust assumptions |
 | [plans/001-bootloader/production-gap.md](plans/001-bootloader/production-gap.md) | Plan 001 Phase 1.11 — production gaps: 8 changes needed to ship (key custody, secure ROM, TrustZone, etc.) |
 | [plans/002-comms-and-dsp-baseband.md](plans/002-comms-and-dsp-baseband.md) | Two-board comms (UART/SPI/I²C) + software BPSK modem with FEC |
+| [plans/002-dsp-baseband/software-modem.md](plans/002-dsp-baseband/software-modem.md) | Plan 002 Sub-track B0 — self-contained software BPSK modem (q15), software-emulated AWGN channel, BER-vs-SNR vs theory |
 
 ## Decisions
 

--- a/docs/wiki/plans/002-comms-and-dsp-baseband.md
+++ b/docs/wiki/plans/002-comms-and-dsp-baseband.md
@@ -5,6 +5,13 @@
 **Depends on:** [Plan 000 — Repository Refactor](000-repo-refactor.md)
 **Optional dependency:** [Plan 001](001-bootloader-and-security.md) — `lib/framing/` is shared; whichever track lands first defines it.
 
+> **Sub-track B reordered (2026-06):** DSP baseband now starts with a **self-contained software
+> modem** — the channel is emulated in software so the full TX→channel→RX chain runs on a single
+> board with no analog fixture or second board. The physical analog-link (PWM-DAC→RC→ADC) and
+> two-board fixtures from Phases 2.1/2.8 become later optional channel backends behind the same
+> seam. See **[Self-Contained Software BPSK Modem (q15)](002-dsp-baseband/software-modem.md)**
+> (issues #193–#198), which supersedes the old Phase 2.7–2.14 ordering for getting started.
+
 ## Why
 
 This track turns the pair of NUCLEO-F411RE boards into a wired comms+DSP testbed. It exercises three competencies:

--- a/docs/wiki/plans/002-dsp-baseband/software-modem.md
+++ b/docs/wiki/plans/002-dsp-baseband/software-modem.md
@@ -1,0 +1,192 @@
+# Plan 002 Sub-track B0 — Self-Contained Software BPSK Modem (q15)
+
+**Status:** proposed
+**Parent plan:** [Plan 002 — Inter-Board Comms + DSP Baseband](../002-comms-and-dsp-baseband.md)
+**Tracking issue:** #138
+**Depends on:** Plan 000 (repo refactor — `lib/`, `apps/dsp/`, `tools/`). No hardware fixture, no second board.
+
+## Why this exists / what changed from the original plan
+
+The original Plan 002 sub-track B leads with a **physical analog-link fixture** (PWM-DAC → RC
+low-pass filter → ADC) before any modem code runs. That front-loads hardware ceremony — a
+breadboard, RC filter, a second NUCLEO, careful ADC/PWM wiring — onto work whose interesting
+substance is the **baseband signal processing**, not the wiring.
+
+This sub-track reorders the work around one idea the user named directly: **wireless communication
+emulation**. If the channel is a *software function* — `samples_out = channel(samples_in, snr)` —
+then the entire transmit/receive chain becomes **self-contained on a single board**. This is
+exactly how production modems are developed: the whole transceiver is validated in simulation
+against theory *before* an RF (or in our case, analog-loopback) front-end is ever attached.
+
+The architectural seam:
+
+```
+   bits ──▶ [TX chain] ──▶ samples ──▶ [CHANNEL] ──▶ samples ──▶ [RX chain] ──▶ bits ──▶ BER
+                                          ▲
+                          swappable backend behind ONE interface:
+        B0 (this doc): software AWGN + impairments   ← self-contained, no hardware
+        Later:         PWM-DAC → RC → ADC loopback    ← single board, one wire
+        Later:         board A TX → wire → board B RX  ← two boards (original 2.1/2.8)
+```
+
+The TX/RX DSP core **never changes** as backends swap. So this self-contained software modem *is*
+the foundation; the analog-link and two-board fixtures from the original plan become later,
+optional channel backends rather than prerequisites.
+
+## Design decisions (locked)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| First useful milestone | **Symbol-level BER vs SNR** (PRBS + BPSK + AWGN), validated against theory | Smallest self-contained "it works"; no waveforms/pulse-shaping yet. |
+| Numeric representation | **Fixed-point q15** (`int16_t`, Q1.15) for the sample path | Authentic to how cost-sensitive real modems run; exercises overflow/scaling discipline. The hard-FPU stays available for scalar control-loop math (AGC, Eb/N0→variance). |
+| DSP library | **Hand-rolled kernels** initially | Matches the repo's "no HAL, implement it yourself" ethos and keeps flash small. CMSIS-DSP can be vendored later if/when FFT or large filters are needed (deferred to expansion). |
+| Where it runs | On-target firmware app `apps/dsp/modem_sim`, CLI-driven; same code host-tested | Fits the existing three-layer test pyramid and DWT cycle-baseline culture. |
+
+### Fixed-point conventions (apply to every sample-path module)
+
+- **Sample type:** `q15_t` = `int16_t`, format **Q1.15** — range [−1.0, +1.0), where `0x7FFF ≈ +0.99997`
+  represents `+1.0` and `0x8000` represents `−1.0`.
+- **Products** use `q31_t` (`int32_t`) accumulators: `q15 * q15 → q30`, shift `>> 15` to return to q15.
+- **Saturation:** all q15 outputs saturate (no wraparound) via a shared `q15_sat(int32_t)` helper.
+- **Rounding:** add `(1 << 14)` before the `>> 15` shift where bias matters (matched filter taps).
+- **Golden references:** Python (`numpy`) generates reference vectors in float, quantised to q15
+  with a documented tolerance (typically ±2 LSB) so host tests compare target output to a fixed,
+  checked-in expected array — mirroring `tests/lib/crypto/vectors/`.
+
+These conventions live in a single header `lib/dsp/inc/fixed.h` so every later module shares them.
+
+## Module map
+
+All new code is pure C with **no peripheral access** in the `lib/` modules (so the exact same
+sources compile for host unit tests and on-target), mirroring `lib/framing/` and `lib/img/`.
+
+| Module | Path | Responsibility |
+|---|---|---|
+| Fixed-point helpers | `lib/dsp/inc/fixed.h` | q15 type, saturate, mul, round-shift, dB↔linear. Header-only where possible. |
+| PRBS generator/checker | `lib/prbs/` | PRBS-9 / PRBS-15 LFSR bit source + self-synchronising error counter. |
+| BPSK modem core | `lib/modem/` | bit→symbol map (0→−1, 1→+1 in q15), symbol→bit slice/demap, BER accounting. |
+| AWGN channel | `lib/channel/` | Seedable Gaussian noise (Box-Muller, deterministic PRNG), Eb/N0→noise-variance, add-to-samples. |
+| RRC pulse shaping | `lib/dsp/` (later phase) | upsample + root-raised-cosine FIR (q15 taps), matched filter, symbol decimation. |
+| FEC | `lib/fec/` (later phase) | Hamming(7,4) encode / decode-and-correct, pure functions. |
+| App | `apps/dsp/modem_sim/` | CLI front-end: `modem run`, `modem sweep`; DWT cycle reporting. |
+
+Host tests land under `tests/lib/prbs/`, `tests/lib/modem/`, `tests/lib/channel/`, `tests/lib/dsp/`,
+`tests/lib/fec/` — one subdir per module, each with its own `Makefile` and `test_*.c`, exactly like
+the existing `tests/lib/framing/` and `tests/lib/crypto/` suites.
+
+## Phases — each is one issue / one PR
+
+### Phase B0.1 — `lib/prbs` + `lib/modem` BPSK core (symbol level, no noise)
+
+**Scope**
+- `lib/dsp/inc/fixed.h`: q15 type + `q15_sat`, `q15_mul`, `q15_from_float` (host/test only), dB helpers.
+- `lib/prbs/`: PRBS-9 (x⁹+x⁵+1) and PRBS-15 (x¹⁵+x¹⁴+1) generators; a checker that locks to the
+  sequence and counts bit errors over a stream (the standard self-synchronising BER technique).
+- `lib/modem/`: `bpsk_map(bit) → q15 symbol` (0 → −1.0, 1 → +1.0), `bpsk_slice(q15) → bit`,
+  and a `ber_counter` that compares demapped bits to the PRBS reference.
+- No channel yet — TX symbols feed straight into RX. BER must be exactly 0.
+
+**Host tests**
+- Exhaustive map/slice round-trip (both bits, boundary q15 values, exact-zero tie-break documented).
+- PRBS period correctness (PRBS-9 period = 511, PRBS-15 = 32767), checker locks and reports 0 errors
+  on a clean stream and the exact injected count on a corrupted stream.
+
+**Validation:** `make test` green; zero-error clean round-trip; coverage ≥95% on both modules.
+
+### Phase B0.2 — `lib/channel/awgn` + end-to-end symbol BER vs SNR ⭐ first useful milestone
+
+**Scope**
+- Deterministic, seedable PRNG (e.g. xorshift128) so runs are reproducible and CI-stable.
+- Box-Muller transform → unit-variance Gaussian; scale to the noise σ implied by a target **Eb/N0**.
+- Eb/N0 (dB) → σ mapping for BPSK documented in the header with the derivation.
+- `channel_awgn_apply(q15 *samples, n, ebn0_db, *prng)` adds noise with q15 saturation.
+- A thin end-to-end harness (host + reusable by the app): PRBS → BPSK map → AWGN → slice → BER.
+
+**Host tests**
+- σ for a fixed seed/Eb/N0 matches the Python golden within tolerance (validates the variance math).
+- **BER vs Eb/N0 matches the theoretical BPSK curve** `BER = Q(√(2·Eb/N0))` within a statistical
+  tolerance band at several points (e.g. 0, 2, 4, 6, 8 dB), using enough bits per point that the
+  band is tight. This is the headline correctness check of the whole sub-track.
+
+**Validation:** Measured BER within tolerance of `Q(√(2·Eb/N0))` at all tested SNR points; same seed
+→ identical BER (determinism).
+
+### Phase B0.3 — `apps/dsp/modem_sim` + CLI + HIL
+
+**Scope**
+- `apps/dsp/modem_sim/`: links `lib/prbs`, `lib/modem`, `lib/channel` and the CLI engine.
+- CLI commands:
+  - `modem run --mod bpsk --snr <dB> --bits <N>` → prints `bits / errors / BER / theory / Mcycles`.
+  - `modem sweep --snr <lo>:<hi>:<step>` → prints an ASCII BER-vs-Eb/N0 table/curve over serial.
+- DWT cycle counter wraps the per-call processing to report **cycles/bit** (feeds the perf-baseline
+  culture already in `tests/baselines/`).
+- HIL test (`HIL_TEST=1`) asserts: BER at a fixed SNR/seed is within the theory band, and cycles/bit
+  is under a recorded budget (regression guard).
+
+**Validation:** On real hardware, `modem run --snr 6` reports BER ≈ 2.4e-3 within band; HIL test green;
+a perf baseline JSON committed under `tests/baselines/`.
+
+### Phase B0.4 — RRC pulse shaping + matched filter (real waveforms)
+
+**Scope**
+- `lib/dsp/`: q15 root-raised-cosine FIR (β=0.35, configurable span/SPS), upsample (zero-stuff +
+  filter) on TX, matched filter + symbol-instant decimation on RX.
+- The channel now operates on **oversampled samples**, not symbols — the seam is unchanged; AWGN just
+  runs at sample rate.
+- Golden-reference host tests: combined TX+RX RRC = raised-cosine → **ISI-free at Nyquist instants**
+  (zero crossings at symbol centres), taps match Python within ±2 LSB.
+
+**Validation:** Nyquist-ISI-free property holds in test; BER with pulse shaping (no noise) is 0; with
+noise, still tracks theory (matched filter is information-lossless).
+
+### Phase B0.5 — Synchronisation & impairments
+
+**Scope**
+- Channel gains optional **timing offset, carrier frequency offset, phase offset** (still all software).
+- RX gains: **AGC** (slow scalar gain), **Mueller-and-Müller timing recovery**, decision-directed /
+  Costas-loop phase recovery, and **Barker-13 preamble frame sync**.
+- CLI flags expose each impairment so they can be toggled and their cost in BER/lock-time observed.
+
+**Validation:** RX locks and recovers bits under combined timing+phase offset; BER degradation vs the
+ideal-sync case is bounded and documented.
+
+### Phase B0.6 — FEC: Hamming(7,4)
+
+**Scope**
+- `lib/fec/hamming74.{c,h}` — pure `encode(nibble)→7 bits`, `decode(7 bits)→nibble + corrected?`.
+- Modem TX/RX gain a `--fec hamming` toggle.
+- Exhaustive host tests over the 16-symbol input space × all single-bit error positions.
+
+**Validation:** Every single-bit error corrected; BER-vs-SNR curve shows the expected coding gain
+over uncoded BPSK at BER=1e-3.
+
+## Expansion path (deferred — not part of this sub-track's issues)
+
+Once the software modem is solid, the original Plan 002 hardware tracks reattach as **channel
+backends** behind the same seam, in increasing order of hardware cost:
+
+1. `tools/ber_plot.py` — host-side SNR sweep driving `modem sweep` over serial, matplotlib BER curves
+   vs theory (the original Phase 2.12 tool, now trivial because the firmware already sweeps).
+2. **Single-board analog loopback** — PWM-DAC → RC filter → ADC on the *same* board (original
+   Phase 2.8 fixture, minus the second board). The software channel becomes a real (short) wire.
+3. **Two-board over-the-wire** — board A TX → board B RX (original Phases 2.1 / 2.8), reusing the
+   two-board HIL fixture and `BOARD_NODE=A|B` strapping.
+4. **Higher-order / harder channels** — QPSK, flat fading, and convolutional + Viterbi (original
+   Phase 2.13) for additional coding gain.
+
+## Risk
+
+- **Fixed-point scaling/overflow** is the main correctness hazard — mitigated by the shared `fixed.h`
+  saturating helpers, ±2-LSB golden-vector tests, and validating BER against closed-form theory
+  (a wrong scale factor shows up immediately as a BER curve that doesn't match `Q(·)`).
+- **PRNG determinism in CI** — the noise generator must be fully deterministic per seed so HIL/host
+  results are reproducible; this is a test requirement, not just a nicety.
+- **Statistical test flakiness** — BER-vs-theory bands must use enough bits per SNR point that the
+  tolerance band is tight but not flaky; document the bit counts and the band derivation.
+
+## Out of scope (this sub-track)
+
+- Any physical fixture (PWM-DAC, RC filter, ADC, second board) — all deferred to the expansion path.
+- CMSIS-DSP dependency — hand-rolled kernels first.
+- QAM/QPSK, fading channels, LDPC/Turbo — BPSK + AWGN + Hamming is sufficient to stand up the
+  methodology end-to-end.

--- a/docs/wiki/plans/index.md
+++ b/docs/wiki/plans/index.md
@@ -9,6 +9,7 @@ Multi-phase project plans. Each plan is a track of related work that spans many 
 | 000 | [Repository refactor for multi-track work](000-repo-refactor.md) | landed | [#136](https://github.com/ViniBR01/stm32-bare-metal/issues/136) |
 | 001 | [Bootloader & embedded security](001-bootloader-and-security.md) | in progress | [#137](https://github.com/ViniBR01/stm32-bare-metal/issues/137) |
 | 002 | [Inter-board comms + DSP baseband](002-comms-and-dsp-baseband.md) | proposed | [#138](https://github.com/ViniBR01/stm32-bare-metal/issues/138) |
+| 002-B0 | [Self-contained software BPSK modem (q15)](002-dsp-baseband/software-modem.md) | in progress | [#138](https://github.com/ViniBR01/stm32-bare-metal/issues/138) |
 
 ## Convention
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -15,7 +15,7 @@ include ../Makefile.common
 # Subdirectories — each is a single middleware library.
 # Add a new lib by creating lib/<name>/{Makefile,inc,src} and listing it here.
 #==============================================================================
-SUBDIRS := skeleton crypto img flash framing bl_handshake
+SUBDIRS := skeleton crypto img flash framing bl_handshake prbs modem channel
 
 #==============================================================================
 # Build rules

--- a/lib/channel/Makefile
+++ b/lib/channel/Makefile
@@ -1,0 +1,64 @@
+#==============================================================================
+# Channel Library Makefile
+#
+# Software AWGN channel ("emulated wireless link") for the software modem
+# (Plan 002 sub-track B0): deterministic PRNG, Box-Muller Gaussian noise, and
+# the Eb/N0 -> sigma mapping. Shares the q15 fixed-point header in lib/dsp/inc.
+# Pure C; links libm for sqrt/erfc/pow. Compiles on host and target. Mirrors
+# lib/framing/Makefile.
+#==============================================================================
+
+# Module name for identification
+MODULE_NAME := lib_channel
+
+# Default target
+.DEFAULT_GOAL := all
+
+# Include common definitions
+include ../../Makefile.common
+
+#==============================================================================
+# Local directories
+#==============================================================================
+LOCAL_SRC_DIR := src
+LOCAL_INC_DIR := inc
+LOCAL_BUILD_DIR := $(BUILD_DIR)/lib/channel
+
+# Shared fixed-point conventions live in lib/dsp/inc.
+DSP_INC_DIR := ../dsp/inc
+
+#==============================================================================
+# Source files
+#==============================================================================
+LOCAL_SRCS := $(wildcard $(LOCAL_SRC_DIR)/*.c)
+LOCAL_OBJS := $(patsubst $(LOCAL_SRC_DIR)/%.c,$(LOCAL_BUILD_DIR)/%.o,$(LOCAL_SRCS))
+
+#==============================================================================
+# Target library
+#==============================================================================
+TARGET_LIB := $(LOCAL_BUILD_DIR)/libchannel.a
+
+#==============================================================================
+# Build rules
+#==============================================================================
+.PHONY: all clean
+
+all: $(TARGET_LIB)
+
+# Build the channel library.
+$(TARGET_LIB): $(LOCAL_OBJS)
+	$(make-build-dir)
+	@echo "Creating channel library..."
+	$(AR) rcs $@ $^
+	@echo "Channel library created: $@"
+
+# Compile sources.
+$(LOCAL_BUILD_DIR)/%.o: $(LOCAL_SRC_DIR)/%.c
+	$(make-build-dir)
+	@echo "Compiling channel: $<"
+	$(CC) $(CFLAGS) -I$(LOCAL_INC_DIR) -I$(DSP_INC_DIR) -o $@ $<
+
+# Clean local build artifacts.
+clean:
+	@echo "Cleaning channel..."
+	@rm -rf $(LOCAL_BUILD_DIR)

--- a/lib/channel/inc/awgn.h
+++ b/lib/channel/inc/awgn.h
@@ -1,0 +1,79 @@
+#ifndef LIB_CHANNEL_AWGN_H
+#define LIB_CHANNEL_AWGN_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include "fixed.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Software AWGN (additive white Gaussian noise) channel for the software modem
+ * (Plan 002 sub-track B0). See docs/wiki/plans/002-dsp-baseband/software-modem.md.
+ *
+ * This is the "emulated wireless channel": instead of a real RF or analog
+ * link, the channel is a function that adds Gaussian noise to the transmitted
+ * samples. Everything is deterministic given a seed, so host and HIL runs are
+ * exactly reproducible.
+ *
+ *
+ * Noise scaling for BPSK
+ * ----------------------
+ * BPSK symbols are +/-1.0, so the symbol energy is Es = 1, and with one bit per
+ * symbol Eb = Es = 1. The real-valued baseband model is
+ *
+ *     r = s + n,    n ~ N(0, sigma^2),   N0/2 = sigma^2
+ *
+ * so Eb/N0 (linear) = Es / N0 = 1 / (2 * sigma^2), giving
+ *
+ *     sigma = sqrt( 1 / (2 * (Eb/N0)_linear) ),   (Eb/N0)_linear = 10^(dB/10).
+ *
+ * The closed-form bit error rate this model should reproduce is
+ *
+ *     BER = Q( sqrt(2 * (Eb/N0)_linear) ) = 0.5 * erfc( sqrt((Eb/N0)_linear) ).
+ *
+ * channel_awgn_theory_ber() returns exactly that, so tests can compare the
+ * measured BER against theory. Symbols live on the q15 scale (+/-1.0 == +/-Q15_ONE),
+ * so the noise standard deviation is applied at the same scale and the noisy
+ * sum is saturated back into q15.
+ */
+
+/* Deterministic PRNG (xorshift128). Same seed -> same stream, on host and target. */
+typedef struct {
+    uint32_t s[4];
+    float    gauss_spare;   /* cached Box-Muller partner sample           */
+    uint8_t  have_spare;    /* 1 if gauss_spare holds an unused sample     */
+} awgn_prng_t;
+
+/* Seed the PRNG. Any 32-bit seed is accepted; internally expanded to 4 words. */
+void awgn_prng_seed(awgn_prng_t *rng, uint32_t seed);
+
+/* Uniform 32-bit draw. */
+uint32_t awgn_prng_u32(awgn_prng_t *rng);
+
+/*
+ * One standard-normal sample (mean 0, variance 1) via the Box-Muller transform.
+ * Box-Muller produces pairs; this returns one per call and caches the partner.
+ */
+float awgn_prng_gauss(awgn_prng_t *rng);
+
+/* Eb/N0 in dB -> noise standard deviation on the unit (+/-1.0) symbol scale. */
+float channel_awgn_sigma(float ebn0_db);
+
+/* Closed-form BPSK BER for a given Eb/N0 in dB: 0.5 * erfc(sqrt(Eb/N0_linear)). */
+double channel_awgn_theory_ber(float ebn0_db);
+
+/*
+ * Add AWGN to a block of q15 samples in place. The noise standard deviation is
+ * derived from ebn0_db via channel_awgn_sigma() and applied on the q15 scale;
+ * each noisy sample is saturated into the q15 range.
+ */
+void channel_awgn_apply(q15_t *samples, size_t n, float ebn0_db, awgn_prng_t *rng);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIB_CHANNEL_AWGN_H */

--- a/lib/channel/src/awgn.c
+++ b/lib/channel/src/awgn.c
@@ -1,0 +1,103 @@
+#include "awgn.h"
+#include <math.h>
+
+/*
+ * xorshift128 (Marsaglia). Small, fast, and fully deterministic — adequate for
+ * reproducible noise in a teaching/measurement modem (not for cryptography).
+ * The 4-word state is seeded from a single 32-bit value via a splitmix32-style
+ * expansion so callers only have to supply one seed.
+ */
+
+void awgn_prng_seed(awgn_prng_t *rng, uint32_t seed)
+{
+    uint32_t z = seed;
+    for (int i = 0; i < 4; i++) {
+        z += 0x9E3779B9u;            /* golden-ratio increment (splitmix) */
+        uint32_t x = z;
+        x = (x ^ (x >> 16)) * 0x85EBCA6Bu;
+        x = (x ^ (x >> 13)) * 0xC2B2AE35u;
+        x =  x ^ (x >> 16);
+        rng->s[i] = x;
+    }
+    /* xorshift128 must not be all-zero state. */
+    if ((rng->s[0] | rng->s[1] | rng->s[2] | rng->s[3]) == 0u) {
+        rng->s[0] = 1u;
+    }
+    /* Drop any cached Gaussian partner so a reseed gives a fresh stream. */
+    rng->gauss_spare = 0.0f;
+    rng->have_spare  = 0u;
+}
+
+uint32_t awgn_prng_u32(awgn_prng_t *rng)
+{
+    uint32_t t = rng->s[3];
+    uint32_t s = rng->s[0];
+    rng->s[3] = rng->s[2];
+    rng->s[2] = rng->s[1];
+    rng->s[1] = s;
+    t ^= t << 11;
+    t ^= t >> 8;
+    rng->s[0] = t ^ s ^ (s >> 19);
+    return rng->s[0];
+}
+
+/* Uniform float in (0, 1]: avoids exactly 0 so log() in Box-Muller is safe. */
+static float prng_unit(awgn_prng_t *rng)
+{
+    /* Top 24 bits -> [0, 2^24); map to (0, 1]. */
+    uint32_t u = awgn_prng_u32(rng) >> 8;
+    return ((float)u + 1.0f) / 16777216.0f;
+}
+
+float awgn_prng_gauss(awgn_prng_t *rng)
+{
+    /*
+     * Box-Muller generates two independent N(0,1) samples per pair of uniforms.
+     * We return one per call and cache its partner (in the PRNG state, so the
+     * cache is per-instance and cleared on reseed) for the next call.
+     */
+    if (rng->have_spare) {
+        rng->have_spare = 0u;
+        return rng->gauss_spare;
+    }
+
+    float u1 = prng_unit(rng);
+    float u2 = prng_unit(rng);
+    float mag = sqrtf(-2.0f * logf(u1));
+    float ang = 6.283185307179586f * u2;   /* 2*pi */
+
+    rng->gauss_spare = mag * sinf(ang);
+    rng->have_spare  = 1u;
+    return mag * cosf(ang);
+}
+
+float channel_awgn_sigma(float ebn0_db)
+{
+    /* sigma = sqrt( 1 / (2 * 10^(dB/10)) ) for unit-energy BPSK. */
+    float ebn0_lin = powf(10.0f, ebn0_db / 10.0f);
+    return sqrtf(1.0f / (2.0f * ebn0_lin));
+}
+
+double channel_awgn_theory_ber(float ebn0_db)
+{
+    /* BER = 0.5 * erfc( sqrt(Eb/N0_linear) ). */
+    double ebn0_lin = pow(10.0, (double)ebn0_db / 10.0);
+    return 0.5 * erfc(sqrt(ebn0_lin));
+}
+
+void channel_awgn_apply(q15_t *samples, size_t n, float ebn0_db, awgn_prng_t *rng)
+{
+    if (samples == NULL || rng == NULL) {
+        return;
+    }
+
+    float sigma = channel_awgn_sigma(ebn0_db);
+    /* Noise scaled onto the q15 unit-symbol scale (+/-1.0 == +/-32768). */
+    float scale = sigma * 32768.0f;
+
+    for (size_t i = 0; i < n; i++) {
+        float noise = awgn_prng_gauss(rng) * scale;
+        q31_t noisy = (q31_t)samples[i] + (q31_t)lrintf(noise);
+        samples[i] = q15_sat(noisy);
+    }
+}

--- a/lib/dsp/inc/fixed.h
+++ b/lib/dsp/inc/fixed.h
@@ -1,0 +1,86 @@
+#ifndef LIB_DSP_FIXED_H
+#define LIB_DSP_FIXED_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Shared fixed-point conventions for the software-modem sample path
+ * (Plan 002 sub-track B0). See docs/wiki/plans/002-dsp-baseband/software-modem.md.
+ *
+ * Format: q15 == int16_t interpreted as Q1.15 — a signed fraction in the
+ * range [-1.0, +1.0). 0x7FFF (Q15_ONE) is the largest representable value,
+ * ~+0.99997, and stands in for +1.0; 0x8000 (Q15_MIN) is exactly -1.0.
+ *
+ * Products of two q15 values are q30 and live in an int32_t accumulator; a
+ * rounding right shift of 15 brings them back to q15. All q15 outputs saturate
+ * rather than wrap, so an out-of-range intermediate clamps to the endpoints
+ * instead of silently changing sign.
+ *
+ * This header is pure integer arithmetic (plus optional float<->q15 helpers
+ * that the host tests and golden-vector generators use); it pulls in no libm
+ * and no peripheral, so it compiles unchanged on host and target.
+ */
+
+typedef int16_t q15_t;
+typedef int32_t q31_t;
+
+#define Q15_ONE   ((q15_t)0x7FFF)   /* +0.99997, represents +1.0          */
+#define Q15_MIN   ((q15_t)0x8000)   /* -1.0                               */
+#define Q15_MAX   ((q15_t)0x7FFF)   /* alias of Q15_ONE for clarity       */
+#define Q15_SHIFT 15
+
+/* Saturate a 32-bit intermediate down to the q15 range (no wraparound). */
+static inline q15_t q15_sat(q31_t x)
+{
+    if (x > (q31_t)Q15_MAX) {
+        return Q15_MAX;
+    }
+    if (x < (q31_t)Q15_MIN) {
+        return Q15_MIN;
+    }
+    return (q15_t)x;
+}
+
+/* Saturating q15 addition. */
+static inline q15_t q15_add(q15_t a, q15_t b)
+{
+    return q15_sat((q31_t)a + (q31_t)b);
+}
+
+/*
+ * q15 * q15 -> q15, with round-to-nearest on the discarded low bits.
+ * The (1 << 14) bias rounds the q30 product before the >>15.
+ */
+static inline q15_t q15_mul(q15_t a, q15_t b)
+{
+    q31_t prod = (q31_t)a * (q31_t)b;
+    return q15_sat((prod + (1 << (Q15_SHIFT - 1))) >> Q15_SHIFT);
+}
+
+/*
+ * Float<->q15 conversions. Used by host unit tests and the Python-derived
+ * golden-vector comparisons; harmless on target (hard-FPU) but the sample
+ * path itself stays integer.
+ */
+static inline q15_t q15_from_float(float x)
+{
+    float scaled = x * 32768.0f;
+    /* Round half away from zero, then saturate. */
+    q31_t r = (q31_t)(scaled >= 0.0f ? scaled + 0.5f : scaled - 0.5f);
+    return q15_sat(r);
+}
+
+static inline float q15_to_float(q15_t x)
+{
+    return (float)x / 32768.0f;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIB_DSP_FIXED_H */

--- a/lib/modem/Makefile
+++ b/lib/modem/Makefile
@@ -1,0 +1,63 @@
+#==============================================================================
+# Modem Library Makefile
+#
+# BPSK symbol mapper/slicer for the software modem (Plan 002 sub-track B0).
+# Pure C with no peripheral dependencies; shares the q15 fixed-point header in
+# lib/dsp/inc. Compiles unchanged on host (unit tests) and target. Mirrors
+# lib/framing/Makefile.
+#==============================================================================
+
+# Module name for identification
+MODULE_NAME := lib_modem
+
+# Default target
+.DEFAULT_GOAL := all
+
+# Include common definitions
+include ../../Makefile.common
+
+#==============================================================================
+# Local directories
+#==============================================================================
+LOCAL_SRC_DIR := src
+LOCAL_INC_DIR := inc
+LOCAL_BUILD_DIR := $(BUILD_DIR)/lib/modem
+
+# Shared fixed-point conventions live in lib/dsp/inc.
+DSP_INC_DIR := ../dsp/inc
+
+#==============================================================================
+# Source files
+#==============================================================================
+LOCAL_SRCS := $(wildcard $(LOCAL_SRC_DIR)/*.c)
+LOCAL_OBJS := $(patsubst $(LOCAL_SRC_DIR)/%.c,$(LOCAL_BUILD_DIR)/%.o,$(LOCAL_SRCS))
+
+#==============================================================================
+# Target library
+#==============================================================================
+TARGET_LIB := $(LOCAL_BUILD_DIR)/libmodem.a
+
+#==============================================================================
+# Build rules
+#==============================================================================
+.PHONY: all clean
+
+all: $(TARGET_LIB)
+
+# Build the modem library.
+$(TARGET_LIB): $(LOCAL_OBJS)
+	$(make-build-dir)
+	@echo "Creating modem library..."
+	$(AR) rcs $@ $^
+	@echo "Modem library created: $@"
+
+# Compile sources.
+$(LOCAL_BUILD_DIR)/%.o: $(LOCAL_SRC_DIR)/%.c
+	$(make-build-dir)
+	@echo "Compiling modem: $<"
+	$(CC) $(CFLAGS) -I$(LOCAL_INC_DIR) -I$(DSP_INC_DIR) -o $@ $<
+
+# Clean local build artifacts.
+clean:
+	@echo "Cleaning modem..."
+	@rm -rf $(LOCAL_BUILD_DIR)

--- a/lib/modem/inc/bpsk.h
+++ b/lib/modem/inc/bpsk.h
@@ -1,0 +1,62 @@
+#ifndef LIB_MODEM_BPSK_H
+#define LIB_MODEM_BPSK_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include "fixed.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * BPSK symbol mapping/slicing for the software modem (Plan 002 sub-track B0).
+ * See docs/wiki/plans/002-dsp-baseband/software-modem.md.
+ *
+ * Mapping (the conventional BPSK constellation):
+ *
+ *   bit 0  ->  -1.0   (BPSK_SYM_LO == Q15_MIN)
+ *   bit 1  ->  +1.0   (BPSK_SYM_HI == Q15_ONE)
+ *
+ * Slicing is a sign decision about 0. A received sample of exactly 0 is a tie;
+ * we resolve it to bit 1 (treating 0 as the non-negative half-plane). This is
+ * an arbitrary but fixed convention so behaviour is deterministic and testable.
+ *
+ * At this phase one symbol is one sample (no pulse shaping yet); phase B0.4
+ * inserts upsampling and the RRC filter between map and channel.
+ */
+
+/*
+ * Note the constellation is asymmetric by 1 LSB: Q15_MIN is exactly -1.0
+ * (-32768) while Q15_ONE is +0.99997 (+32767), per the q15 convention in
+ * fixed.h. The resulting energy imbalance is ~1 part in 32768 — far below the
+ * noise floor at every SNR of interest — so it is negligible for BER work.
+ * Revisit if a future EVM/matched-filter metric (phase B0.4) needs exact
+ * symmetry.
+ */
+#define BPSK_SYM_LO  (Q15_MIN)   /* bit 0 -> -1.0 */
+#define BPSK_SYM_HI  (Q15_ONE)   /* bit 1 -> +1.0 */
+
+/* Map a single bit (any nonzero treated as 1) to its BPSK symbol. */
+static inline q15_t bpsk_map(uint8_t bit)
+{
+    return (bit & 1u) ? BPSK_SYM_HI : BPSK_SYM_LO;
+}
+
+/* Hard-decision slice: sample >= 0 -> bit 1, sample < 0 -> bit 0. */
+static inline uint8_t bpsk_slice(q15_t sample)
+{
+    return (sample >= 0) ? 1u : 0u;
+}
+
+/* Map n bits to n symbols. */
+void bpsk_map_block(const uint8_t *bits, q15_t *syms, size_t n);
+
+/* Slice n samples to n bits. */
+void bpsk_slice_block(const q15_t *samples, uint8_t *bits, size_t n);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIB_MODEM_BPSK_H */

--- a/lib/modem/src/bpsk.c
+++ b/lib/modem/src/bpsk.c
@@ -1,0 +1,21 @@
+#include "bpsk.h"
+
+void bpsk_map_block(const uint8_t *bits, q15_t *syms, size_t n)
+{
+    if (bits == NULL || syms == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < n; i++) {
+        syms[i] = bpsk_map(bits[i]);
+    }
+}
+
+void bpsk_slice_block(const q15_t *samples, uint8_t *bits, size_t n)
+{
+    if (samples == NULL || bits == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < n; i++) {
+        bits[i] = bpsk_slice(samples[i]);
+    }
+}

--- a/lib/prbs/Makefile
+++ b/lib/prbs/Makefile
@@ -1,0 +1,60 @@
+#==============================================================================
+# PRBS Library Makefile
+#
+# Maximal-length LFSR pseudo-random bit sequence generator + bit-error checker
+# for the software modem (Plan 002 sub-track B0). Pure C with no peripheral
+# dependencies, so the same source compiles on the host (unit tests) and on the
+# target (apps/dsp/modem_sim). Mirrors lib/framing/Makefile.
+#==============================================================================
+
+# Module name for identification
+MODULE_NAME := lib_prbs
+
+# Default target
+.DEFAULT_GOAL := all
+
+# Include common definitions
+include ../../Makefile.common
+
+#==============================================================================
+# Local directories
+#==============================================================================
+LOCAL_SRC_DIR := src
+LOCAL_INC_DIR := inc
+LOCAL_BUILD_DIR := $(BUILD_DIR)/lib/prbs
+
+#==============================================================================
+# Source files
+#==============================================================================
+LOCAL_SRCS := $(wildcard $(LOCAL_SRC_DIR)/*.c)
+LOCAL_OBJS := $(patsubst $(LOCAL_SRC_DIR)/%.c,$(LOCAL_BUILD_DIR)/%.o,$(LOCAL_SRCS))
+
+#==============================================================================
+# Target library
+#==============================================================================
+TARGET_LIB := $(LOCAL_BUILD_DIR)/libprbs.a
+
+#==============================================================================
+# Build rules
+#==============================================================================
+.PHONY: all clean
+
+all: $(TARGET_LIB)
+
+# Build the PRBS library.
+$(TARGET_LIB): $(LOCAL_OBJS)
+	$(make-build-dir)
+	@echo "Creating prbs library..."
+	$(AR) rcs $@ $^
+	@echo "PRBS library created: $@"
+
+# Compile sources.
+$(LOCAL_BUILD_DIR)/%.o: $(LOCAL_SRC_DIR)/%.c
+	$(make-build-dir)
+	@echo "Compiling prbs: $<"
+	$(CC) $(CFLAGS) -I$(LOCAL_INC_DIR) -o $@ $<
+
+# Clean local build artifacts.
+clean:
+	@echo "Cleaning prbs..."
+	@rm -rf $(LOCAL_BUILD_DIR)

--- a/lib/prbs/inc/prbs.h
+++ b/lib/prbs/inc/prbs.h
@@ -1,0 +1,82 @@
+#ifndef LIB_PRBS_H
+#define LIB_PRBS_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Pseudo-random bit sequence (PRBS) generator and bit-error checker for the
+ * software modem (Plan 002 sub-track B0). See
+ * docs/wiki/plans/002-dsp-baseband/software-modem.md.
+ *
+ * Two maximal-length Fibonacci LFSR polynomials are supported (ITU-T O.150
+ * tap assignments):
+ *
+ *   PRBS-9   x^9  + x^5  + 1   period 2^9  - 1 = 511
+ *   PRBS-15  x^15 + x^14 + 1   period 2^15 - 1 = 32767
+ *
+ * The generator emits one bit per step. The checker runs an identical
+ * generator in lock-step with the received bit stream and counts mismatches —
+ * the standard way to measure BER when transmitter and receiver share the same
+ * seed (which they do in the on-board simulator). True self-synchronising
+ * recovery from an unknown phase, and frame sync, arrive with the receiver
+ * loops in phase B0.5; here both ends start aligned by construction.
+ *
+ * Pure integer logic, no peripheral access: compiles unchanged on host and
+ * target.
+ */
+
+typedef enum {
+    PRBS9  = 0,
+    PRBS15 = 1,
+} prbs_poly_t;
+
+typedef struct {
+    uint16_t state;   /* current LFSR state (never zero once seeded)        */
+    uint8_t  tap_a;   /* high feedback tap bit index                        */
+    uint8_t  tap_b;   /* low feedback tap bit index                         */
+    uint16_t mask;    /* width mask: (1 << width) - 1                       */
+} prbs_t;
+
+/*
+ * Initialise a generator. seed is forced nonzero (a zero seed would lock the
+ * LFSR at all-zeros); if seed masks to zero it is replaced by 1. Returns the
+ * sequence period (2^width - 1) for the chosen polynomial.
+ */
+uint32_t prbs_init(prbs_t *p, prbs_poly_t poly, uint16_t seed);
+
+/* Advance the LFSR by one step and return the freshly shifted-in bit (0/1). */
+uint8_t prbs_next_bit(prbs_t *p);
+
+/* Fill buf[0..n-1] with the next n bits (each 0 or 1). */
+void prbs_next_bits(prbs_t *p, uint8_t *buf, size_t n);
+
+/*
+ * Bit-error checker: an internal reference generator plus running counters.
+ * Seed it identically to the transmit-side generator, then feed each received
+ * bit; every bit that disagrees with the reference increments the error count.
+ */
+typedef struct {
+    prbs_t   ref;
+    uint64_t total;
+    uint64_t errors;
+} prbs_check_t;
+
+/* Initialise a checker with the same polynomial/seed as the transmitter. */
+void prbs_check_init(prbs_check_t *c, prbs_poly_t poly, uint16_t seed);
+
+/*
+ * Compare one received bit against the reference and advance. Returns 1 if the
+ * bit matched, 0 if it was an error. Updates total/errors.
+ */
+uint8_t prbs_check_bit(prbs_check_t *c, uint8_t rx_bit);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIB_PRBS_H */

--- a/lib/prbs/src/prbs.c
+++ b/lib/prbs/src/prbs.c
@@ -1,0 +1,76 @@
+#include "prbs.h"
+
+/*
+ * Fibonacci LFSR. The two feedback taps for each supported polynomial are the
+ * highest-degree term (width-1) and the second listed term:
+ *
+ *   PRBS-9   x^9  + x^5  + 1  -> taps at bit indices 8 and 4
+ *   PRBS-15  x^15 + x^14 + 1  -> taps at bit indices 14 and 13
+ *
+ * Each step XORs the tapped bits to form the feedback, shifts the register up
+ * by one, and inserts the feedback at bit 0. The inserted bit is what we hand
+ * back as the output bit, so generator and checker stay in exact lock-step.
+ */
+
+static void lfsr_config(prbs_t *p, prbs_poly_t poly)
+{
+    if (poly == PRBS15) {
+        p->tap_a = 14u;
+        p->tap_b = 13u;
+        p->mask  = (uint16_t)((1u << 15) - 1u);
+    } else { /* PRBS9 (default) */
+        p->tap_a = 8u;
+        p->tap_b = 4u;
+        p->mask  = (uint16_t)((1u << 9) - 1u);
+    }
+}
+
+uint32_t prbs_init(prbs_t *p, prbs_poly_t poly, uint16_t seed)
+{
+    lfsr_config(p, poly);
+
+    uint16_t s = (uint16_t)(seed & p->mask);
+    if (s == 0u) {
+        s = 1u; /* a zero state would lock the LFSR at all-zeros */
+    }
+    p->state = s;
+
+    /* Maximal-length sequence period: 2^width - 1, which equals the mask. */
+    return (uint32_t)p->mask;
+}
+
+uint8_t prbs_next_bit(prbs_t *p)
+{
+    uint8_t fb = (uint8_t)(((p->state >> p->tap_a) ^ (p->state >> p->tap_b)) & 1u);
+    p->state = (uint16_t)(((p->state << 1) | fb) & p->mask);
+    return fb;
+}
+
+void prbs_next_bits(prbs_t *p, uint8_t *buf, size_t n)
+{
+    if (buf == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < n; i++) {
+        buf[i] = prbs_next_bit(p);
+    }
+}
+
+void prbs_check_init(prbs_check_t *c, prbs_poly_t poly, uint16_t seed)
+{
+    (void)prbs_init(&c->ref, poly, seed);
+    c->total  = 0u;
+    c->errors = 0u;
+}
+
+uint8_t prbs_check_bit(prbs_check_t *c, uint8_t rx_bit)
+{
+    uint8_t expected = prbs_next_bit(&c->ref);
+    uint8_t matched  = (uint8_t)((rx_bit & 1u) == expected);
+
+    c->total++;
+    if (!matched) {
+        c->errors++;
+    }
+    return matched;
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS = string_utils cli gpio exti rcc timer uart systick flash iwdg crc lowpower lib/skeleton lib/crypto lib/img lib/flash lib/framing tools/sign_roundtrip
+SUBDIRS = string_utils cli gpio exti rcc timer uart systick flash iwdg crc lowpower lib/skeleton lib/crypto lib/img lib/flash lib/framing lib/dsp lib/prbs lib/modem lib/channel tools/sign_roundtrip
 
 COVERAGE_INFO = coverage.info
 COVERAGE_FILT = coverage-filtered.info
@@ -80,6 +80,22 @@ run: all
 	@echo "Running lib/framing tests"
 	@echo "========================================"
 	@$(MAKE) -C lib/framing run
+	@echo "========================================"
+	@echo "Running lib/dsp tests"
+	@echo "========================================"
+	@$(MAKE) -C lib/dsp run
+	@echo "========================================"
+	@echo "Running lib/prbs tests"
+	@echo "========================================"
+	@$(MAKE) -C lib/prbs run
+	@echo "========================================"
+	@echo "Running lib/modem tests"
+	@echo "========================================"
+	@$(MAKE) -C lib/modem run
+	@echo "========================================"
+	@echo "Running lib/channel tests"
+	@echo "========================================"
+	@$(MAKE) -C lib/channel run
 	@echo "========================================"
 	@echo "Running tools/sign_roundtrip tests"
 	@echo "========================================"

--- a/tests/lib/channel/Makefile
+++ b/tests/lib/channel/Makefile
@@ -1,0 +1,29 @@
+CC      = gcc
+# UNITY_INCLUDE_DOUBLE: BER values reach ~1e-3, so the theory/measured
+# comparisons use double-precision Unity asserts (off by default).
+CFLAGS  = -Wall -Wextra -Wno-unknown-pragmas -Wno-unknown-warning-option \
+          -DUNITY_INCLUDE_DOUBLE \
+          -I../../../lib/channel/inc \
+          -I../../../lib/dsp/inc \
+          -I../../../lib/modem/inc \
+          -I../../../lib/prbs/inc \
+          -I../../../3rd_party/unity/src \
+          $(EXTRA_CFLAGS)
+
+UNITY_SRC   = ../../../3rd_party/unity/src/unity.c
+AWGN_SRC    = ../../../lib/channel/src/awgn.c
+BPSK_SRC    = ../../../lib/modem/src/bpsk.c
+PRBS_SRC    = ../../../lib/prbs/src/prbs.c
+
+.PHONY: all run clean
+
+all: test_awgn.out
+
+run: all
+	./test_awgn.out
+
+test_awgn.out: test_awgn.c $(AWGN_SRC) $(BPSK_SRC) $(PRBS_SRC) $(UNITY_SRC)
+	$(CC) $(CFLAGS) $^ -o $@ -lm
+
+clean:
+	rm -f *.out *.gcda *.gcno

--- a/tests/lib/channel/test_awgn.c
+++ b/tests/lib/channel/test_awgn.c
@@ -1,0 +1,169 @@
+#include "unity.h"
+#include "awgn.h"
+#include "bpsk.h"
+#include "prbs.h"
+#include <math.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* --- PRNG determinism ---------------------------------------------------- */
+
+static void test_prng_same_seed_same_stream(void)
+{
+    awgn_prng_t a, b;
+    awgn_prng_seed(&a, 12345u);
+    awgn_prng_seed(&b, 12345u);
+    for (int i = 0; i < 1000; i++) {
+        TEST_ASSERT_EQUAL_UINT32(awgn_prng_u32(&a), awgn_prng_u32(&b));
+    }
+}
+
+static void test_prng_different_seed_diverges(void)
+{
+    awgn_prng_t a, b;
+    awgn_prng_seed(&a, 1u);
+    awgn_prng_seed(&b, 2u);
+    int differences = 0;
+    for (int i = 0; i < 100; i++) {
+        if (awgn_prng_u32(&a) != awgn_prng_u32(&b)) {
+            differences++;
+        }
+    }
+    TEST_ASSERT_TRUE(differences > 90);
+}
+
+static void test_reseed_resets_gauss_cache(void)
+{
+    /* A reseed must yield an identical Gaussian stream (no leftover spare). */
+    awgn_prng_t a;
+    awgn_prng_seed(&a, 777u);
+    float first_run[8];
+    for (int i = 0; i < 8; i++) {
+        first_run[i] = awgn_prng_gauss(&a);
+    }
+
+    awgn_prng_seed(&a, 777u);
+    for (int i = 0; i < 8; i++) {
+        TEST_ASSERT_EQUAL_FLOAT(first_run[i], awgn_prng_gauss(&a));
+    }
+}
+
+/* --- Gaussian statistics ------------------------------------------------- */
+
+static void test_gauss_mean_and_variance(void)
+{
+    awgn_prng_t rng;
+    awgn_prng_seed(&rng, 42u);
+
+    const int N = 200000;
+    double sum = 0.0, sumsq = 0.0;
+    for (int i = 0; i < N; i++) {
+        float g = awgn_prng_gauss(&rng);
+        sum   += g;
+        sumsq += (double)g * g;
+    }
+    double mean = sum / N;
+    double var  = sumsq / N - mean * mean;
+
+    TEST_ASSERT_TRUE(fabs(mean) < 0.02);          /* ~0 */
+    TEST_ASSERT_TRUE(fabs(var - 1.0) < 0.03);     /* ~1 */
+}
+
+/* --- sigma mapping ------------------------------------------------------- */
+
+static void test_sigma_matches_formula(void)
+{
+    /*
+     * Hand-computed expectations (not a re-derivation of the function under
+     * test): sigma = sqrt(1 / (2 * 10^(dB/10))).
+     *   0 dB  -> sqrt(1/2)            = 0.70710678
+     *   3 dB  -> sqrt(1/(2*1.9952623)) = 0.50059306
+     *   10 dB -> sqrt(1/20)           = 0.22360680
+     */
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, 0.70710678f, channel_awgn_sigma(0.0f));
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, 0.50059306f, channel_awgn_sigma(3.0f));
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, 0.22360680f, channel_awgn_sigma(10.0f));
+}
+
+static void test_theory_ber_known_points(void)
+{
+    /* Reference BPSK BER values (0.5*erfc(sqrt(Eb/N0_lin))). */
+    TEST_ASSERT_DOUBLE_WITHIN(1e-4, 0.0786496, channel_awgn_theory_ber(0.0f));
+    TEST_ASSERT_DOUBLE_WITHIN(1e-4, 0.0375061, channel_awgn_theory_ber(2.0f));
+    TEST_ASSERT_DOUBLE_WITHIN(1e-5, 0.0023883, channel_awgn_theory_ber(6.0f));
+}
+
+/* --- headline: end-to-end BER tracks theory ------------------------------ */
+
+/*
+ * Run PRBS -> BPSK map -> AWGN -> slice -> BER and compare the measured BER to
+ * the closed-form BPSK curve. With N bits the standard error of the measured
+ * BER is ~sqrt(p(1-p)/N); we use a generous absolute+relative band so the test
+ * is tight enough to catch a wrong scale factor but not flaky.
+ */
+static double measure_ber(float ebn0_db, int nbits, uint32_t seed)
+{
+    prbs_t tx;
+    prbs_check_t chk;
+    awgn_prng_t  rng;
+    prbs_init(&tx, PRBS15, 0xBEEFu);
+    prbs_check_init(&chk, PRBS15, 0xBEEFu);
+    awgn_prng_seed(&rng, seed);
+
+    for (int i = 0; i < nbits; i++) {
+        uint8_t bit = prbs_next_bit(&tx);
+        q15_t   sym = bpsk_map(bit);
+        channel_awgn_apply(&sym, 1, ebn0_db, &rng);
+        prbs_check_bit(&chk, bpsk_slice(sym));
+    }
+    return (double)chk.errors / (double)chk.total;
+}
+
+static void test_ber_tracks_theory_curve(void)
+{
+    const int N = 400000;
+    const float points[] = {0.0f, 2.0f, 4.0f, 6.0f};
+
+    for (unsigned k = 0; k < sizeof(points)/sizeof(points[0]); k++) {
+        float db = points[k];
+        double measured = measure_ber(db, N, 0xC0FFEEu + k);
+        double theory   = channel_awgn_theory_ber(db);
+
+        /* Band: max(absolute floor, relative) to handle small BER at high SNR. */
+        double tol = theory * 0.20 + 5.0e-4;
+        TEST_ASSERT_DOUBLE_WITHIN(tol, theory, measured);
+    }
+}
+
+static void test_ber_deterministic_for_seed(void)
+{
+    double a = measure_ber(4.0f, 50000, 0x5151u);
+    double b = measure_ber(4.0f, 50000, 0x5151u);
+    TEST_ASSERT_EQUAL_DOUBLE(a, b);
+}
+
+static void test_apply_null_args_safe(void)
+{
+    awgn_prng_t rng;
+    awgn_prng_seed(&rng, 1u);
+    q15_t s = 0;
+    channel_awgn_apply(NULL, 4, 3.0f, &rng);
+    channel_awgn_apply(&s, 1, 3.0f, NULL);
+    TEST_PASS();
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_prng_same_seed_same_stream);
+    RUN_TEST(test_prng_different_seed_diverges);
+    RUN_TEST(test_reseed_resets_gauss_cache);
+    RUN_TEST(test_gauss_mean_and_variance);
+    RUN_TEST(test_sigma_matches_formula);
+    RUN_TEST(test_theory_ber_known_points);
+    RUN_TEST(test_ber_tracks_theory_curve);
+    RUN_TEST(test_ber_deterministic_for_seed);
+    RUN_TEST(test_apply_null_args_safe);
+    return UNITY_END();
+}

--- a/tests/lib/dsp/Makefile
+++ b/tests/lib/dsp/Makefile
@@ -1,0 +1,21 @@
+CC      = gcc
+CFLAGS  = -Wall -Wextra -Wno-unknown-pragmas -Wno-unknown-warning-option \
+          -I../../../lib/dsp/inc \
+          -I../../../3rd_party/unity/src \
+          $(EXTRA_CFLAGS)
+
+UNITY_SRC = ../../../3rd_party/unity/src/unity.c
+
+.PHONY: all run clean
+
+all: test_fixed.out
+
+run: all
+	./test_fixed.out
+
+# fixed.h is header-only (static inline), so only the test + Unity compile.
+test_fixed.out: test_fixed.c $(UNITY_SRC)
+	$(CC) $(CFLAGS) $^ -o $@
+
+clean:
+	rm -f *.out *.gcda *.gcno

--- a/tests/lib/dsp/test_fixed.c
+++ b/tests/lib/dsp/test_fixed.c
@@ -1,0 +1,116 @@
+#include "unity.h"
+#include "fixed.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* --- q15_sat ------------------------------------------------------------- */
+
+static void test_sat_in_range_unchanged(void)
+{
+    TEST_ASSERT_EQUAL_INT16(0, q15_sat(0));
+    TEST_ASSERT_EQUAL_INT16(1234, q15_sat(1234));
+    TEST_ASSERT_EQUAL_INT16(-1234, q15_sat(-1234));
+    TEST_ASSERT_EQUAL_INT16(Q15_MAX, q15_sat((q31_t)Q15_MAX));
+    TEST_ASSERT_EQUAL_INT16(Q15_MIN, q15_sat((q31_t)Q15_MIN));
+}
+
+static void test_sat_clamps_high_and_low(void)
+{
+    TEST_ASSERT_EQUAL_INT16(Q15_MAX, q15_sat(40000));
+    TEST_ASSERT_EQUAL_INT16(Q15_MAX, q15_sat(0x7FFFFFFF));
+    TEST_ASSERT_EQUAL_INT16(Q15_MIN, q15_sat(-40000));
+    TEST_ASSERT_EQUAL_INT16(Q15_MIN, q15_sat((q31_t)0x80000000));
+}
+
+/* --- q15_add ------------------------------------------------------------- */
+
+static void test_add_basic(void)
+{
+    TEST_ASSERT_EQUAL_INT16(300, q15_add(100, 200));
+    TEST_ASSERT_EQUAL_INT16(0, q15_add(500, -500));
+}
+
+static void test_add_saturates(void)
+{
+    /* 0.75 + 0.75 would overflow +1.0 -> clamps to Q15_MAX. */
+    TEST_ASSERT_EQUAL_INT16(Q15_MAX, q15_add(24576, 24576));
+    /* -0.75 + -0.75 clamps to Q15_MIN. */
+    TEST_ASSERT_EQUAL_INT16(Q15_MIN, q15_add(-24576, -24576));
+}
+
+/* --- q15_mul ------------------------------------------------------------- */
+
+static void test_mul_identity_and_zero(void)
+{
+    /* x * (+1.0) ~= x (Q15_ONE is +0.99997, so allow 1 LSB of rounding). */
+    TEST_ASSERT_INT16_WITHIN(1, 12345, q15_mul(12345, Q15_ONE));
+    TEST_ASSERT_EQUAL_INT16(0, q15_mul(12345, 0));
+}
+
+static void test_mul_half_times_half_rounds(void)
+{
+    /* 0.5 * 0.5 = 0.25 -> 8192 in q15, with round-to-nearest. */
+    TEST_ASSERT_EQUAL_INT16(8192, q15_mul(16384, 16384));
+}
+
+static void test_mul_minus_one_squared_saturates(void)
+{
+    /*
+     * (-1.0) * (-1.0) = +1.0, but +1.0 is not representable in q15; the
+     * q30 product 0x40000000 rounds/shifts to 0x8000 which MUST saturate to
+     * Q15_MAX rather than wrap to Q15_MIN (the classic q15 overflow case).
+     */
+    TEST_ASSERT_EQUAL_INT16(Q15_MAX, q15_mul(Q15_MIN, Q15_MIN));
+}
+
+static void test_mul_sign(void)
+{
+    TEST_ASSERT_EQUAL_INT16(-8192, q15_mul(16384, -16384));
+    TEST_ASSERT_EQUAL_INT16(-8192, q15_mul(-16384, 16384));
+}
+
+/* --- float conversions --------------------------------------------------- */
+
+static void test_from_float_round_half_away_from_zero(void)
+{
+    TEST_ASSERT_EQUAL_INT16(0, q15_from_float(0.0f));
+    /* 0.5 * 32768 = 16384 exactly. */
+    TEST_ASSERT_EQUAL_INT16(16384, q15_from_float(0.5f));
+    TEST_ASSERT_EQUAL_INT16(-16384, q15_from_float(-0.5f));
+}
+
+static void test_from_float_saturates(void)
+{
+    TEST_ASSERT_EQUAL_INT16(Q15_MAX, q15_from_float(2.0f));
+    TEST_ASSERT_EQUAL_INT16(Q15_MIN, q15_from_float(-2.0f));
+    /* Exactly +1.0 is out of range (32768) and must clamp to Q15_MAX. */
+    TEST_ASSERT_EQUAL_INT16(Q15_MAX, q15_from_float(1.0f));
+    /* Exactly -1.0 is representable. */
+    TEST_ASSERT_EQUAL_INT16(Q15_MIN, q15_from_float(-1.0f));
+}
+
+static void test_to_float_roundtrip(void)
+{
+    for (q15_t v = -30000; v < 30000; v += 777) {
+        float f = q15_to_float(v);
+        TEST_ASSERT_INT16_WITHIN(1, v, q15_from_float(f));
+    }
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_sat_in_range_unchanged);
+    RUN_TEST(test_sat_clamps_high_and_low);
+    RUN_TEST(test_add_basic);
+    RUN_TEST(test_add_saturates);
+    RUN_TEST(test_mul_identity_and_zero);
+    RUN_TEST(test_mul_half_times_half_rounds);
+    RUN_TEST(test_mul_minus_one_squared_saturates);
+    RUN_TEST(test_mul_sign);
+    RUN_TEST(test_from_float_round_half_away_from_zero);
+    RUN_TEST(test_from_float_saturates);
+    RUN_TEST(test_to_float_roundtrip);
+    return UNITY_END();
+}

--- a/tests/lib/modem/Makefile
+++ b/tests/lib/modem/Makefile
@@ -1,0 +1,24 @@
+CC      = gcc
+CFLAGS  = -Wall -Wextra -Wno-unknown-pragmas -Wno-unknown-warning-option \
+          -I../../../lib/modem/inc \
+          -I../../../lib/dsp/inc \
+          -I../../../lib/prbs/inc \
+          -I../../../3rd_party/unity/src \
+          $(EXTRA_CFLAGS)
+
+UNITY_SRC = ../../../3rd_party/unity/src/unity.c
+BPSK_SRC  = ../../../lib/modem/src/bpsk.c
+PRBS_SRC  = ../../../lib/prbs/src/prbs.c
+
+.PHONY: all run clean
+
+all: test_bpsk.out
+
+run: all
+	./test_bpsk.out
+
+test_bpsk.out: test_bpsk.c $(BPSK_SRC) $(PRBS_SRC) $(UNITY_SRC)
+	$(CC) $(CFLAGS) $^ -o $@
+
+clean:
+	rm -f *.out *.gcda *.gcno

--- a/tests/lib/modem/test_bpsk.c
+++ b/tests/lib/modem/test_bpsk.c
@@ -1,0 +1,95 @@
+#include "unity.h"
+#include "bpsk.h"
+#include "prbs.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* --- map ----------------------------------------------------------------- */
+
+static void test_map_bit0_is_negative_one(void)
+{
+    TEST_ASSERT_EQUAL_INT16(Q15_MIN, bpsk_map(0u));
+}
+
+static void test_map_bit1_is_positive_one(void)
+{
+    TEST_ASSERT_EQUAL_INT16(Q15_ONE, bpsk_map(1u));
+}
+
+static void test_map_ignores_high_bits(void)
+{
+    /* Only the LSB matters. */
+    TEST_ASSERT_EQUAL_INT16(BPSK_SYM_LO, bpsk_map(0xFEu));
+    TEST_ASSERT_EQUAL_INT16(BPSK_SYM_HI, bpsk_map(0xFFu));
+}
+
+/* --- slice --------------------------------------------------------------- */
+
+static void test_slice_positive_is_1(void)
+{
+    TEST_ASSERT_EQUAL_UINT8(1u, bpsk_slice(Q15_ONE));
+    TEST_ASSERT_EQUAL_UINT8(1u, bpsk_slice(1));
+}
+
+static void test_slice_negative_is_0(void)
+{
+    TEST_ASSERT_EQUAL_UINT8(0u, bpsk_slice(Q15_MIN));
+    TEST_ASSERT_EQUAL_UINT8(0u, bpsk_slice(-1));
+}
+
+static void test_slice_zero_tie_resolves_to_1(void)
+{
+    /* Documented convention: exactly 0 -> bit 1 (non-negative half-plane). */
+    TEST_ASSERT_EQUAL_UINT8(1u, bpsk_slice(0));
+}
+
+/* --- round-trip ---------------------------------------------------------- */
+
+static void test_map_slice_roundtrip_both_bits(void)
+{
+    TEST_ASSERT_EQUAL_UINT8(0u, bpsk_slice(bpsk_map(0u)));
+    TEST_ASSERT_EQUAL_UINT8(1u, bpsk_slice(bpsk_map(1u)));
+}
+
+static void test_block_roundtrip_against_prbs(void)
+{
+    prbs_t p;
+    prbs_init(&p, PRBS9, 0xABCu);
+
+    uint8_t bits[256];
+    uint8_t out[256];
+    q15_t   syms[256];
+
+    prbs_next_bits(&p, bits, 256);
+    bpsk_map_block(bits, syms, 256);
+    bpsk_slice_block(syms, out, 256);
+
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(bits, out, 256);
+}
+
+static void test_block_null_args_safe(void)
+{
+    q15_t syms[4];
+    uint8_t bits[4];
+    bpsk_map_block(NULL, syms, 4);
+    bpsk_slice_block(NULL, bits, 4);
+    bpsk_map_block(bits, NULL, 4);
+    bpsk_slice_block(syms, NULL, 4);
+    TEST_PASS();
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_map_bit0_is_negative_one);
+    RUN_TEST(test_map_bit1_is_positive_one);
+    RUN_TEST(test_map_ignores_high_bits);
+    RUN_TEST(test_slice_positive_is_1);
+    RUN_TEST(test_slice_negative_is_0);
+    RUN_TEST(test_slice_zero_tie_resolves_to_1);
+    RUN_TEST(test_map_slice_roundtrip_both_bits);
+    RUN_TEST(test_block_roundtrip_against_prbs);
+    RUN_TEST(test_block_null_args_safe);
+    return UNITY_END();
+}

--- a/tests/lib/prbs/Makefile
+++ b/tests/lib/prbs/Makefile
@@ -1,0 +1,21 @@
+CC      = gcc
+CFLAGS  = -Wall -Wextra -Wno-unknown-pragmas -Wno-unknown-warning-option \
+          -I../../../lib/prbs/inc \
+          -I../../../3rd_party/unity/src \
+          $(EXTRA_CFLAGS)
+
+UNITY_SRC = ../../../3rd_party/unity/src/unity.c
+PRBS_SRC  = ../../../lib/prbs/src/prbs.c
+
+.PHONY: all run clean
+
+all: test_prbs.out
+
+run: all
+	./test_prbs.out
+
+test_prbs.out: test_prbs.c $(PRBS_SRC) $(UNITY_SRC)
+	$(CC) $(CFLAGS) $^ -o $@
+
+clean:
+	rm -f *.out *.gcda *.gcno

--- a/tests/lib/prbs/test_prbs.c
+++ b/tests/lib/prbs/test_prbs.c
@@ -1,0 +1,170 @@
+#include "unity.h"
+#include "prbs.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* --- init / period ------------------------------------------------------- */
+
+static void test_prbs9_period_value(void)
+{
+    prbs_t p;
+    uint32_t period = prbs_init(&p, PRBS9, 1u);
+    TEST_ASSERT_EQUAL_UINT32(511u, period);
+}
+
+static void test_prbs15_period_value(void)
+{
+    prbs_t p;
+    uint32_t period = prbs_init(&p, PRBS15, 1u);
+    TEST_ASSERT_EQUAL_UINT32(32767u, period);
+}
+
+static void test_zero_seed_is_forced_nonzero(void)
+{
+    prbs_t p;
+    prbs_init(&p, PRBS9, 0u);
+    TEST_ASSERT_NOT_EQUAL(0u, p.state);
+    /* A nonzero state must produce a sequence that is not stuck at 0. */
+    uint8_t ones = 0;
+    for (int i = 0; i < 64; i++) {
+        ones |= prbs_next_bit(&p);
+    }
+    TEST_ASSERT_EQUAL_UINT8(1u, ones);
+}
+
+/* --- maximal-length: full period before repeat --------------------------- */
+
+/*
+ * A maximal-length LFSR visits every nonzero state exactly once per period.
+ * Verify PRBS-9 returns to its seed state after exactly 511 steps and not
+ * before.
+ */
+static void test_prbs9_returns_after_full_period(void)
+{
+    prbs_t p;
+    prbs_init(&p, PRBS9, 0x1FFu);
+    uint16_t seed_state = p.state;
+
+    int returned_early = 0;
+    for (uint32_t i = 0; i < 510u; i++) {
+        prbs_next_bit(&p);
+        if (p.state == seed_state) {
+            returned_early = 1;
+            break;
+        }
+    }
+    TEST_ASSERT_FALSE(returned_early);
+
+    prbs_next_bit(&p); /* 511th step */
+    TEST_ASSERT_EQUAL_UINT16(seed_state, p.state);
+}
+
+/*
+ * Over one full period a maximal-length sequence has 2^(n-1) ones and
+ * 2^(n-1)-1 zeros. For PRBS-9: 256 ones, 255 zeros.
+ */
+static void test_prbs9_ones_balance_over_period(void)
+{
+    prbs_t p;
+    prbs_init(&p, PRBS9, 1u);
+    uint32_t ones = 0;
+    for (uint32_t i = 0; i < 511u; i++) {
+        ones += prbs_next_bit(&p);
+    }
+    TEST_ASSERT_EQUAL_UINT32(256u, ones);
+}
+
+/* --- next_bits matches next_bit ------------------------------------------ */
+
+static void test_next_bits_matches_single(void)
+{
+    prbs_t a, b;
+    prbs_init(&a, PRBS15, 0xACE1u);
+    prbs_init(&b, PRBS15, 0xACE1u);
+
+    uint8_t buf[100];
+    prbs_next_bits(&a, buf, 100);
+    for (int i = 0; i < 100; i++) {
+        TEST_ASSERT_EQUAL_UINT8(prbs_next_bit(&b), buf[i]);
+    }
+}
+
+static void test_next_bits_null_is_safe(void)
+{
+    prbs_t p;
+    prbs_init(&p, PRBS9, 1u);
+    prbs_next_bits(&p, NULL, 10); /* must not crash */
+    TEST_PASS();
+}
+
+/* --- checker ------------------------------------------------------------- */
+
+static void test_checker_clean_stream_zero_errors(void)
+{
+    prbs_t tx;
+    prbs_check_t chk;
+    prbs_init(&tx, PRBS9, 0x55u);
+    prbs_check_init(&chk, PRBS9, 0x55u);
+
+    for (int i = 0; i < 2000; i++) {
+        uint8_t bit = prbs_next_bit(&tx);
+        uint8_t ok = prbs_check_bit(&chk, bit);
+        TEST_ASSERT_EQUAL_UINT8(1u, ok);
+    }
+    TEST_ASSERT_EQUAL_UINT64(2000u, chk.total);
+    TEST_ASSERT_EQUAL_UINT64(0u, chk.errors);
+}
+
+static void test_checker_counts_injected_errors(void)
+{
+    prbs_t tx;
+    prbs_check_t chk;
+    prbs_init(&tx, PRBS15, 0x1234u);
+    prbs_check_init(&chk, PRBS15, 0x1234u);
+
+    /* Flip every 7th bit; count how many we flipped. */
+    uint64_t injected = 0;
+    for (int i = 0; i < 7000; i++) {
+        uint8_t bit = prbs_next_bit(&tx);
+        if ((i % 7) == 0) {
+            bit ^= 1u;
+            injected++;
+        }
+        prbs_check_bit(&chk, bit);
+    }
+    TEST_ASSERT_EQUAL_UINT64(7000u, chk.total);
+    TEST_ASSERT_EQUAL_UINT64(injected, chk.errors);
+}
+
+static void test_checker_mismatched_seed_high_error_rate(void)
+{
+    /* Different seed but same poly: streams decorrelate -> ~50% errors. */
+    prbs_t tx;
+    prbs_check_t chk;
+    prbs_init(&tx, PRBS15, 0x0001u);
+    prbs_check_init(&chk, PRBS15, 0x7FFFu);
+
+    for (int i = 0; i < 4000; i++) {
+        prbs_check_bit(&chk, prbs_next_bit(&tx));
+    }
+    /* Expect roughly half errors; assert a wide band to avoid flakiness. */
+    TEST_ASSERT_TRUE(chk.errors > 1500u);
+    TEST_ASSERT_TRUE(chk.errors < 2500u);
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_prbs9_period_value);
+    RUN_TEST(test_prbs15_period_value);
+    RUN_TEST(test_zero_seed_is_forced_nonzero);
+    RUN_TEST(test_prbs9_returns_after_full_period);
+    RUN_TEST(test_prbs9_ones_balance_over_period);
+    RUN_TEST(test_next_bits_matches_single);
+    RUN_TEST(test_next_bits_null_is_safe);
+    RUN_TEST(test_checker_clean_stream_zero_errors);
+    RUN_TEST(test_checker_counts_injected_errors);
+    RUN_TEST(test_checker_mismatched_seed_high_error_rate);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

First slice of the reframed Plan 002 DSP sub-track (**B0**): a **self-contained software modem** where the wireless channel is emulated in software, so the full `bits → TX → channel → RX → bits → BER` chain runs on a single board — no analog fixture (PWM-DAC/RC/ADC) and no second NUCLEO. The TX/RX DSP core stays fixed while the channel backend swaps; later phases bolt the analog-loopback and two-board fixtures onto the same seam.

Design doc: [docs/wiki/plans/002-dsp-baseband/software-modem.md](../blob/193-software-bpsk-modem-q15/docs/wiki/plans/002-dsp-baseband/software-modem.md)

Closes #193, closes #194. Tracking: #138.

## What's in here

New pure, peripheral-free middleware (compiles unchanged on host and target, mirrors `lib/framing`):

| Module | Purpose |
|---|---|
| `lib/dsp/inc/fixed.h` | q15 (Q1.15) fixed-point: saturating `sat`/`add`/`mul`, float↔q15 helpers — shared conventions for the whole sample path |
| `lib/prbs/` | PRBS-9 / PRBS-15 maximal-length LFSR generator + lock-step bit-error checker |
| `lib/modem/` | BPSK symbol map (0→−1.0, 1→+1.0) and hard-decision slice |
| `lib/channel/` | Deterministic xorshift128 + Box-Muller AWGN, Eb/N0→σ mapping, closed-form BPSK BER theory |

## Headline result

`tests/lib/channel` runs the full PRBS → BPSK → AWGN → slice → BER chain and asserts the measured BER tracks the theoretical curve `BER = Q(√(2·Eb/N0))` at 0/2/4/6 dB. This is the correctness anchor for the whole sub-track — a wrong fixed-point scale factor shows up immediately as a curve that doesn't match theory.

## Fixed-point (q15) decision

Per design discussion, the sample path is **fixed-point q15** (authentic to cost-sensitive real modems), with conventions centralized in `fixed.h`: q31 accumulators, saturating outputs, round-to-nearest. Hand-rolled kernels; CMSIS-DSP deferred.

## Tests

All host suites pass (`make test`) and all firmware apps build (`make all`); the new libs cross-compile for Cortex-M4.

- `tests/lib/dsp` (11) — fixed-point edge cases incl. `(−1)×(−1)` saturation, rounding, float-conversion saturation
- `tests/lib/prbs` (10) — period (511/32767), maximal-length return, ones balance, checker error counting
- `tests/lib/modem` (9) — map/slice round-trip vs PRBS
- `tests/lib/channel` (9) — PRNG determinism, Gaussian mean/variance, σ, BER-vs-theory, reproducibility

## Reviewer pass

A reviewer agent flagged no blockers; addressed its warnings in this branch — added the direct `tests/lib/dsp` suite for the q15 primitives, replaced a tautological σ test with hand-computed expectations, and documented the 1-LSB BPSK constellation asymmetry.

## Not in this PR (next phases)

B0.3 on-device CLI app (`modem run`/`modem sweep` + DWT cycles + HIL), B0.4 RRC pulse shaping, B0.5 sync/impairments, B0.6 Hamming(7,4) FEC.