### PR TITLE
Plan 002 B0.3 — modem_sim CLI app + HIL Tier 9 (BER on hardware)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,8 @@ ALL_APPS := \
 	crc_basic \
 	iwdg_basic \
 	serial_simple \
-	cli_simple
+	cli_simple \
+	modem_sim
 
 # Per-app build rule target list.  A single rule (below) covers every app in
 # $(ALL_APPS) plus the default goal $(EXAMPLE).  We deliberately do NOT add a

--- a/Makefile.common
+++ b/Makefile.common
@@ -174,6 +174,10 @@ CRYPTO_LIB := $(BUILD_DIR)/lib/crypto/libcrypto.a
 FLASH_LIB := $(BUILD_DIR)/lib/flash/libflash.a
 FRAMING_LIB := $(BUILD_DIR)/lib/framing/libframing.a
 BL_HANDSHAKE_LIB := $(BUILD_DIR)/lib/bl_handshake/libbl_handshake.a
+# Plan 002 sub-track B0 — software BPSK modem (q15)
+PRBS_LIB := $(BUILD_DIR)/lib/prbs/libprbs.a
+MODEM_LIB := $(BUILD_DIR)/lib/modem/libmodem.a
+CHANNEL_LIB := $(BUILD_DIR)/lib/channel/libchannel.a
 
 #==============================================================================
 # Plan 001 signing artifacts
@@ -239,7 +243,7 @@ clean-module:
 export CC CP OD SZ AR
 export MCU_FLAGS CFLAGS LDFLAGS LDSCRIPT
 export ROOT_DIR BUILD_DIR HIL_TEST LIB_DIR
-export DRIVERS_LIB STARTUP_OBJ PRINTF_LIB LOG_C_LIB UTILS_LIB UNITY_ARM_LIB IMG_LIB CRYPTO_LIB FLASH_LIB FRAMING_LIB BL_HANDSHAKE_LIB
+export DRIVERS_LIB STARTUP_OBJ PRINTF_LIB LOG_C_LIB UTILS_LIB UNITY_ARM_LIB IMG_LIB CRYPTO_LIB FLASH_LIB FRAMING_LIB BL_HANDSHAKE_LIB PRBS_LIB MODEM_LIB CHANNEL_LIB
 export KEYS_DIR KEY_SEED DEV_PRIV BL_PUBKEY_C
 export SLOT SLOT_BASE SLOT_SUFFIX
 export PROFILE PROFILE_SUFFIX SIGN_IMAGE

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -14,7 +14,7 @@ include ../Makefile.common
 #==============================================================================
 # Subdirectories
 #==============================================================================
-SUBDIRS := basic cli bootloader
+SUBDIRS := basic cli bootloader dsp
 
 #==============================================================================
 # App to build (passed from root makefile via the EXAMPLE variable, kept for

--- a/apps/cli/Makefile
+++ b/apps/cli/Makefile
@@ -67,9 +67,13 @@ cli_simple_DEPS := $(BL_HANDSHAKE_LIB) $(IMG_LIB) $(FLASH_LIB) $(DRIVERS_LIB) $(
 # include path.  Picked up by the per-source compile rule below.
 CLI_LIB_INCS := -I$(LIB_DIR)/bl_handshake/inc -I$(LIB_DIR)/img/inc -I$(LIB_DIR)/flash/inc
 
-# Add Unity library when HIL_TEST is enabled
+# Add Unity library when HIL_TEST is enabled.  The Tier 9 software-modem BER
+# test (test_harness.c) links the Plan 002 B0 modem libs; they are pulled in
+# only under HIL_TEST so the production cli_simple image stays free of the
+# libm-heavy float path.
 ifeq ($(HIL_TEST),1)
-  cli_simple_DEPS += $(UNITY_ARM_LIB)
+  cli_simple_DEPS += $(UNITY_ARM_LIB) $(PRBS_LIB) $(MODEM_LIB) $(CHANNEL_LIB)
+  CLI_LIB_INCS += -I$(LIB_DIR)/prbs/inc -I$(LIB_DIR)/modem/inc -I$(LIB_DIR)/channel/inc -I$(LIB_DIR)/dsp/inc
 endif
 
 #==============================================================================

--- a/apps/cli/test_harness.c
+++ b/apps/cli/test_harness.c
@@ -46,6 +46,12 @@
 #include "sleep_mode.h"
 #include "stm32f4xx.h"  /* DWT / CoreDebug for cycle counting */
 
+/* Plan 002 B0.3 — software BPSK modem (Tier 9). */
+#include "prbs.h"
+#include "bpsk.h"
+#include "awgn.h"
+#include "fixed.h"
+
 /* ====================================================================
  * UART loopback test helpers
  *
@@ -966,6 +972,82 @@ void test_stop_mode_enter_and_wake(void)
 }
 
 /* ====================================================================
+ * Software BPSK modem — Tier 9 (Plan 002 B0.3)
+ *
+ * Runs the self-contained PRBS -> BPSK -> AWGN -> slice -> BER chain on the
+ * Cortex-M4F and reports two metrics: the measured bit-error rate (in parts
+ * per million) and the DWT cycle count for the run (from which cycles/bit is
+ * derived).  No external wiring — the channel is software AWGN.
+ *
+ * Correctness gate (computed on-device): the measured BER must land within a
+ * factor of two of the closed-form BPSK theory, AND cycles/bit must be under a
+ * generous budget.  The factor-of-two band is deliberately loose: with a fixed
+ * seed the run is deterministic, but the band stays robust to toolchain/libm
+ * drift while still catching a broken chain (BER ~0 or ~0.5).  The tight
+ * performance gate is the baseline JSON (cycles +/- tolerance).
+ * ==================================================================== */
+
+#define MODEM_BER_SEED            1u
+#define MODEM_BER_SNR_DB          6.0f
+/*
+ * 100000 bits at theory BER ~2.4e-3 gives ~239 expected errors, enough
+ * statistical margin for the factor-of-two band below; shrinking this would
+ * make the band flaky.  cyc/bit is dominated by the AWGN Box-Muller (libm
+ * sqrtf/logf/sinf/cosf), not the BPSK map/slice — hence the loose budget.
+ */
+#define MODEM_BER_NBITS           100000u
+#define MODEM_CYC_PER_BIT_BUDGET  400u   /* generous firmware-side guard */
+
+void test_modem_bpsk_ber_awgn(void)
+{
+    prbs_t       tx;
+    prbs_check_t chk;
+    awgn_prng_t  rng;
+
+    prbs_init(&tx, PRBS9, MODEM_BER_SEED);
+    prbs_check_init(&chk, PRBS9, MODEM_BER_SEED);
+    awgn_prng_seed(&rng, MODEM_BER_SEED);
+
+    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+    DWT->CYCCNT = 0;
+    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+
+    for (uint32_t i = 0; i < MODEM_BER_NBITS; i++) {
+        uint8_t bit = prbs_next_bit(&tx);
+        q15_t   sym = bpsk_map(bit);
+        channel_awgn_apply(&sym, 1, MODEM_BER_SNR_DB, &rng);
+        prbs_check_bit(&chk, bpsk_slice(sym));
+    }
+
+    uint32_t cycles      = DWT->CYCCNT;
+    uint64_t total       = chk.total;
+    uint64_t errors      = chk.errors;
+    uint32_t ber_ppm     = (total > 0u)
+                             ? (uint32_t)((errors * 1000000ull) / total) : 0u;
+    double   theory      = channel_awgn_theory_ber(MODEM_BER_SNR_DB);
+    uint32_t theory_ppm  = (uint32_t)(theory * 1.0e6 + 0.5);
+    uint32_t cyc_per_bit = (total > 0u) ? (uint32_t)(cycles / total) : 0u;
+
+    /* Factor-of-two correctness band around theory. */
+    int ber_ok = (theory_ppm > 0u) &&
+                 (ber_ppm >= theory_ppm / 2u) && (ber_ppm <= theory_ppm * 2u);
+    int cyc_ok = (cyc_per_bit <= MODEM_CYC_PER_BIT_BUDGET);
+    int pass   = ber_ok && cyc_ok;
+
+    /* Emit the machine-parseable line BEFORE the asserts: Unity longjmps out
+     * of the test on the first failure, so the metric must already be printed
+     * for the runner to record cycles/ber_ppm even on a fail. */
+    TEST_OUTPUT_RESULT("modem_bpsk_ber_snr6", pass, cycles, "ber_ppm", ber_ppm);
+
+    printf("  [modem] BER=%.3e theory=%.3e cyc/bit=%lu\n",
+           (double)ber_ppm / 1.0e6, theory, (unsigned long)cyc_per_bit);
+    printf_dma_flush();
+
+    TEST_ASSERT_TRUE_MESSAGE(ber_ok, "BPSK BER outside factor-2 band of theory");
+    TEST_ASSERT_TRUE_MESSAGE(cyc_ok, "BPSK modem cyc/bit over budget");
+}
+
+/* ====================================================================
  * Main test runner
  * ==================================================================== */
 
@@ -1195,6 +1277,16 @@ int run_unity_tests(void) {
     printf_dma_flush();
 
     RUN_TEST(test_stop_mode_enter_and_wake);
+
+    /* ----------------------------------------------------------
+     * Tier 9: Software BPSK modem (PRBS + AWGN)
+     *   Self-contained DSP chain — no external wiring.
+     *   Asserts BER tracks theory and cycles/bit under budget.
+     * ---------------------------------------------------------- */
+    printf("\n--- Tier 9: Software BPSK modem (PRBS+AWGN) ---\n");
+    printf_dma_flush();
+
+    RUN_TEST(test_modem_bpsk_ber_awgn);
 
     printf_dma_flush();
     return UNITY_END();

--- a/apps/cli/test_harness.c
+++ b/apps/cli/test_harness.c
@@ -996,7 +996,13 @@ void test_stop_mode_enter_and_wake(void)
  * sqrtf/logf/sinf/cosf), not the BPSK map/slice — hence the loose budget.
  */
 #define MODEM_BER_NBITS           100000u
-#define MODEM_CYC_PER_BIT_BUDGET  400u   /* generous firmware-side guard */
+/*
+ * Measured ~1039 cyc/bit on the F411 @ 100 MHz (Box-Muller sqrtf/logf/sinf/
+ * cosf per noise sample dominates).  1500 leaves ~45% headroom as a coarse
+ * "did something blow up" guard; the tight performance gate is the baseline
+ * JSON cycles +/- tolerance, not this number.
+ */
+#define MODEM_CYC_PER_BIT_BUDGET  1500u
 
 void test_modem_bpsk_ber_awgn(void)
 {

--- a/apps/dsp/Makefile
+++ b/apps/dsp/Makefile
@@ -1,0 +1,124 @@
+#==============================================================================
+# DSP Apps Makefile
+#
+# Plan 002 sub-track B0 — software BPSK modem. modem_sim is a single-file
+# interactive CLI app that links the modem middleware (lib/prbs, lib/modem,
+# lib/channel) and the q15 header (lib/dsp). Mirrors apps/cli/Makefile.
+#==============================================================================
+
+# Module name for identification
+MODULE_NAME := dsp_apps
+
+# Default target - build specific app if EXAMPLE is set, otherwise show help
+ifdef EXAMPLE
+.DEFAULT_GOAL := $(EXAMPLE)
+else
+.DEFAULT_GOAL := help
+endif
+
+# Include common definitions
+include ../../Makefile.common
+
+#==============================================================================
+# Local directories
+#
+# PROFILE_SUFFIX (_a slot A, _b slot B, _standalone) keeps profile/slot builds
+# of the same app from clobbering each other.
+#==============================================================================
+LOCAL_BUILD_DIR := $(BUILD_DIR)/apps/dsp/modem_sim$(PROFILE_SUFFIX)
+
+#==============================================================================
+# All apps in this directory
+#==============================================================================
+APPS := modem_sim
+
+#==============================================================================
+# Source files (single-file app: all .c in this directory)
+#==============================================================================
+MODEM_SIM_SRCS := $(wildcard *.c)
+MODEM_SIM_OBJS := $(patsubst %.c,$(LOCAL_BUILD_DIR)/%.o,$(MODEM_SIM_SRCS))
+
+#==============================================================================
+# Output artifacts (profile-suffixed)
+#==============================================================================
+ELF  := $(LOCAL_BUILD_DIR)/modem_sim$(PROFILE_SUFFIX).elf
+BIN  := $(LOCAL_BUILD_DIR)/modem_sim$(PROFILE_SUFFIX).bin
+SBIN := $(LOCAL_BUILD_DIR)/modem_sim$(PROFILE_SUFFIX).signed.bin
+
+# Bootloader profiles sign the image; standalone stops at the raw .bin.
+ifeq ($(SIGN_IMAGE),1)
+  FINAL := $(SBIN)
+else
+  FINAL := $(BIN)
+endif
+
+#==============================================================================
+# Dependencies — modem libs are linked unconditionally (the point of the app)
+#==============================================================================
+modem_sim_DEPS := $(STARTUP_OBJ) $(DRIVERS_LIB) $(LOG_C_LIB) $(PRINTF_LIB) \
+                  $(UTILS_LIB) $(BL_HANDSHAKE_LIB) $(IMG_LIB) $(FLASH_LIB) \
+                  $(PRBS_LIB) $(MODEM_LIB) $(CHANNEL_LIB)
+
+# Header lookup for the middleware libs (and bl_handshake/img/flash used by
+# the bootloader handshake in main()).
+DSP_LIB_INCS := -I$(LIB_DIR)/prbs/inc -I$(LIB_DIR)/modem/inc \
+                -I$(LIB_DIR)/channel/inc -I$(LIB_DIR)/dsp/inc \
+                -I$(LIB_DIR)/bl_handshake/inc -I$(LIB_DIR)/img/inc \
+                -I$(LIB_DIR)/flash/inc
+
+#==============================================================================
+# Build rules
+#==============================================================================
+.PHONY: all clean help $(APPS)
+
+help:
+	@echo "Usage: make EXAMPLE=<app_name>"
+	@echo "       make all                 # Build all apps"
+	@echo ""
+	@echo "Available apps:"
+	@for app in $(APPS); do \
+		echo "  - $$app"; \
+	done
+	@echo ""
+	@echo "Example: make EXAMPLE=modem_sim"
+
+# Image-version field stamped into the signed header.
+IMAGE_VERSION ?= 1
+
+all: $(APPS)
+
+modem_sim: $(FINAL)
+	@echo "App modem_sim built successfully! ($(FINAL))"
+
+# Compile each .c file in this directory into an object file.
+$(LOCAL_BUILD_DIR)/%.o: %.c
+	$(make-build-dir)
+	@echo "Compiling: $<"
+	$(CC) $(CFLAGS) -I. $(DSP_LIB_INCS) -o $@ $<
+
+# Link all object files with the dependency libraries.
+$(ELF): $(MODEM_SIM_OBJS) $(modem_sim_DEPS)
+	$(make-build-dir)
+	@echo "Linking modem_sim..."
+	$(CC) $(LDFLAGS) -Wl,-Map=$(LOCAL_BUILD_DIR)/modem_sim$(PROFILE_SUFFIX).map,--cref -o $@ $(MODEM_SIM_OBJS) -Wl,--start-group $(modem_sim_DEPS) -Wl,--end-group -lc -lm -lgcc
+	@echo "Linking complete."
+
+# Create binary from ELF.
+$(BIN): $(ELF)
+	$(CP) -O binary $< $@
+	@echo "Created $(notdir $(BIN))"
+	@$(SZ) $<
+
+# Sign the bin so the bootloader will accept it (bootloader profiles only).
+$(SBIN): $(BIN) $(DEV_PRIV)
+	@echo "Signing $(notdir $(BIN))..."
+	python3 $(ROOT_DIR)/tools/sign_image.py \
+		--priv-in $(DEV_PRIV) \
+		--in $< \
+		--out $@ \
+		--image-type app \
+		--image-version $(IMAGE_VERSION)
+
+clean:
+	@echo "Cleaning dsp apps..."
+	@rm -rf $(BUILD_DIR)/apps/dsp

--- a/apps/dsp/modem_sim.c
+++ b/apps/dsp/modem_sim.c
@@ -168,14 +168,34 @@ typedef struct {
     uint64_t bits;
     uint64_t errors;
     double   theory;
-    uint32_t cycles;
+    uint32_t mod_cycles;      /* bit -> symbol (BPSK map)                 */
+    uint32_t channel_cycles;  /* symbol -> noisy symbol (AWGN)            */
+    uint32_t demod_cycles;    /* noisy symbol -> bit + BER (slice+check)  */
 } modem_result_t;
 
 /*
- * Run the full PRBS -> BPSK -> AWGN -> slice -> BER chain for nbits and report
- * the DWT cycle count for the loop. Transmitter and checker share the same
- * polynomial and seed, so they start aligned and every mismatch is a true bit
- * error. No printing happens inside the timed region.
+ * Storing every symbol for a 100k-bit run would need ~200 KB (> 128 KB SRAM),
+ * so the chain runs block-by-block: each block fills a buffer (mod), adds noise
+ * over the whole buffer (channel), then slices+checks it (demod).  The three
+ * stages are timed separately and accumulated across blocks, so the reported
+ * mod/channel/demod cycles isolate each component instead of one end-to-end
+ * number.  Block processing also matches how channel_awgn_apply() is meant to
+ * be used (one sigma/powf per block, not per bit).
+ */
+#define MODEM_BLOCK 1024u
+
+static q15_t g_sym_block[MODEM_BLOCK];
+
+/* Read the DWT cycle counter (enabled once in modem_run_chain). */
+static inline uint32_t dwt_now(void) {
+    return DWT->CYCCNT;
+}
+
+/*
+ * Run the PRBS -> BPSK -> AWGN -> slice -> BER chain for nbits, timing the
+ * modulation, channel, and demodulation stages separately.  Transmitter and
+ * checker share the same polynomial and seed, so they start aligned and every
+ * mismatch is a true bit error.  No printing happens inside the timed regions.
  */
 static modem_result_t modem_run_chain(prbs_poly_t poly, uint16_t seed,
                                       float snr_db, uint32_t nbits) {
@@ -192,20 +212,42 @@ static modem_result_t modem_run_chain(prbs_poly_t poly, uint16_t seed,
     DWT->CYCCNT = 0;
     DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
 
-    for (uint32_t i = 0; i < nbits; i++) {
-        uint8_t bit = prbs_next_bit(&tx);
-        q15_t   sym = bpsk_map(bit);
-        channel_awgn_apply(&sym, 1, snr_db, &rng);
-        prbs_check_bit(&chk, bpsk_slice(sym));
+    uint32_t mod_cycles = 0, channel_cycles = 0, demod_cycles = 0;
+
+    uint32_t remaining = nbits;
+    while (remaining > 0u) {
+        uint32_t n = (remaining < MODEM_BLOCK) ? remaining : MODEM_BLOCK;
+
+        /* Stage 1 — modulation: bits -> BPSK symbols. */
+        uint32_t t0 = dwt_now();
+        for (uint32_t i = 0; i < n; i++) {
+            g_sym_block[i] = bpsk_map(prbs_next_bit(&tx));
+        }
+        uint32_t t1 = dwt_now();
+
+        /* Stage 2 — channel: add AWGN over the whole block. */
+        channel_awgn_apply(g_sym_block, n, snr_db, &rng);
+        uint32_t t2 = dwt_now();
+
+        /* Stage 3 — demodulation: slice + BER check. */
+        for (uint32_t i = 0; i < n; i++) {
+            prbs_check_bit(&chk, bpsk_slice(g_sym_block[i]));
+        }
+        uint32_t t3 = dwt_now();
+
+        mod_cycles     += t1 - t0;
+        channel_cycles += t2 - t1;
+        demod_cycles   += t3 - t2;
+        remaining      -= n;
     }
 
-    uint32_t cycles = DWT->CYCCNT;
-
     modem_result_t r;
-    r.bits   = chk.total;
-    r.errors = chk.errors;
-    r.theory = channel_awgn_theory_ber(snr_db);
-    r.cycles = cycles;
+    r.bits           = chk.total;
+    r.errors         = chk.errors;
+    r.theory         = channel_awgn_theory_ber(snr_db);
+    r.mod_cycles     = mod_cycles;
+    r.channel_cycles = channel_cycles;
+    r.demod_cycles   = demod_cycles;
     return r;
 }
 
@@ -255,15 +297,22 @@ static int cmd_modem_run(const char* args) {
 
     modem_result_t r = modem_run_chain(MODEM_POLY, MODEM_SEED, snr_db, nbits);
 
-    double ber       = (r.bits > 0u) ? (double)r.errors / (double)r.bits : 0.0;
-    double mcycles   = (double)r.cycles / 1.0e6;
-    double cyc_bit   = (r.bits > 0u) ? (double)r.cycles / (double)r.bits : 0.0;
+    uint32_t total_cycles = r.mod_cycles + r.channel_cycles + r.demod_cycles;
+    double   ber     = (r.bits > 0u) ? (double)r.errors / (double)r.bits : 0.0;
+    double   nbf     = (r.bits > 0u) ? (double)r.bits : 1.0;
 
     printf("Eb/N0=%.2f dB  bits=%lu  errors=%lu\n",
            (double)snr_db, (unsigned long)r.bits, (unsigned long)r.errors);
     printf("  BER=%.3e  theory=%.3e\n", ber, r.theory);
-    printf("  cycles=%lu  Mcycles=%.3f  cyc/bit=%.1f\n",
-           (unsigned long)r.cycles, mcycles, cyc_bit);
+    printf("  total : cycles=%lu  Mcycles=%.3f  cyc/bit=%.1f\n",
+           (unsigned long)total_cycles, (double)total_cycles / 1.0e6,
+           (double)total_cycles / nbf);
+    printf("  mod   : cycles=%lu  cyc/bit=%.1f\n",
+           (unsigned long)r.mod_cycles, (double)r.mod_cycles / nbf);
+    printf("  chan  : cycles=%lu  cyc/bit=%.1f\n",
+           (unsigned long)r.channel_cycles, (double)r.channel_cycles / nbf);
+    printf("  demod : cycles=%lu  cyc/bit=%.1f\n",
+           (unsigned long)r.demod_cycles, (double)r.demod_cycles / nbf);
     return 0;
 }
 
@@ -298,18 +347,19 @@ static int cmd_modem_sweep(const char* args) {
         return 1;
     }
 
-    printf("Eb/N0(dB) |    bits |  errors |       BER  |    theory  | cyc/bit\n");
-    printf("----------+---------+---------+------------+------------+--------\n");
+    printf("Eb/N0(dB) |  errors |       BER  |    theory  | cyc/bit: mod /chan /demod\n");
+    printf("----------+---------+------------+------------+--------------------------\n");
     printf_dma_flush();
 
     /* Add a small epsilon so the inclusive endpoint isn't lost to rounding. */
     for (float snr = lo; snr <= hi + step * 0.001f; snr += step) {
         modem_result_t r = modem_run_chain(MODEM_POLY, MODEM_SEED, snr, nbits);
+        double nbf     = (r.bits > 0u) ? (double)r.bits : 1.0;
         double ber     = (r.bits > 0u) ? (double)r.errors / (double)r.bits : 0.0;
-        double cyc_bit = (r.bits > 0u) ? (double)r.cycles / (double)r.bits : 0.0;
-        printf("  %6.2f  | %7lu | %7lu | %.3e | %.3e | %7.1f\n",
-               (double)snr, (unsigned long)r.bits, (unsigned long)r.errors,
-               ber, r.theory, cyc_bit);
+        printf("  %6.2f  | %7lu | %.3e | %.3e | %6.1f /%6.1f /%6.1f\n",
+               (double)snr, (unsigned long)r.errors, ber, r.theory,
+               (double)r.mod_cycles / nbf, (double)r.channel_cycles / nbf,
+               (double)r.demod_cycles / nbf);
         printf_dma_flush();
     }
     return 0;

--- a/apps/dsp/modem_sim.c
+++ b/apps/dsp/modem_sim.c
@@ -1,0 +1,396 @@
+/*
+ * modem_sim — interactive software BPSK modem simulator (Plan 002 B0.3).
+ *
+ * Runs the self-contained software modem on the NUCLEO-F411RE: a PRBS bit
+ * source is BPSK-mapped to q15 symbols, passed through the software AWGN
+ * channel, sliced, and checked against the same PRBS to count bit errors.
+ * The whole transmit -> channel -> receive chain lives in SRAM; there is no
+ * analog fixture and no second board. See
+ * docs/wiki/plans/002-dsp-baseband/software-modem.md.
+ *
+ * CLI:
+ *   modem run [--mod bpsk] [--snr <dB>] [--bits <N>]
+ *       One BER measurement at a fixed Eb/N0; prints bits, errors, measured
+ *       BER, closed-form theory BER, total cycles / Mcycles, and cycles/bit.
+ *   modem sweep --snr <lo>:<hi>:<step> [--bits <N>]
+ *       An ASCII BER-vs-Eb/N0 table, one row per SNR point.
+ *
+ * Cycle counts come from the Cortex-M4 DWT cycle counter (same pattern as
+ * drivers/src/spi_perf.c); the core runs at rcc_get_sysclk() (100 MHz).
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "stm32f4xx.h"
+
+#include "bl_handshake.h"
+#include "cli.h"
+#include "fault_handler.h"
+#include "flash_slot.h"
+#include "led2.h"
+#include "printf.h"
+#include "printf_dma.h"
+#include "rcc.h"
+#include "sleep_mode.h"
+#include "systick.h"
+#include "uart.h"
+
+/* Software modem core (Plan 002 B0.1/B0.2). */
+#include "awgn.h"
+#include "bpsk.h"
+#include "fixed.h"
+#include "prbs.h"
+
+/* "modem run --snr 5.5 --bits 1000000" is ~34 chars; 64 leaves headroom. */
+#define MODEM_CMD_SIZE 64
+
+/* Defaults chosen so a bare `modem run` reproduces the issue's example. */
+#define MODEM_DEFAULT_SNR_DB   6.0f
+#define MODEM_DEFAULT_RUN_BITS 100000u
+#define MODEM_DEFAULT_SWEEP_BITS 50000u
+#define MODEM_SEED             1u
+#define MODEM_POLY             PRBS9
+
+static cli_context_t g_cli;
+static char g_cmd_buffer[MODEM_CMD_SIZE];
+static volatile uint8_t command_pending = 0;
+
+/* ------------------------------------------------------------------ */
+/* Argument parsing helpers (no atof/scanf in this codebase).         */
+/* ------------------------------------------------------------------ */
+
+/* Skip leading spaces; returns the first non-space character. */
+static const char* skip_ws(const char* s) {
+    while (*s == ' ') {
+        s++;
+    }
+    return s;
+}
+
+/*
+ * Parse an unsigned decimal integer. Returns a pointer past the digits, or
+ * NULL if no digit is present. (Mirrors parse_uint in apps/cli/cli_commands.c.)
+ */
+static const char* parse_uint(const char* s, uint32_t* out) {
+    if (*s < '0' || *s > '9') {
+        return NULL;
+    }
+    uint32_t val = 0;
+    while (*s >= '0' && *s <= '9') {
+        val = val * 10u + (uint32_t)(*s - '0');
+        s++;
+    }
+    *out = val;
+    return s;
+}
+
+/*
+ * Parse a decimal number into a float: optional sign, integer part, optional
+ * fractional part ('.' followed by digits). Returns a pointer past the number,
+ * or NULL if no digit is present. No exponent form — dB values don't need it.
+ */
+static const char* parse_float(const char* s, float* out) {
+    float sign = 1.0f;
+    if (*s == '-') {
+        sign = -1.0f;
+        s++;
+    } else if (*s == '+') {
+        s++;
+    }
+
+    if ((*s < '0' || *s > '9') && *s != '.') {
+        return NULL;
+    }
+
+    float val = 0.0f;
+    int saw_digit = 0;
+    while (*s >= '0' && *s <= '9') {
+        val = val * 10.0f + (float)(*s - '0');
+        s++;
+        saw_digit = 1;
+    }
+    if (*s == '.') {
+        s++;
+        float scale = 0.1f;
+        while (*s >= '0' && *s <= '9') {
+            val += (float)(*s - '0') * scale;
+            scale *= 0.1f;
+            s++;
+            saw_digit = 1;
+        }
+    }
+    if (!saw_digit) {
+        return NULL;
+    }
+
+    *out = sign * val;
+    return s;
+}
+
+/*
+ * Find the value following a "--<key>" flag in an argument string. On a match,
+ * returns a pointer to the first non-space character after the flag; otherwise
+ * NULL. Matching is whitespace-delimited so "--snr" does not match "--snrx".
+ */
+static const char* find_flag(const char* args, const char* key) {
+    size_t klen = 0;
+    while (key[klen] != '\0') {
+        klen++;
+    }
+    const char* s = args;
+    while (*s != '\0') {
+        s = skip_ws(s);
+        if (*s == '\0') {
+            break;
+        }
+        /* Does the token at s start with key and end at a space/EOL? */
+        size_t i = 0;
+        while (i < klen && s[i] == key[i]) {
+            i++;
+        }
+        if (i == klen && (s[klen] == '\0' || s[klen] == ' ')) {
+            return skip_ws(s + klen);
+        }
+        /* Advance to the next whitespace-delimited token. */
+        while (*s != '\0' && *s != ' ') {
+            s++;
+        }
+    }
+    return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* Modem chain                                                        */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+    uint64_t bits;
+    uint64_t errors;
+    double   theory;
+    uint32_t cycles;
+} modem_result_t;
+
+/*
+ * Run the full PRBS -> BPSK -> AWGN -> slice -> BER chain for nbits and report
+ * the DWT cycle count for the loop. Transmitter and checker share the same
+ * polynomial and seed, so they start aligned and every mismatch is a true bit
+ * error. No printing happens inside the timed region.
+ */
+static modem_result_t modem_run_chain(prbs_poly_t poly, uint16_t seed,
+                                      float snr_db, uint32_t nbits) {
+    prbs_t       tx;
+    prbs_check_t chk;
+    awgn_prng_t  rng;
+
+    prbs_init(&tx, poly, seed);
+    prbs_check_init(&chk, poly, seed);
+    awgn_prng_seed(&rng, seed);
+
+    /* Enable and zero the DWT cycle counter (same pattern as spi_perf.c). */
+    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+    DWT->CYCCNT = 0;
+    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+
+    for (uint32_t i = 0; i < nbits; i++) {
+        uint8_t bit = prbs_next_bit(&tx);
+        q15_t   sym = bpsk_map(bit);
+        channel_awgn_apply(&sym, 1, snr_db, &rng);
+        prbs_check_bit(&chk, bpsk_slice(sym));
+    }
+
+    uint32_t cycles = DWT->CYCCNT;
+
+    modem_result_t r;
+    r.bits   = chk.total;
+    r.errors = chk.errors;
+    r.theory = channel_awgn_theory_ber(snr_db);
+    r.cycles = cycles;
+    return r;
+}
+
+/* ------------------------------------------------------------------ */
+/* CLI command                                                        */
+/* ------------------------------------------------------------------ */
+
+static void print_run_usage(void) {
+    printf("Usage:\n");
+    printf("  modem run [--mod bpsk] [--snr <dB>] [--bits <N>]\n");
+    printf("  modem sweep --snr <lo>:<hi>:<step> [--bits <N>]\n");
+}
+
+/* Confirm an optional "--mod" value is bpsk (the only modulation in B0). */
+static int mod_is_ok(const char* args) {
+    const char* m = find_flag(args, "--mod");
+    if (m == NULL) {
+        return 1; /* default: bpsk */
+    }
+    return (m[0] == 'b' && m[1] == 'p' && m[2] == 's' && m[3] == 'k' &&
+            (m[4] == '\0' || m[4] == ' '));
+}
+
+static int cmd_modem_run(const char* args) {
+    if (!mod_is_ok(args)) {
+        printf("Only --mod bpsk is supported.\n");
+        return 1;
+    }
+
+    float    snr_db = MODEM_DEFAULT_SNR_DB;
+    uint32_t nbits  = MODEM_DEFAULT_RUN_BITS;
+
+    const char* v = find_flag(args, "--snr");
+    if (v != NULL && parse_float(v, &snr_db) == NULL) {
+        printf("Invalid --snr value.\n");
+        return 1;
+    }
+    v = find_flag(args, "--bits");
+    if (v != NULL && parse_uint(v, &nbits) == NULL) {
+        printf("Invalid --bits value.\n");
+        return 1;
+    }
+    if (nbits == 0u) {
+        printf("--bits must be > 0.\n");
+        return 1;
+    }
+
+    modem_result_t r = modem_run_chain(MODEM_POLY, MODEM_SEED, snr_db, nbits);
+
+    double ber       = (r.bits > 0u) ? (double)r.errors / (double)r.bits : 0.0;
+    double mcycles   = (double)r.cycles / 1.0e6;
+    double cyc_bit   = (r.bits > 0u) ? (double)r.cycles / (double)r.bits : 0.0;
+
+    printf("Eb/N0=%.2f dB  bits=%lu  errors=%lu\n",
+           (double)snr_db, (unsigned long)r.bits, (unsigned long)r.errors);
+    printf("  BER=%.3e  theory=%.3e\n", ber, r.theory);
+    printf("  cycles=%lu  Mcycles=%.3f  cyc/bit=%.1f\n",
+           (unsigned long)r.cycles, mcycles, cyc_bit);
+    return 0;
+}
+
+static int cmd_modem_sweep(const char* args) {
+    const char* v = find_flag(args, "--snr");
+    if (v == NULL) {
+        printf("sweep requires --snr <lo>:<hi>:<step>\n");
+        return 1;
+    }
+
+    float lo = 0.0f, hi = 0.0f, step = 0.0f;
+    const char* p = parse_float(v, &lo);
+    if (p == NULL || *p != ':') {
+        printf("Invalid sweep range; expected lo:hi:step\n");
+        return 1;
+    }
+    p = parse_float(p + 1, &hi);
+    if (p == NULL || *p != ':') {
+        printf("Invalid sweep range; expected lo:hi:step\n");
+        return 1;
+    }
+    p = parse_float(p + 1, &step);
+    if (p == NULL || step <= 0.0f || hi < lo) {
+        printf("Invalid sweep range; need step>0 and hi>=lo\n");
+        return 1;
+    }
+
+    uint32_t nbits = MODEM_DEFAULT_SWEEP_BITS;
+    v = find_flag(args, "--bits");
+    if (v != NULL && (parse_uint(v, &nbits) == NULL || nbits == 0u)) {
+        printf("Invalid --bits value.\n");
+        return 1;
+    }
+
+    printf("Eb/N0(dB) |    bits |  errors |       BER  |    theory  | cyc/bit\n");
+    printf("----------+---------+---------+------------+------------+--------\n");
+    printf_dma_flush();
+
+    /* Add a small epsilon so the inclusive endpoint isn't lost to rounding. */
+    for (float snr = lo; snr <= hi + step * 0.001f; snr += step) {
+        modem_result_t r = modem_run_chain(MODEM_POLY, MODEM_SEED, snr, nbits);
+        double ber     = (r.bits > 0u) ? (double)r.errors / (double)r.bits : 0.0;
+        double cyc_bit = (r.bits > 0u) ? (double)r.cycles / (double)r.bits : 0.0;
+        printf("  %6.2f  | %7lu | %7lu | %.3e | %.3e | %7.1f\n",
+               (double)snr, (unsigned long)r.bits, (unsigned long)r.errors,
+               ber, r.theory, cyc_bit);
+        printf_dma_flush();
+    }
+    return 0;
+}
+
+/* "modem ..." top-level command: dispatch on the first sub-token. */
+static int cmd_modem(const char* args) {
+    args = skip_ws(args);
+    if (args[0] == 'r' && args[1] == 'u' && args[2] == 'n' &&
+        (args[3] == '\0' || args[3] == ' ')) {
+        return cmd_modem_run(skip_ws(args + 3));
+    }
+    if (args[0] == 's' && args[1] == 'w' && args[2] == 'e' && args[3] == 'e' &&
+        args[4] == 'p' && (args[5] == '\0' || args[5] == ' ')) {
+        return cmd_modem_sweep(skip_ws(args + 5));
+    }
+    print_run_usage();
+    return 1;
+}
+
+static const cli_command_t commands[] = {
+    {"modem", "BPSK modem sim: run|sweep (see 'modem')", cmd_modem},
+};
+
+/* ------------------------------------------------------------------ */
+/* App boilerplate (mirrors apps/cli/cli_simple.c)                    */
+/* ------------------------------------------------------------------ */
+
+static void on_char_received(char ch) {
+    cli_process_char(&g_cli, ch, uart_write);
+    if (ch == '\n' || ch == '\r') {
+        command_pending = 1;
+    }
+}
+
+static void process_pending_command(void) {
+    if (command_pending) {
+        cli_history_save(&g_cli);
+        cli_execute_command(&g_cli);
+        g_cli.buffer_pos = 0;
+        printf("\n> ");
+        printf_dma_mark_pending();
+        command_pending = 0;
+    }
+}
+
+int main(void) {
+    led2_init();
+    uart_init();
+    systick_init();
+    sleep_mode_init();
+    fault_handler_init();
+    printf_dma_init();
+
+    /*
+     * Phase 1.9 handshake: tell the bootloader we booted past init so a clean
+     * boot doesn't accumulate toward the fail-count cap. Resolve the slot from
+     * the vector table base the bootloader programmed.
+     */
+    flash_slot_id_t boot_slot = ((SCB->VTOR & ~0x1FFu) >= FLASH_SLOT_B_BASE)
+                                  ? FLASH_SLOT_B : FLASH_SLOT_A;
+    (void)bl_handshake_clear_fail_count(boot_slot);
+
+    uart_register_rx_callback(on_char_received);
+    uart_register_tx_complete_callback(printf_dma_tx_complete_callback);
+
+    size_t num_commands = sizeof(commands) / sizeof(commands[0]);
+    cli_init(&g_cli, commands, num_commands, g_cmd_buffer, MODEM_CMD_SIZE);
+
+    cli_print_welcome("\n=== STM32 Software BPSK Modem Simulator ===");
+    printf("Try: modem run --snr 6 --bits 100000\n");
+    printf("\n> ");
+    printf_dma_mark_pending();
+
+    while (1) {
+        if (command_pending) {
+            process_pending_command();
+        }
+        printf_dma_process();
+        if (!command_pending) {
+            enter_sleep_mode();
+        }
+    }
+}

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -4,6 +4,28 @@ Chronological record of significant changes. Newest entries at the top.
 Format: `## [YYYY-MM-DD] <type> | <title> (<PR/Issue>)`
 Types: `merge`, `decision`, `milestone`, `infra`
 
+## [2026-06-26] milestone | Software BPSK modem on hardware: modem_sim CLI app + HIL Tier 9 (#195)
+
+Plan 002 sub-track B0.3 — wired the merged software modem libs (`lib/prbs`,
+`lib/modem`, `lib/channel`, `lib/dsp`) into firmware, the first time the q15
+BPSK-over-AWGN chain runs on the Cortex-M4F.
+
+- New interactive app `apps/dsp/modem_sim` (new `apps/dsp/` subdir): `modem run
+  [--mod bpsk] [--snr <dB>] [--bits <N>]` prints measured BER vs closed-form
+  theory and DWT cycles/bit; `modem sweep --snr <lo>:<hi>:<step>` prints an
+  ASCII BER-vs-Eb/N0 table. Decimal SNR supported via a local `parse_float`
+  (no `atof` in this codebase). Built/signed at slot A like `cli_simple`.
+- New HIL **Tier 9** in `apps/cli/test_harness.c` (`test_modem_bpsk_ber_awgn`):
+  PRBS9, seed 1, 6 dB, 100000 bits. Emits `TEST:modem_bpsk_ber_snr6:...:ber_ppm`.
+  On-device gate = BER within a factor of two of theory AND cyc/bit under
+  budget. Modem libs link into `cli_simple` only under `HIL_TEST=1`, keeping
+  the production image free of the libm-heavy float path.
+- `tests/baselines/performance.json` gained a `modem_bpsk_ber_snr6` entry with
+  `null` cycles/ber_ppm — the runner reports the measured values without gating
+  until populated from the first CI HIL run.
+- Build plumbing: `PRBS_LIB`/`MODEM_LIB`/`CHANNEL_LIB` in `Makefile.common`,
+  `dsp` added to `apps/Makefile` SUBDIRS, `modem_sim` to root `ALL_APPS`.
+
 ## [2026-06-20] infra | Max-clock SPI-DMA integrity made advisory (non-gating) (#185)
 
 The `spi*_dma_psc2_256B` HIL smoke tests (SPI DMA at the fastest prescaler)

--- a/tests/baselines/performance.json
+++ b/tests/baselines/performance.json
@@ -56,5 +56,8 @@
   "spi1_dma_psc2_1B":       { "throughput_kbps": 297,   "cycles": 336,     "tolerance_percent": 20, "last_updated": "2026-04-19", "notes": "SPI1 APB2, DMA, 1-byte (DMA setup overhead dominates)" },
   "spi1_dma_psc2_4B":       { "throughput_kbps": 1049,  "cycles": 381,     "tolerance_percent": 15, "last_updated": "2026-04-19", "notes": "SPI1 APB2, DMA, 4-byte" },
   "spi1_dma_psc2_16B":      { "throughput_kbps": 2792,  "cycles": 573,     "tolerance_percent": 10, "last_updated": "2026-04-19", "notes": "SPI1 APB2, DMA, 16-byte" },
-  "spi1_dma_psc2_64B":      { "throughput_kbps": 4772,  "cycles": 1341,    "tolerance_percent": 10, "last_updated": "2026-04-19", "notes": "SPI1 APB2, DMA, 64-byte" }
+  "spi1_dma_psc2_64B":      { "throughput_kbps": 4772,  "cycles": 1341,    "tolerance_percent": 10, "last_updated": "2026-04-19", "notes": "SPI1 APB2, DMA, 64-byte" },
+
+  "_comment_modem": "Plan 002 B0.3 software BPSK modem over software AWGN. cycles/ber_ppm are null (unpopulated) so the runner reports the measured values without gating; fill them from the first CI HIL run (ber_ppm expected ~2388 at 6 dB), then tighten the cycles tolerance to 10%.",
+  "modem_bpsk_ber_snr6": { "ber_ppm": null, "cycles": null, "tolerance_percent": 25, "last_updated": "2026-06-26", "notes": "Software BPSK over AWGN, PRBS9 seed=1, snr=6dB, 100000 bits. null = not populated yet." }
 }

--- a/tests/baselines/performance.json
+++ b/tests/baselines/performance.json
@@ -58,6 +58,6 @@
   "spi1_dma_psc2_16B":      { "throughput_kbps": 2792,  "cycles": 573,     "tolerance_percent": 10, "last_updated": "2026-04-19", "notes": "SPI1 APB2, DMA, 16-byte" },
   "spi1_dma_psc2_64B":      { "throughput_kbps": 4772,  "cycles": 1341,    "tolerance_percent": 10, "last_updated": "2026-04-19", "notes": "SPI1 APB2, DMA, 64-byte" },
 
-  "_comment_modem": "Plan 002 B0.3 software BPSK modem over software AWGN. cycles/ber_ppm are null (unpopulated) so the runner reports the measured values without gating; fill them from the first CI HIL run (ber_ppm expected ~2388 at 6 dB), then tighten the cycles tolerance to 10%.",
-  "modem_bpsk_ber_snr6": { "ber_ppm": null, "cycles": null, "tolerance_percent": 25, "last_updated": "2026-06-26", "notes": "Software BPSK over AWGN, PRBS9 seed=1, snr=6dB, 100000 bits. null = not populated yet." }
+  "_comment_modem": "Plan 002 B0.3 software BPSK modem over software AWGN. Measured on the CI board (PR #201): ~1039 cyc/bit, BER 2360 ppm vs theory 2388. ber_ppm uses a wide 25% band (statistical + the factor-2 firmware gate is the real correctness check); cycles is the tight perf gate. Box-Muller (sqrtf/logf/sinf/cosf per noise sample) dominates the cycle cost.",
+  "modem_bpsk_ber_snr6": { "ber_ppm": 2360, "cycles": 103960745, "tolerance_percent": 15, "last_updated": "2026-06-27", "notes": "Software BPSK over AWGN, PRBS9 seed=1, snr=6dB, 100000 bits. cycles=total run (~1039 cyc/bit); 15% tolerance covers cycles; ber_ppm band [2006,2714] holds theory 2388." }
 }


### PR DESCRIPTION
## Summary

Wires the merged software BPSK modem libs (`lib/prbs`, `lib/modem`, `lib/channel`, `lib/dsp`) into firmware — the first time the q15 BPSK-over-AWGN chain runs on the Cortex-M4F.

Closes #195. Tracking: #138.
Plan: [software-modem.md](../blob/195-modem-sim-cli-hil/docs/wiki/plans/002-dsp-baseband/software-modem.md) (Phase B0.3).

## Interactive app — `apps/dsp/modem_sim` (new `apps/dsp/` subdir)

- `modem run [--mod bpsk] [--snr <dB>] [--bits <N>]` → runs PRBS → BPSK → AWGN → slice → BER and prints measured BER, closed-form theory, total cycles / Mcycles, and DWT cycles/bit.
- `modem sweep --snr <lo>:<hi>:<step> [--bits <N>]` → ASCII BER-vs-Eb/N0 table, one row per SNR point.
- Decimal SNR via a local `parse_float` (no `atof` in this codebase). Built and signed at slot A like `cli_simple`.

Example (once flashed):
```
> modem run --snr 6 --bits 100000
Eb/N0=6.00 dB  bits=100000  errors=~240
  BER=2.4xxe-03  theory=2.388e-03
  cycles=...  Mcycles=...  cyc/bit=...
```

## HIL — Tier 9 (`apps/cli/test_harness.c`)

`test_modem_bpsk_ber_awgn`: PRBS9, seed 1, 6 dB, 100000 bits, DWT-timed. Emits `TEST:modem_bpsk_ber_snr6:<PASS|FAIL>:cycles=<C>:ber_ppm=<P>`. On-device gate = **BER within a factor of two of theory** AND cyc/bit under budget (the `TEST_OUTPUT_RESULT` line is emitted before the Unity asserts, since Unity longjmps out on failure). The modem libs link into `cli_simple` **only under `HIL_TEST=1`**, so the production image stays free of the libm-heavy float path.

## Baseline (no local HIL/SSH access)

`tests/baselines/performance.json` gains `modem_bpsk_ber_snr6` with **`null`** `cycles`/`ber_ppm`. The runner reports the measured values without gating when a baseline is null (`run_hil_tests.py:534`), so CI stays green. I'll read the real `cycles`/`ber_ppm` from the **CI HIL job log**, then a follow-up commit on this PR will populate them (expected `ber_ppm` ≈ 2388) and tighten the `cycles` tolerance to 10%.

## Build plumbing

`PRBS_LIB`/`MODEM_LIB`/`CHANNEL_LIB` in `Makefile.common` (+ export), `dsp` added to `apps/Makefile` SUBDIRS, `modem_sim` added to root `ALL_APPS`.

## Verification

- `make EXAMPLE=modem_sim` → `modem_sim_a.signed.bin` (text ~31.6 KB).
- `make all` builds every app incl. modem_sim.
- `make clean && make EXAMPLE=cli_simple HIL_TEST=1` links (libm resolves).
- `make test` green (no host tests touched).

A reviewer agent found no blocking issues; addressed its clarity notes (documented that cyc/bit is channel-dominated and that the bit count is tied to the factor-2 band width).

## Not in this PR

B0.4 RRC pulse shaping, B0.5 sync/impairments, B0.6 Hamming FEC.